### PR TITLE
ProxyClient v2

### DIFF
--- a/src/main/groovy/io/seqera/wave/http/HttpClientFactory.groovy
+++ b/src/main/groovy/io/seqera/wave/http/HttpClientFactory.groovy
@@ -58,6 +58,7 @@ class HttpClientFactory {
         }
     }
 
+    @Deprecated
     static HttpClient neverRedirectsHttpClient() {
         if( client2!=null )
             return client2

--- a/src/main/groovy/io/seqera/wave/proxy/ClientResponseException.groovy
+++ b/src/main/groovy/io/seqera/wave/proxy/ClientResponseException.groovy
@@ -18,9 +18,9 @@
 
 package io.seqera.wave.proxy
 
-import java.net.http.HttpRequest
 
 import groovy.transform.CompileStatic
+import io.micronaut.http.HttpRequest
 
 /**
  * Model an invalid response got by the registry client client

--- a/src/main/groovy/io/seqera/wave/proxy/ErrResponse.groovy
+++ b/src/main/groovy/io/seqera/wave/proxy/ErrResponse.groovy
@@ -18,13 +18,15 @@
 
 package io.seqera.wave.proxy
 
-import javax.net.ssl.SSLSession
-import java.net.http.HttpClient
-import java.net.http.HttpHeaders
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
 
 import groovy.transform.CompileStatic
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.convert.value.MutableConvertibleValues
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.simple.SimpleHttpHeaders
 
 /**
  *
@@ -50,57 +52,46 @@ class ErrResponse<T> implements HttpResponse<T> {
     private HttpHeaders headers
 
     @Override
-    int statusCode() {
-        return statusCode
+    HttpStatus getStatus() {
+        return HttpStatus.valueOf(statusCode)
     }
 
     @Override
-    HttpRequest request() {
-        return request
-    }
-
-    @Override
-    Optional<HttpResponse<T>> previousResponse() {
-        return null
-    }
-
-    @Override
-    HttpHeaders headers() {
+    HttpHeaders getHeaders() {
         return headers
     }
 
     @Override
-    T body() {
-        return body
-    }
-
-    @Override
-    Optional<SSLSession> sslSession() {
+    MutableConvertibleValues<Object> getAttributes() {
         return null
     }
 
     @Override
-    URI uri() {
-        return uri
+    Optional getBody() {
+        return Optional.of(body)
     }
+    
 
-    @Override
-    HttpClient.Version version() {
-        return HttpClient.Version.HTTP_1_1
-    }
+//    URI uri() {
+//        return uri
+//    }
+//
+//    static HttpVersion version() {
+//        return HttpVersion.HTTP_1_1
+//    }
 
     static ErrResponse<String> forString(String msg, HttpRequest request) {
-        final head = HttpHeaders.of('Content-Type': ['text/plain'], {true})
-        new ErrResponse<String>(statusCode: 400, body: msg, request: request, uri: request.uri(), headers: head)
+        final head = new SimpleHttpHeaders(Map.of('Content-Type', 'text/plain'), ConversionService.SHARED)
+        new ErrResponse<String>(statusCode: 400, body: msg, request: request, uri: request.getUri(), headers: head)
     }
 
     static ErrResponse<InputStream> forStream(String msg, HttpRequest request) {
-        final head = HttpHeaders.of('Content-Type': ['text/plain'], {true})
-        new ErrResponse<InputStream>(statusCode: 400, body: new ByteArrayInputStream(msg.bytes), request: request, uri: request.uri(), headers: head)
+        final head = new SimpleHttpHeaders(Map.of('Content-Type', 'text/plain'), ConversionService.SHARED)
+        new ErrResponse<InputStream>(statusCode: 400, body: new ByteArrayInputStream(msg.bytes), request: request, uri: request.getUri(), headers: head)
     }
 
     static ErrResponse<byte[]> forByteArray(String msg, HttpRequest request) {
-        final head = HttpHeaders.of('Content-Type': ['text/plain'], {true})
-        new ErrResponse<byte[]>(statusCode: 400, body: msg.bytes, request: request, uri: request.uri(), headers: head)
+        final head = new SimpleHttpHeaders(Map.of('Content-Type', 'text/plain'), ConversionService.SHARED)
+        new ErrResponse<byte[]>(statusCode: 400, body: msg.bytes, request: request, uri: request.getUri(), headers: head)
     }
 }

--- a/src/main/groovy/io/seqera/wave/proxy/ProxyClient.groovy
+++ b/src/main/groovy/io/seqera/wave/proxy/ProxyClient.groovy
@@ -25,7 +25,6 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MutableHttpRequest
 import io.micronaut.http.client.HttpClient
-import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.server.exceptions.InternalServerException
 import io.seqera.wave.auth.RegistryAuthService
 import io.seqera.wave.auth.RegistryCredentials
@@ -195,15 +194,6 @@ class ProxyClient {
 
     }
 
-    private <I,O> HttpResponse<O> exchange(HttpRequest<I> request, Class<O> bodyType) {
-        try {
-            return httpClient.toBlocking().exchange(request, bodyType)
-        }
-        catch (HttpClientResponseException e) {
-            return (HttpResponse<O>)e.getResponse()
-        }
-    }
-
     private <T> HttpResponse<T> get1(URI uri, Map<String,List<String>> headers, Class<T> bodyType, boolean authorize, MutableHttpRequest request) {
         try{
             copyHeaders(headers, request)
@@ -214,7 +204,7 @@ class ProxyClient {
                     request.header("Authorization", header)
             }
             // send it
-            HttpResponse<T> response = exchange(request, bodyType)
+            HttpResponse<T> response = httpClient.toBlocking().exchange(request, bodyType)
             traceResponse(request, response)
             return response
         }
@@ -266,7 +256,7 @@ class ProxyClient {
         if( header )
             request.header("Authorization", header)
         // send it
-        final response= exchange(request, Void)
+        final response= httpClient.toBlocking().exchange(request, Void)
         traceResponse(request, response)
         return response
     }

--- a/src/main/groovy/io/seqera/wave/proxy/ProxyClient.groovy
+++ b/src/main/groovy/io/seqera/wave/proxy/ProxyClient.groovy
@@ -47,9 +47,6 @@ import static io.seqera.wave.WaveDefault.HTTP_RETRYABLE_ERRORS
 @CompileStatic
 class ProxyClient {
 
-    private static final long RETRY_MAX_DELAY_MILLIS = 30_000
-    private static final int RETRY_MAX_ATTEMPTS = 8
-
     private String image
     private RegistryInfo registry
     private RegistryCredentials credentials

--- a/src/main/groovy/io/seqera/wave/service/inspect/ContainerInspectServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/inspect/ContainerInspectServiceImpl.groovy
@@ -18,12 +18,13 @@
 
 package io.seqera.wave.service.inspect
 
-
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
 import io.seqera.wave.WaveDefault
 import io.seqera.wave.auth.RegistryAuthService
 import io.seqera.wave.auth.RegistryCredentials
@@ -34,7 +35,6 @@ import io.seqera.wave.core.ContainerAugmenter
 import io.seqera.wave.core.ContainerPath
 import io.seqera.wave.core.RegistryProxyService
 import io.seqera.wave.core.spec.ManifestSpec
-import io.seqera.wave.http.HttpClientFactory
 import io.seqera.wave.model.ContainerCoordinates
 import io.seqera.wave.proxy.ProxyClient
 import io.seqera.wave.util.RegHelper
@@ -79,6 +79,10 @@ class ContainerInspectServiceImpl implements ContainerInspectService {
 
     @Inject
     private HttpClientConfig httpConfig
+
+    @Inject
+    @Client("proxy-client")
+    HttpClient httpClient
 
     /**
      * {@inheritDoc}
@@ -197,7 +201,6 @@ class ContainerInspectServiceImpl implements ContainerInspectService {
 
     private ProxyClient client0(ContainerPath route, RegistryCredentials creds) {
         final registry = lookupService.lookup(route.registry)
-        final httpClient = HttpClientFactory.neverRedirectsHttpClient()
         new ProxyClient(httpClient, httpConfig)
                 .withRoute(route)
                 .withImage(route.image)

--- a/src/main/groovy/io/seqera/wave/util/RegHelper.groovy
+++ b/src/main/groovy/io/seqera/wave/util/RegHelper.groovy
@@ -280,4 +280,18 @@ class RegHelper {
             log.debug "Unexpected error while closing http response - cause: ${e.message}", e
         }
     }
+
+    static void closeResponse(io.micronaut.http.HttpResponse<?> response) {
+        log.trace "Closing HttpClient response: $response"
+        try {
+            // close the httpclient response to prevent leaks
+            // https://bugs.openjdk.org/browse/JDK-8308364
+            final b0 = response.body()
+            if( b0 instanceof Closeable )
+                b0.close()
+        }
+        catch (Throwable e) {
+            log.debug "Unexpected error while closing http response - cause: ${e.message}", e
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,10 @@ micronaut:
         paths: 'classpath:io/seqera/wave/assets'
         mapping: '/assets/**'
         enabled: true
+  http:
+    services:
+      proxy-client:
+        follow-redirects: false
 ---
 wave:
   allowAnonymous: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,10 +30,13 @@ micronaut:
         paths: 'classpath:io/seqera/wave/assets'
         mapping: '/assets/**'
         enabled: true
+# http client configuration
+# https://docs.micronaut.io/latest/guide/configurationreference.html#io.micronaut.http.client.DefaultHttpClientConfiguration
   http:
     services:
       proxy-client:
         follow-redirects: false
+        exception-on-error-status: false
 ---
 wave:
   allowAnonymous: true

--- a/src/test/groovy/io/seqera/wave/ProxyClientTest.groovy
+++ b/src/test/groovy/io/seqera/wave/ProxyClientTest.groovy
@@ -23,13 +23,14 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.seqera.wave.auth.RegistryAuth
 import io.seqera.wave.auth.RegistryAuthService
 import io.seqera.wave.auth.RegistryCredentialsProvider
 import io.seqera.wave.auth.RegistryLookupService
 import io.seqera.wave.configuration.HttpClientConfig
-import io.seqera.wave.http.HttpClientFactory
 import io.seqera.wave.proxy.ProxyClient
 import jakarta.inject.Inject
 /**
@@ -49,13 +50,16 @@ class ProxyClientTest extends Specification {
 
     @Inject HttpClientConfig httpConfig
 
+    @Inject
+    @Client("proxy-client")
+    HttpClient httpClient
+
     def 'should call target manifests on docker.io' () {
         given:
         def REG = 'docker.io'
         def IMAGE = 'library/hello-world'
         def registry = lookupService.lookup(REG)
         def creds = credentialsProvider.getDefaultCredentials(REG)
-        def httpClient = HttpClientFactory.neverRedirectsHttpClient()
         and:
         def proxy = new ProxyClient(httpClient, httpConfig)
                 .withImage(IMAGE)
@@ -67,7 +71,7 @@ class ProxyClientTest extends Specification {
         def resp1 = proxy.getString('/v2/library/hello-world/manifests/sha256:aa0cc8055b82dc2509bed2e19b275c8f463506616377219d9642221ab53cf9fe')
         and:
         then:
-        resp1.statusCode() == 200
+        resp1.code() == 200
     }
 
     def 'should call target manifests on docker.io with no creds' () {
@@ -75,7 +79,6 @@ class ProxyClientTest extends Specification {
         def REG = 'docker.io'
         def IMAGE = 'library/hello-world'
         def registry = lookupService.lookup(REG)
-        def httpClient = HttpClientFactory.neverRedirectsHttpClient()
         and:
         def proxy = new ProxyClient(httpClient, httpConfig)
                 .withImage(IMAGE)
@@ -86,7 +89,7 @@ class ProxyClientTest extends Specification {
         def resp1 = proxy.getString('/v2/library/hello-world/manifests/sha256:aa0cc8055b82dc2509bed2e19b275c8f463506616377219d9642221ab53cf9fe')
         and:
         then:
-        resp1.statusCode() == 200
+        resp1.code() == 200
     }
 
     def 'should call target blob on quay' () {
@@ -95,7 +98,6 @@ class ProxyClientTest extends Specification {
         def IMAGE = 'biocontainers/fastqc'
         def registry = lookupService.lookup(REG)
         def creds = credentialsProvider.getDefaultCredentials(REG)
-        def httpClient = HttpClientFactory.neverRedirectsHttpClient()
         and:
         def proxy = new ProxyClient(httpClient, httpConfig)
                 .withImage(IMAGE)
@@ -107,7 +109,7 @@ class ProxyClientTest extends Specification {
         def resp1 = proxy.getString('/v2/biocontainers/fastqc/blobs/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4')
         and:
         then:
-        resp1.statusCode() == 200
+        resp1.code() == 200
     }
 
     def 'should redirect a target blob on quay' () {
@@ -116,7 +118,6 @@ class ProxyClientTest extends Specification {
         def IMAGE = 'biocontainers/fastqc'
         def registry = lookupService.lookup(REG)
         def creds = credentialsProvider.getDefaultCredentials(REG)
-        def httpClient = HttpClientFactory.neverRedirectsHttpClient()
         and:
         def proxy = new ProxyClient(httpClient, httpConfig)
                 .withImage(IMAGE)
@@ -128,7 +129,7 @@ class ProxyClientTest extends Specification {
         def resp1 = proxy.getString('/v2/biocontainers/fastqc/blobs/sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4',null,false)
         and:
         then:
-        resp1.statusCode() == 302
+        resp1.code() == 302
     }
 
     def 'should lookup aws registry' () {
@@ -150,7 +151,6 @@ class ProxyClientTest extends Specification {
         def REG = '195996028523.dkr.ecr.eu-west-1.amazonaws.com'
         def registry = lookupService.lookup(REG)
         def creds = credentialsProvider.getDefaultCredentials(REG)
-        def httpClient = HttpClientFactory.neverRedirectsHttpClient()
         and:
         def proxy = new ProxyClient(httpClient, httpConfig)
                 .withImage(IMAGE)
@@ -161,7 +161,7 @@ class ProxyClientTest extends Specification {
         when:
         def resp = proxy.getString("/v2/$IMAGE/manifests/0.1.0")
         then:
-        resp.statusCode() == 200
+        resp.code() == 200
     }
 
     @Requires({System.getenv('AWS_ACCESS_KEY_ID') && System.getenv('AWS_SECRET_ACCESS_KEY')})
@@ -171,7 +171,6 @@ class ProxyClientTest extends Specification {
         def REG = 'public.ecr.aws'
         def registry = lookupService.lookup(REG)
         def creds = credentialsProvider.getDefaultCredentials(REG)
-        def httpClient = HttpClientFactory.neverRedirectsHttpClient()
         and:
         def proxy = new ProxyClient(httpClient, httpConfig)
                 .withImage(IMAGE)
@@ -182,7 +181,7 @@ class ProxyClientTest extends Specification {
         when:
         def resp = proxy.getString("/v2/$IMAGE/manifests/23.04.0")
         then:
-        resp.statusCode() == 200
+        resp.code() == 200
     }
 
     @Requires({System.getenv('GOOGLECR_KEYS')})
@@ -233,7 +232,6 @@ class ProxyClientTest extends Specification {
         def REG = 'europe-southwest1-docker.pkg.dev'
         def registry = lookupService.lookup(REG)
         def creds = credentialsProvider.getDefaultCredentials(REG)
-        def httpClient = HttpClientFactory.neverRedirectsHttpClient()
         and:
         def proxy = new ProxyClient(httpClient, httpConfig)
                 .withImage(IMAGE)
@@ -244,6 +242,6 @@ class ProxyClientTest extends Specification {
         when:
         def resp = proxy.getString("/v2/$IMAGE/manifests/latest")
         then:
-        resp.statusCode() == 200
+        resp.code() == 200
     }
 }

--- a/src/test/groovy/io/seqera/wave/ProxyClientWithLocalRegistryTest.groovy
+++ b/src/test/groovy/io/seqera/wave/ProxyClientWithLocalRegistryTest.groovy
@@ -22,12 +22,13 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.seqera.wave.auth.RegistryAuthService
 import io.seqera.wave.auth.RegistryCredentialsProvider
 import io.seqera.wave.auth.RegistryLookupService
 import io.seqera.wave.configuration.HttpClientConfig
-import io.seqera.wave.http.HttpClientFactory
 import io.seqera.wave.proxy.ProxyClient
 import io.seqera.wave.test.DockerRegistryContainer
 import jakarta.inject.Inject
@@ -48,6 +49,10 @@ class ProxyClientWithLocalRegistryTest extends Specification implements DockerRe
 
     @Inject HttpClientConfig httpConfig
 
+    @Inject
+    @Client("noFollowRedirect")
+    HttpClient httpClient
+
     def setupSpec() {
         initRegistryContainer(applicationContext)
     }
@@ -56,7 +61,6 @@ class ProxyClientWithLocalRegistryTest extends Specification implements DockerRe
         given:
         def IMAGE = 'library/hello-world'
         and:
-        def httpClient = HttpClientFactory.neverRedirectsHttpClient()
         def proxy = new ProxyClient(httpClient, httpConfig)
                 .withImage(IMAGE)
                 .withRegistry(getLocalTestRegistryInfo())
@@ -67,7 +71,7 @@ class ProxyClientWithLocalRegistryTest extends Specification implements DockerRe
         and:
         println resp1.body()
         then:
-        resp1.statusCode() == 200
+        resp1.code() == 200
     }
 
 }

--- a/src/test/groovy/io/seqera/wave/RegistryProxyServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/RegistryProxyServiceTest.groovy
@@ -18,18 +18,13 @@
 
 package io.seqera.wave
 
-import spock.lang.Requires
+
 import spock.lang.Shared
 import spock.lang.Specification
 
 import io.micronaut.context.ApplicationContext
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import io.seqera.wave.auth.RegistryAuth
-import io.seqera.wave.auth.RegistryAuthService
-import io.seqera.wave.auth.RegistryCredentialsProvider
-import io.seqera.wave.auth.RegistryLookupService
 import io.seqera.wave.core.RegistryProxyService
-import io.seqera.wave.proxy.ProxyClient
 import io.seqera.wave.test.DockerRegistryContainer
 import jakarta.inject.Inject
 /**

--- a/src/test/groovy/io/seqera/wave/core/ContainerAugmenterTest.groovy
+++ b/src/test/groovy/io/seqera/wave/core/ContainerAugmenterTest.groovy
@@ -28,6 +28,8 @@ import java.nio.file.Paths
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import io.micronaut.context.annotation.Value
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.seqera.wave.WaveDefault
 import io.seqera.wave.api.ContainerConfig
@@ -38,7 +40,6 @@ import io.seqera.wave.auth.RegistryCredentialsProvider
 import io.seqera.wave.auth.RegistryInfo
 import io.seqera.wave.auth.RegistryLookupService
 import io.seqera.wave.configuration.HttpClientConfig
-import io.seqera.wave.http.HttpClientFactory
 import io.seqera.wave.model.ContentType
 import io.seqera.wave.proxy.ProxyClient
 import io.seqera.wave.storage.Storage
@@ -75,6 +76,10 @@ class ContainerAugmenterTest extends Specification {
     @Inject RegistryCredentialsProvider credentialsProvider
 
     @Inject HttpClientConfig httpConfig
+
+    @Inject
+    @Client('proxy-client')
+    HttpClient httpClient
 
     def 'should set layer paths' () {
         given:
@@ -762,7 +767,6 @@ class ContainerAugmenterTest extends Specification {
         def TAG = 'latest'
         def registry = lookupService.lookup(REGISTRY)
         def creds = credentialsProvider.getDefaultCredentials(REGISTRY)
-        def httpClient = HttpClientFactory.neverRedirectsHttpClient()
         and:
 
         def client = new ProxyClient(httpClient, httpConfig)
@@ -790,7 +794,6 @@ class ContainerAugmenterTest extends Specification {
         def IMAGE = 'library/busybox'
         def registry = lookupService.lookup(REGISTRY)
         def creds = credentialsProvider.getDefaultCredentials(REGISTRY)
-        def httpClient = HttpClientFactory.neverRedirectsHttpClient()
         and:
 
         def client = new ProxyClient(httpClient, httpConfig)
@@ -818,7 +821,6 @@ class ContainerAugmenterTest extends Specification {
         def TAG = '0.11.9--0'
         def registry = lookupService.lookup(REGISTRY)
         def creds = credentialsProvider.getDefaultCredentials(REGISTRY)
-        def httpClient = HttpClientFactory.neverRedirectsHttpClient()
         and:
 
         def client = new ProxyClient(httpClient, httpConfig)


### PR DESCRIPTION
This PR implements the Wave ProxyClient using the Micronaut HTTP client instead of Java SDK one, based [on the work done](https://github.com/seqeralabs/wave/pull/306).

Most tests pass, however, it looks like there's a problem when retrieving a binary stream by using the following method 

https://github.com/seqeralabs/wave/blob/51a22d80416adb4cf382c2991ca942333da0b56c/src/main/groovy/io/seqera/wave/proxy/ProxyClient.groovy#L107-L114

The response body (stream) is always `null`. @munishchouhan have you encountered this problem? 
 