### PR TITLE
bugfix: activate storage factory in rate-limit

### DIFF
--- a/src/main/groovy/io/seqera/wave/ratelimit/impl/SpillWayStorageFactory.groovy
+++ b/src/main/groovy/io/seqera/wave/ratelimit/impl/SpillWayStorageFactory.groovy
@@ -20,6 +20,7 @@ import redis.clients.jedis.JedisPool
  * @author : jorge <jorge.aguilera@seqera.io>
  *
  */
+@Requires(env = 'rate-limit')
 @Factory
 @Slf4j
 @CompileStatic


### PR DESCRIPTION
SpillWayStorageFactory is only needed when rate-limit env is active

Signed-off-by: Jorge Aguilera <jorge.aguilera@seqera.io>