### PR TITLE
Support Singularity client

### DIFF
--- a/src/main/groovy/io/seqera/controller/V2Controller.groovy
+++ b/src/main/groovy/io/seqera/controller/V2Controller.groovy
@@ -51,7 +51,7 @@ class V2Controller {
         )
     }
 
-    @Get(uri="/{url:(.+)}")
+    @Get(uri="/{url:(.+)}", produces = "*/*")
     MutableHttpResponse<?> handleGet(String url, HttpRequest httpRequest) {
 
         def route = RouteHelper.parse("/v2/"+url, configuration.defaultRegistry.name)


### PR DESCRIPTION
## Description

Tower Registry was returning a HTTP 406 not valid error to [Singularity](https://sylabs.io/guides/latest/user-guide/index.html) requests. 

This was happening because singularity adds the header `Accept: application/vnd.oci.image.index.v1+json`.

Example singularity usage:
```
 singularity run docker://0e2e-79-153-75-49.ngrok.io/library/hello-world
```