### PR TITLE
bump kubernetes client to 18.0.1 and commons-compress to 1.24.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,8 @@ dependencies {
     implementation("io.seqera:tower-crypto:22.4.0-watson") { transitive = false }  // to be replaced with 22.4.0 once released
     implementation 'org.apache.commons:commons-compress:1.21'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'io.kubernetes:client-java:18.0.0'
-    implementation 'io.kubernetes:client-java-api-fluent:18.0.0'
+    implementation 'io.kubernetes:client-java:18.0.1'
+    implementation 'io.kubernetes:client-java-api-fluent:18.0.1'
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
@@ -79,7 +79,7 @@ dependencies {
 
     runtimeOnly("io.netty:netty-tcnative-boringssl-static:2.0.0.Final")
     runtimeOnly("javax.xml.bind:jaxb-api:2.3.1")
-    testImplementation "org.apache.commons:commons-compress:1.21"
+    testImplementation "org.apache.commons:commons-compress:1.24.0"
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:mysql:1.17.3")
 


### PR DESCRIPTION
This PR will remove Java CVE from wave container