### PR TITLE
parse token body only when status code is 200

### DIFF
--- a/src/main/groovy/io/seqera/wave/auth/RegistryAuthServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/auth/RegistryAuthServiceImpl.groovy
@@ -177,8 +177,8 @@ class RegistryAuthServiceImpl implements RegistryAuthService {
 
         HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
         final body = resp.body()
-        final result = (Map) new JsonSlurper().parseText(body)
         if( resp.statusCode()==200 ) {
+            final result = (Map) new JsonSlurper().parseText(body)
             log.debug "Registry '$login' => token: ${result.token}"
             return result.get('token')
         }


### PR DESCRIPTION
When we are retrieving the token response body is not present when status code is not 200

move the extraction after check the status code