### PR TITLE
generate build-info as an externalized resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           cache: gradle
 
       - name: Compile
-        run: make buildInfo compile
+        run: make compile
         env:
           GRADLE_OPTS: '-Dorg.gradle.daemon=false'
 

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,6 @@ pack/layers/layer.tar.gzip: .layer/opt/geesefs .layer/opt/tini
 
 pack: clean pack/layers/layer.tar.gzip
 
-buildInfo:
-	./gradlew buildInfo
 
 compile:
 	 ./gradlew assemble

--- a/build.gradle
+++ b/build.gradle
@@ -147,10 +147,11 @@ task buildInfo { doLast {
                 version=${version}
                 commitId=${project.property('commitId')}
             """.stripIndent().toString()
-    def f = file("src/main/resources/META-INF/build-info.properties")
+    def f = file("${buildDir}/resources/main/META-INF/build-info.properties")
     f.parentFile.mkdirs()
     f.text = info
 } }
+compileGroovy.dependsOn buildInfo
 
 asciidoctorj {
     modules {

--- a/src/main/resources/META-INF/build-info.properties
+++ b/src/main/resources/META-INF/build-info.properties
@@ -1,4 +1,0 @@
-name=wave
-group=io.seqera
-version=0.6.11
-commitId=4699bb3


### PR DESCRIPTION
Instead of writing into `src/`  , write into `build/` as it's a generated resource

closes #65