### PR TITLE
use jedis instead jedispool in tests

### DIFF
--- a/src/test/groovy/io/seqera/wave/controller/RedisContainerTokenControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/RedisContainerTokenControllerTest.groovy
@@ -15,7 +15,7 @@ import io.seqera.wave.api.SubmitContainerTokenResponse
 import io.seqera.wave.core.RouteHandler
 import io.seqera.wave.exception.NotFoundException
 import io.seqera.wave.test.RedisTestContainer
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.Jedis
 /**
  * @author : jorge <jorge.aguilera@seqera.io>
  *
@@ -26,7 +26,7 @@ class RedisContainerTokenControllerTest extends Specification implements RedisTe
 
     int port
 
-    JedisPool jedisPool
+    Jedis jedis
 
     def setup() {
         port = SocketUtils.findAvailableTcpPort()
@@ -37,8 +37,12 @@ class RedisContainerTokenControllerTest extends Specification implements RedisTe
                 'micronaut.http.services.default.url' : "http://localhost:$port".toString(),
         ], 'test', 'h2', 'redis')
 
-        jedisPool = new JedisPool(redisHostName, redisPort as int)
-        jedisPool.resource.flushAll()
+        jedis = new Jedis(redisHostName, redisPort as int)
+        jedis.flushAll()
+    }
+
+    def cleanup(){
+        jedis.close()
     }
 
     ApplicationContext getApplicationContext() {
@@ -61,9 +65,9 @@ class RedisContainerTokenControllerTest extends Specification implements RedisTe
         noExceptionThrown()
 
         and:
-        new JsonSlurper().parseText(jedisPool.resource.get("wave-tokens/v1:"+body.containerToken)).platform.arch == 'arm64'
-        new JsonSlurper().parseText(jedisPool.resource.get("wave-tokens/v1:"+body.containerToken)).workspaceId == 10
-        new JsonSlurper().parseText(jedisPool.resource.get("wave-tokens/v1:"+body.containerToken)).containerImage == 'ubuntu:latest'
+        new JsonSlurper().parseText(jedis.get("wave-tokens/v1:"+body.containerToken)).platform.arch == 'arm64'
+        new JsonSlurper().parseText(jedis.get("wave-tokens/v1:"+body.containerToken)).workspaceId == 10
+        new JsonSlurper().parseText(jedis.get("wave-tokens/v1:"+body.containerToken)).containerImage == 'ubuntu:latest'
     }
 
     def 'should not retrieve an expired build request' () {
@@ -82,7 +86,7 @@ class RedisContainerTokenControllerTest extends Specification implements RedisTe
         noExceptionThrown()
 
         when:
-        jedisPool.resource.del("wave-tokens/v1:"+body.containerToken)
+        jedis.del("wave-tokens/v1:"+body.containerToken)
 
         and:
         RouteHandler routeHelper = applicationContext.getBean(RouteHandler)

--- a/src/test/groovy/io/seqera/wave/controller/RedisRegistryControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/RedisRegistryControllerTest.groovy
@@ -18,7 +18,7 @@ import io.seqera.wave.model.ContentType
 import io.seqera.wave.storage.RedisStorage
 import io.seqera.wave.test.DockerRegistryContainer
 import io.seqera.wave.test.RedisTestContainer
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.Jedis
 /**
  *
  * @author Jorge Aguilera <jorge.aguilera@seqera.io>
@@ -30,7 +30,7 @@ class RedisRegistryControllerTest extends Specification implements DockerRegistr
 
     int port
 
-    JedisPool jedisPool
+    Jedis jedis
 
     def setup() {
         port = SocketUtils.findAvailableTcpPort()
@@ -42,9 +42,13 @@ class RedisRegistryControllerTest extends Specification implements DockerRegistr
                 'micronaut.http.services.default.url' : "http://localhost:$port".toString(),
         ], 'test', 'h2', 'redis')
 
-        jedisPool = new JedisPool(redisHostName, redisPort as int)
-        jedisPool.resource.flushAll()
+        jedis = new Jedis(redisHostName, redisPort as int)
+        jedis.flushAll()
         initRegistryContainer(applicationContext)
+    }
+
+    def cleanup(){
+        jedis.close()
     }
 
     ApplicationContext getApplicationContext() {
@@ -89,8 +93,8 @@ class RedisRegistryControllerTest extends Specification implements DockerRegistr
         given:
         HttpClient client = applicationContext.createBean(HttpClient)
         and:
-        jedisPool.resource.set("wave-tokens/v1:1234", '{"containerImage":"hello-world"}')
-        jedisPool.resource.set("wave-build/v1:hello-world", '{"containerImage":"hello-world"}')
+        jedis.set("wave-tokens/v1:1234", '{"containerImage":"hello-world"}')
+        jedis.set("wave-build/v1:hello-world", '{"containerImage":"hello-world"}')
         when:
         HttpRequest request = HttpRequest.GET("http://localhost:$port/v2/wt/1234/hello-world/manifests/latest").headers({h->
             h.add('Accept', ContentType.DOCKER_MANIFEST_V2_TYPE)

--- a/src/test/groovy/io/seqera/wave/ratelimit/SpillwayRedisRateLimiterTest.groovy
+++ b/src/test/groovy/io/seqera/wave/ratelimit/SpillwayRedisRateLimiterTest.groovy
@@ -8,7 +8,7 @@ import io.seqera.wave.exception.SlowDownException
 import io.seqera.wave.configuration.RateLimiterConfig
 import io.seqera.wave.ratelimit.impl.SpillwayRateLimiter
 import io.seqera.wave.test.RedisTestContainer
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.Jedis
 
 /**
  * @author : jorge <jorge.aguilera@seqera.io>
@@ -20,7 +20,7 @@ class SpillwayRedisRateLimiterTest extends Specification implements RedisTestCon
 
     SpillwayRateLimiter rateLimiter
 
-    JedisPool jedisPool
+    Jedis jedis
 
     def setup() {
         applicationContext = ApplicationContext.run([
@@ -28,8 +28,12 @@ class SpillwayRedisRateLimiterTest extends Specification implements RedisTestCon
                 REDIS_PORT   : redisPort
         ], 'test', 'redis','rate-limit')
         rateLimiter = applicationContext.getBean(SpillwayRateLimiter)
-        jedisPool = new JedisPool(redisHostName, redisPort as int)
-        jedisPool.resource.flushAll()
+        jedis = new Jedis(redisHostName, redisPort as int)
+        jedis.flushAll()
+    }
+
+    def cleanup(){
+        jedis.close()
     }
 
     void "can acquire 1 auth resource"() {
@@ -38,8 +42,8 @@ class SpillwayRedisRateLimiterTest extends Specification implements RedisTestCon
         then:
         noExceptionThrown()
         and:
-        jedisPool.resource.scan("0").result.size() == 1
-        jedisPool.resource.scan("0").result.first().startsWith('spillway|authenticatedBuilds|perUser|test')
+        jedis.scan("0").result.size() == 1
+        jedis.scan("0").result.first().startsWith('spillway|authenticatedBuilds|perUser|test')
     }
 
     void "can acquire 1 anon resource"() {
@@ -48,8 +52,8 @@ class SpillwayRedisRateLimiterTest extends Specification implements RedisTestCon
         then:
         noExceptionThrown()
         and:
-        jedisPool.resource.scan("0").result.size() == 1
-        jedisPool.resource.scan("0").result.first().startsWith('spillway|anonymousBuilds|perUser|test')
+        jedis.scan("0").result.size() == 1
+        jedis.scan("0").result.first().startsWith('spillway|anonymousBuilds|perUser|test')
     }
 
     void "can't acquire more resources"() {
@@ -63,7 +67,7 @@ class SpillwayRedisRateLimiterTest extends Specification implements RedisTestCon
         then:
         noExceptionThrown()
         and:
-        jedisPool.resource.scan("0").result.size() == 1
+        jedis.scan("0").result.size() == 1
 
         when:
         rateLimiter.acquireBuild( new AcquireRequest("test", null))

--- a/src/test/groovy/io/seqera/wave/service/builder/cache/RedisBuildStoreTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/cache/RedisBuildStoreTest.groovy
@@ -12,7 +12,7 @@ import io.seqera.wave.exception.BuildTimeoutException
 import io.seqera.wave.service.builder.BuildResult
 import io.seqera.wave.service.builder.BuildStore
 import io.seqera.wave.test.RedisTestContainer
-import redis.clients.jedis.JedisPool
+import redis.clients.jedis.Jedis
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -21,7 +21,7 @@ class RedisBuildStoreTest extends Specification implements RedisTestContainer {
 
     ApplicationContext applicationContext
 
-    JedisPool jedisPool
+    Jedis jedis
 
     def setup() {
         applicationContext = ApplicationContext.run([
@@ -29,8 +29,12 @@ class RedisBuildStoreTest extends Specification implements RedisTestContainer {
                 REDIS_HOST: redisHostName,
                 REDIS_PORT: redisPort
         ], 'test', 'redis')
-        jedisPool = new JedisPool(redisHostName, redisPort as int)
-        jedisPool.resource.flushAll()
+        jedis = new Jedis(redisHostName, redisPort as int)
+        jedis.flushAll()
+    }
+
+    def cleanup(){
+        jedis.close()
     }
 
     def 'should get and put key values' () {
@@ -47,7 +51,7 @@ class RedisBuildStoreTest extends Specification implements RedisTestContainer {
         then:
         cacheStore.getBuild('foo') == req1
         and:
-        jedisPool.resource.get("wave-build:foo").toString()
+        jedis.get("wave-build:foo").toString()
 
     }
 


### PR DESCRIPTION
Don't know why but I was using JedisPool instead Jedis 

JedisPool creates a thread to watch and maintain the connection and this can cause errors