### PR TITLE
spack templates: all configs available in spack.yaml and its dir

### DIFF
--- a/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
@@ -16,32 +16,33 @@ ENV \
   AWS_ROLE_ARN=${AWS_ROLE_ARN} \
   AWS_WEB_IDENTITY_TOKEN_FILE=${AWS_WEB_IDENTITY_TOKEN_FILE}
 
-RUN mkdir -p /opt/spack-env \
-&&  sed -i -e 's;compilers:;compilers::;' \
-         -e 's;^ *flags: *{};    flags:\n      cflags: -O3\n      cxxflags: -O3\n      fflags: -O3;' \
-         /root/.spack/linux/compilers.yaml \
-&& cd /opt/spack-env \
-&& spack config add config:install_tree:/opt/software \
-&& spack config add concretizer:unify:true \
-&& spack config add concretizer:reuse:true \
-&& spack config add packages:all:target:[{{spack_arch}}] \
-&& printf "  view: /opt/view\n" >> /opt/spack-env/spack.yaml
+# Set up Spack environment
+RUN cd /opt/spack-env \
+&& sed -e 's;compilers:;compilers::;' \
+       -e 's;^ *flags: *{};    flags:\n      cflags: -O3\n      cxxflags: -O3\n      fflags: -O3;' \
+       /root/.spack/linux/compilers.yaml > compilers.yaml \
+&& sed -i '/^spack:/a\  include: [compilers.yaml]' spack.yaml \
+&& spack -e . config add config:install_tree:/opt/software \
+&& spack -e . config add concretizer:unify:true \
+&& spack -e . config add concretizer:reuse:true \
+&& spack -e . config add packages:all:target:[{{spack_arch}}] \
+&& spack -e . env view enable /opt/view
 
 # Install packages, clean afterward, finally strip binaries
 RUN cd /opt/spack-env \
 && fingerprint="$(spack gpg trust {{spack_key_file}} 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\1/p")" \
-&& spack mirror add seqera-spack {{spack_cache_bucket}} \
-&& spack mirror add binary_mirror  https://binaries.spack.io/releases/v0.20 \
+&& spack -e . mirror add seqera-spack {{spack_cache_bucket}} \
+&& spack -e . mirror add binary_mirror  https://binaries.spack.io/releases/v0.20 \
 && spack buildcache keys --install --trust \
 && spack -e . concretize -f \
-&& spack --env . install \
+&& spack -e . install \
 && spack -e . buildcache push --allow-root --key "$fingerprint" {{spack_cache_bucket}} \
 && spack gc -y \
-&& ( find -L /opt/._view/* -type f -exec readlink -f '{}' \; | \
+&& ( ( find -L /opt/._view/* -type f -exec readlink -f '{}' \; | \
     xargs file -i | \
     grep 'charset=binary' | \
     grep 'x-executable\|x-archive\|x-sharedlib' | \
-    awk -F: '{print $1}' | xargs strip -s ) || true
+    awk -F: '{print $1}' | xargs strip -s ) || true )
 
 RUN cd /opt/spack-env && \
     spack env activate --sh -d . >> /opt/spack-env/z10_spack_environment.sh && \

--- a/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
@@ -31,7 +31,7 @@ RUN cd /opt/spack-env \
 # Install packages, clean afterward, finally strip binaries
 RUN cd /opt/spack-env \
 && fingerprint="$(spack gpg trust {{spack_key_file}} 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\1/p")" \
-&& spack -e . mirror add seqera-spack {{spack_cache_bucket}} \
+&& spack -e . mirror add seqera_spack {{spack_cache_bucket}} \
 && spack -e . mirror add binary_mirror  https://binaries.spack.io/releases/v0.20 \
 && spack buildcache keys --install --trust \
 && spack -e . concretize -f \

--- a/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
@@ -35,7 +35,7 @@ EOF
 
     # Install packages, clean afterward, finally strip binaries
     fingerprint="$(spack gpg trust {{spack_key_file}} 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\1/p")"
-    spack -e . mirror add seqera-spack {{spack_cache_bucket}}
+    spack -e . mirror add seqera_spack {{spack_cache_bucket}}
     spack -e . mirror add binary_mirror  https://binaries.spack.io/releases/v0.20
     spack buildcache keys --install --trust
     spack -e . concretize -f

--- a/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
@@ -20,27 +20,26 @@ EOF
     # import AWS environment
     . /aws-env.sh
 
-    # Copy and modify spack.yaml
-    sed -i -e 's;compilers:;compilers::;' \
-           -e 's;^ *flags: *{};    flags:\n      cflags: -O3\n      cxxflags: -O3\n      fflags: -O3;' \
-           /root/.spack/linux/compilers.yaml
-
     # Set up Spack environment
     export PATH=/opt/spack/bin:$PATH
     cd /opt/spack-env
-    spack config add config:install_tree:/opt/software
-    spack config add concretizer:unify:true
-    spack config add concretizer:reuse:true
-    spack config add packages:all:target:[{{spack_arch}}]
-    printf "  view: /opt/view\n" >> /opt/spack-env/spack.yaml
+    sed -e 's;compilers:;compilers::;' \
+        -e 's;^ *flags: *{};    flags:\n      cflags: -O3\n      cxxflags: -O3\n      fflags: -O3;' \
+        /root/.spack/linux/compilers.yaml > compilers.yaml
+    sed -i '/^spack:/a\  include: [compilers.yaml]' spack.yaml
+    spack -e . config add config:install_tree:/opt/software
+    spack -e . config add concretizer:unify:true
+    spack -e . config add concretizer:reuse:true
+    spack -e . config add packages:all:target:[{{spack_arch}}]
+    spack -e . env view enable /opt/view
 
     # Install packages, clean afterward, finally strip binaries
     fingerprint="$(spack gpg trust {{spack_key_file}} 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\1/p")"
-    spack mirror add seqera-spack {{spack_cache_bucket}}
-    spack mirror add binary_mirror  https://binaries.spack.io/releases/v0.20
+    spack -e . mirror add seqera-spack {{spack_cache_bucket}}
+    spack -e . mirror add binary_mirror  https://binaries.spack.io/releases/v0.20
     spack buildcache keys --install --trust
     spack -e . concretize -f
-    spack --env . install
+    spack -e . install
     spack -e . buildcache push --allow-root --key "$fingerprint" {{spack_cache_bucket}}
     spack gc -y
     ( find -L /opt/._view/* -type f -exec readlink -f '{}' \; | \

--- a/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceTest.groovy
@@ -278,7 +278,7 @@ class ContainerBuildServiceTest extends Specification {
         and:
         result.contains('FROM spack-builder:2.0 as builder')
         result.contains('spack config add packages:all:target:[x86_64]')
-        result.contains('spack mirror add seqera-spack s3://bucket/cache')
+        result.contains('spack mirror add seqera_spack s3://bucket/cache')
         result.contains('fingerprint="$(spack gpg trust /mnt/key 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\\1/p")"')
 
         cleanup:
@@ -309,7 +309,7 @@ class ContainerBuildServiceTest extends Specification {
                 'From: spack-builder:2.0\n' +
                 'Stage: build')
         result.contains('spack config add packages:all:target:[x86_64]')
-        result.contains('spack mirror add seqera-spack s3://bucket/cache')
+        result.contains('spack mirror add seqera_spack s3://bucket/cache')
         result.contains('fingerprint="$(spack gpg trust /mnt/key 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\\1/p")"')
         result.contains('/some/context/dir/spack.yaml /opt/spack-env/spack.yaml')
 


### PR DESCRIPTION
Hi @pditommaso, this PR updates the Spack templates for Docker/Singularity, so that all package build configurations are visible in `spack.yaml` and its sister yaml, `compilers.yaml`, in the `/opt/spack` directory. 

This change does not impact the way packages are compiled, but in my opinion is beneficial to users as it improved transparency of how the packages are built, hence improving provenance of the build from the software perspective.

@bebosudo FYI