### PR TITLE
Simplify sidebar slightly

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -5,8 +5,11 @@
       "type": "category",
       "label": "Wave CLI",
       "collapsed": false,
+      "link": {
+        "type": "doc",
+        "id": "cli/index"
+      },
       "items": [
-        "cli/index",
         "cli/install",
         "cli/build-directory",
         "cli/build-docker",


### PR DESCRIPTION
This rolls up the CLI index into the category itself. This simplifies the sidebar and uses space more efficiently.

<img width="779" alt="Screenshot 2023-12-06 at 10 42 44 AM" src="https://github.com/seqeralabs/wave/assets/141646877/fec8b28e-47a4-471d-9af7-1bfe6cc08a2d">
