### PR TITLE
Lazy digest cache

### DIFF
--- a/src/main/groovy/io/seqera/controller/V2Controller.groovy
+++ b/src/main/groovy/io/seqera/controller/V2Controller.groovy
@@ -11,7 +11,7 @@ import io.micronaut.http.hateoas.JsonError
 import io.micronaut.http.hateoas.Link
 import io.micronaut.http.server.types.files.StreamedFile
 import io.seqera.storage.Storage
-import io.seqera.storage.DigestByteArray
+import io.seqera.storage.DigestStore
 import io.seqera.RouteHelper
 import io.seqera.docker.ContainerService
 import io.seqera.docker.ContainerService.DelegateResponse
@@ -89,7 +89,7 @@ class V2Controller {
         fromDelegateResponse(response)
     }
 
-    protected DigestByteArray manifestForPath(RouteHelper.Route route, HttpRequest httpRequest) {
+    protected DigestStore manifestForPath(RouteHelper.Route route, HttpRequest httpRequest) {
         def manifest = storage.getManifest(route.path)
         if (manifest.present) {
             return manifest.get()
@@ -109,7 +109,7 @@ class V2Controller {
         return fromCache(entry)
     }
 
-    MutableHttpResponse<?> fromCache(DigestByteArray entry) {
+    MutableHttpResponse<?> fromCache(DigestStore entry) {
         Map<CharSequence, CharSequence> headers = Map.of(
                         "Content-Length", entry.bytes.length.toString(),
                         "Content-Type", entry.mediaType,

--- a/src/main/groovy/io/seqera/docker/ContainerService.groovy
+++ b/src/main/groovy/io/seqera/docker/ContainerService.groovy
@@ -10,7 +10,7 @@ import io.micronaut.context.annotation.Value
 import io.micronaut.inject.qualifiers.Qualifiers
 import io.seqera.auth.LoginValidator
 import io.seqera.storage.Storage
-import io.seqera.storage.DigestByteArray
+import io.seqera.storage.DigestStore
 import io.seqera.RouteHelper
 import io.seqera.auth.DockerAuthProvider
 import io.seqera.config.Registry
@@ -63,7 +63,7 @@ class ContainerService {
     }
 
 
-    DigestByteArray handleManifest(RouteHelper.Route route, Map<String,List<String>> headers){
+    DigestStore handleManifest(RouteHelper.Route route, Map<String,List<String>> headers){
         final Registry registry = findRegistry(route.registry)
         assert registry
 
@@ -76,7 +76,7 @@ class ContainerService {
         final req = "/v2/$route.image/manifests/$digest"
         final entry = storage.getManifest(req).orElseThrow( ()->
                 new IllegalStateException("Missing cached entry for request: $req"))
-        entry
+        return entry
     }
 
     DelegateResponse handleRequest(RouteHelper.Route route, Map<String,List<String>> headers){

--- a/src/main/groovy/io/seqera/util/RegHelper.groovy
+++ b/src/main/groovy/io/seqera/util/RegHelper.groovy
@@ -1,14 +1,15 @@
 package io.seqera.util
 
-import com.google.common.io.BaseEncoding
-import com.sun.net.httpserver.Headers
-import groovy.json.JsonOutput
-
 import java.net.http.HttpHeaders
 import java.nio.charset.Charset
+import java.nio.file.Files
+import java.nio.file.Path
 import java.security.MessageDigest
 import java.security.SecureRandom
 
+import com.google.common.io.BaseEncoding
+import com.sun.net.httpserver.Headers
+import groovy.json.JsonOutput
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -32,6 +33,10 @@ class RegHelper {
 
     static String digest(String str) {
         return digest(str.getBytes())
+    }
+
+    static String digest(Path path) {
+        return digest(Files.readAllBytes(path))
     }
 
     static String digest(byte[] bytes) {

--- a/src/main/java/io/seqera/storage/DigestStore.java
+++ b/src/main/java/io/seqera/storage/DigestStore.java
@@ -1,0 +1,12 @@
+package io.seqera.storage;
+
+/**
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+public interface DigestStore {
+
+    byte[] getBytes();
+    String getMediaType();
+    String getDigest();
+
+}

--- a/src/main/java/io/seqera/storage/LazyDigestStore.java
+++ b/src/main/java/io/seqera/storage/LazyDigestStore.java
@@ -1,0 +1,44 @@
+package io.seqera.storage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Implements a digest store that laods the binary content on-demand
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+public class LazyDigestStore implements DigestStore{
+
+    final private String mediaType;
+    final private String digest;
+    final private Path contentLocation;
+
+    LazyDigestStore(Path content, String mediaType, String digest) {
+        this.contentLocation = content;
+        this.mediaType = mediaType;
+        this.digest = digest;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        try {
+            return contentLocation!=null ? Files.readAllBytes(contentLocation) : null;
+        }
+        catch (IOException e) {
+            throw new IllegalStateException("Unable to load digest content at path: "+contentLocation, e);
+        }
+    }
+
+    @Override
+    public String getMediaType() {
+        return mediaType;
+    }
+
+    @Override
+    public String getDigest() {
+        return digest;
+    }
+
+}

--- a/src/main/java/io/seqera/storage/Storage.java
+++ b/src/main/java/io/seqera/storage/Storage.java
@@ -1,6 +1,7 @@
 package io.seqera.storage;
 
 
+import java.nio.file.Path;
 import java.util.Optional;
 
 /**
@@ -8,11 +9,13 @@ import java.util.Optional;
  **/
 public interface Storage {
 
-    Optional<DigestByteArray> getManifest(String path);
+    Optional<DigestStore> getManifest(String path);
 
-    DigestByteArray saveManifest(String path, String manifest, String type, String digest);
+    DigestStore saveManifest(String path, String manifest, String type, String digest);
 
-    Optional<DigestByteArray> getBlob(String path);
+    Optional<DigestStore> getBlob(String path);
 
-    DigestByteArray saveBlob(String path, byte[] bytes, String type, String digest);
+    DigestStore saveBlob(String path, byte[] content, String type, String digest);
+
+    DigestStore saveBlob(String path, Path content, String type, String digest);
 }

--- a/src/main/java/io/seqera/storage/ZippedDigestStore.java
+++ b/src/main/java/io/seqera/storage/ZippedDigestStore.java
@@ -3,14 +3,18 @@ package io.seqera.storage;
 import io.seqera.util.ZipUtils;
 
 /**
+ * Implements a digest store compress/decompression on-demand
+ * the byte array content to retain as less as possible memory
+ *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
-public class DigestByteArray {
-    private byte[] bytes;
-    private String mediaType;
-    private String digest;
+public class ZippedDigestStore implements DigestStore{
 
-    public DigestByteArray(byte[] bytes, String mediaType, String digest) {
+    final private byte[] bytes;
+    final private String mediaType;
+    final private String digest;
+
+    public ZippedDigestStore(byte[] bytes, String mediaType, String digest) {
         this.bytes = ZipUtils.compress(bytes);
         this.mediaType = mediaType;
         this.digest = digest;
@@ -27,4 +31,5 @@ public class DigestByteArray {
     public String getDigest() {
         return digest;
     }
+
 }

--- a/src/test/groovy/io/seqera/storage/LazyDigestStoreTest.groovy
+++ b/src/test/groovy/io/seqera/storage/LazyDigestStoreTest.groovy
@@ -1,0 +1,30 @@
+package io.seqera.storage
+
+import spock.lang.Specification
+
+import java.nio.file.Files
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class LazyDigestStoreTest extends Specification {
+
+    def 'should load a lazy digest' () {
+        given:
+        def CONTENT = 'Hello world!'
+        def file = Files.createTempFile('test', null)
+        Files.write(file, CONTENT.bytes)
+
+        when:
+        def digest = new LazyDigestStore(file, 'text', 'sha256:122345567890')
+        then:
+        digest.bytes == CONTENT.bytes
+        digest.digest == 'sha256:122345567890'
+        digest.mediaType == 'text'
+
+        cleanup:
+        Files.deleteIfExists(file)
+    }
+
+}

--- a/src/test/groovy/io/seqera/storage/ZippedDigestStoreTest.groovy
+++ b/src/test/groovy/io/seqera/storage/ZippedDigestStoreTest.groovy
@@ -1,0 +1,23 @@
+package io.seqera.storage
+
+import spock.lang.Specification
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class ZippedDigestStoreTest extends Specification {
+
+    def 'should load a lazy digest' () {
+        given:
+        def CONTENT = 'Hello world!'
+
+        when:
+        def digest = new ZippedDigestStore(CONTENT.bytes, 'text', 'sha256:122345567890')
+        then:
+        digest.bytes == CONTENT.bytes
+        digest.digest == 'sha256:122345567890'
+        digest.mediaType == 'text'
+
+    }
+
+}


### PR DESCRIPTION
This commit refactors the DigestByteArray into an interface
providing specialised implementations.

In particular, for large content, it uses a lazy mechanism to load
the content on-demand.

Small text content is compressed on-fly to reduce the memory footprint.