### PR TITLE
notask: adds monitoring endpoint for prometheus

### DIFF
--- a/src/main/resources/application-prometheus.yml
+++ b/src/main/resources/application-prometheus.yml
@@ -1,0 +1,11 @@
+micronaut:
+  metrics:
+    enabled: true
+    export :
+      prometheus :
+        enabled : true
+        step : PT1M
+        descriptions : true
+endpoints:
+  prometheus:
+    sensitive: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,21 +4,11 @@ micronaut:
     name: wave-app
   server:
     port: 9090
-  metrics:
-    enabled: true
-    export :
-      prometheus :
-        enabled : true
-        step : PT1M
-        descriptions : true
 ---
 netty:
   default:
     allocator:
       max-order: 3
-endpoints:
-  prometheus:
-    sensitive: false
 ---
 wave:
   debug: false


### PR DESCRIPTION
This PR adds dependencies and configuration to enable the prometheus.
This is a first integration before adding specific matrics that we want to add instrumenting the code.


The metrics exposed by default are:
- database connection pool metrics
- JVM metrics
- executors/thread pool resources
- endpoints metrics (count and latencies)