### PR TITLE
Update build.yml: softer conditional to skip build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Build Wave
-    if: "github.event == 'push' || github.repository != github.event.pull_request.head.repo.full_name"
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
I think this [commit](https://github.com/seqeralabs/wave/pull/71/commits/bdecfc3793fa98836d1215802fcf48eaaa309a7d) has to be reverted,  because it is causing CI to be skipped, in cases where they should be executed.

Not having the current conditional is in line with nextflow, tower, fusion repos.  

Leaving the condition on `[skip ci]` commits, as in wave-cli, can be good to skip CIs in specific cases.
