### PR TITLE
prefix objects store in redis

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/token/RedisTokenStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/token/RedisTokenStore.groovy
@@ -24,6 +24,8 @@ import jakarta.inject.Singleton
 @Slf4j
 class RedisTokenStore implements ContainerTokenStore {
 
+    private static final String PREFIX = 'wave/token/'
+
     ObjectMapper mapper = new ObjectMapper()
 
     StatefulRedisConnection<String,String> redisConnection
@@ -42,13 +44,13 @@ class RedisTokenStore implements ContainerTokenStore {
     ContainerRequestData put(String key, ContainerRequestData request) {
         def json = new JsonBuilder(request).toString()
         // once created the token the user has `Duration` time to pull the layers of the image
-        redisConnection.sync().psetex(key, tokenConfiguration.cache.duration.toMillis(), json)
+        redisConnection.sync().psetex(PREFIX+key, tokenConfiguration.cache.duration.toMillis(), json)
         return request
     }
 
     @Override
     ContainerRequestData get(String key) {
-        def json = redisConnection.sync().get(key)
+        def json = redisConnection.sync().get(PREFIX+key.toString())
         if( !json )
             return null
         def requestData = mapper.readValue(json, ContainerRequestData)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,3 +11,12 @@ mail:
     auth: true
     user: "${TOWER_SMTP_USER:`missing smtp user`}"
     password: "${TOWER_SMTP_PASSWORD:`missing smtp password`}"
+---
+datasources:
+  default:
+    url: "jdbc:h2:mem:test_mem"
+    driverClassName: "org.h2.Driver"
+    username: "sq"
+    password: ""
+    dialect: H2
+    schema-generate: CREATE_DROP

--- a/src/test/groovy/io/seqera/wave/controller/RedisContainerTokenControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/RedisContainerTokenControllerTest.groovy
@@ -65,9 +65,9 @@ class RedisContainerTokenControllerTest extends Specification implements RedisTe
         noExceptionThrown()
 
         and:
-        new JsonSlurper().parseText(jedisPool.resource.get(body.containerToken)).platform.arch == 'arm64'
-        new JsonSlurper().parseText(jedisPool.resource.get(body.containerToken)).workspaceId == 10
-        new JsonSlurper().parseText(jedisPool.resource.get(body.containerToken)).containerImage == 'ubuntu:latest'
+        new JsonSlurper().parseText(jedisPool.resource.get("wave/token/"+body.containerToken)).platform.arch == 'arm64'
+        new JsonSlurper().parseText(jedisPool.resource.get("wave/token/"+body.containerToken)).workspaceId == 10
+        new JsonSlurper().parseText(jedisPool.resource.get("wave/token/"+body.containerToken)).containerImage == 'ubuntu:latest'
     }
 
     def 'should not retrieve an expired build request' () {
@@ -86,7 +86,7 @@ class RedisContainerTokenControllerTest extends Specification implements RedisTe
         noExceptionThrown()
 
         when:
-        jedisPool.resource.del(body.containerToken)
+        jedisPool.resource.del("wave/token/"+body.containerToken)
 
         and:
         RouteHandler routeHelper = applicationContext.getBean(RouteHandler)

--- a/src/test/groovy/io/seqera/wave/service/builder/cache/RedisBuildStoreTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/cache/RedisBuildStoreTest.groovy
@@ -48,6 +48,8 @@ class RedisBuildStoreTest extends Specification implements RedisTestContainer {
         then:
         cacheStore.getBuild('foo') == req1
         and:
+        jedisPool.resource.get("wave/status/foo").toString()
+        and:
         cacheStore.hasBuild('foo')
     }
 


### PR DESCRIPTION
prefix objects to be stored in redis with 'wave/'


closes #137

Signed-off-by: Jorge Aguilera <jorge.aguilera@seqera.io>