### PR TITLE
Remove GitHub repo from header, as private

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,5 @@
 site_name: Wave containers
 site_url: https://wavecontainers.io/
-repo_url: https://github.com/seqeralabs/wave
-repo_name: seqeralabs/wave
 
 nav:
   - Home: index.md


### PR DESCRIPTION
For anyone not part of the Seqera GitHub org, that link will give a 404...