### PR TITLE
Spack templates: flipped order of mirrors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ on:
 jobs:
   build:
     name: Build Wave
-    if: "github.event == 'push' || github.repository != github.event.pull_request.head.repo.full_name"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
@@ -30,8 +30,8 @@ RUN mkdir -p /opt/spack-env \
 # Install packages, clean afterward, finally strip binaries
 RUN cd /opt/spack-env \
 && fingerprint="$(spack gpg trust {{spack_key_file}} 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\1/p")" \
-&& spack mirror add seqera-spack {{spack_cache_bucket}} \
 && spack mirror add binary_mirror  https://binaries.spack.io/releases/v0.20 \
+&& spack mirror add seqera_spack {{spack_cache_bucket}} \
 && spack buildcache keys --install --trust \
 && spack -e . concretize -f \
 && spack --env . install \

--- a/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
@@ -36,8 +36,8 @@ EOF
 
     # Install packages, clean afterward, finally strip binaries
     fingerprint="$(spack gpg trust {{spack_key_file}} 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\1/p")"
-    spack mirror add seqera-spack {{spack_cache_bucket}}
     spack mirror add binary_mirror  https://binaries.spack.io/releases/v0.20
+    spack mirror add seqera_spack {{spack_cache_bucket}}
     spack buildcache keys --install --trust
     spack -e . concretize -f
     spack --env . install

--- a/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceTest.groovy
@@ -278,7 +278,7 @@ class ContainerBuildServiceTest extends Specification {
         and:
         result.contains('FROM spack-builder:2.0 as builder')
         result.contains('spack config add packages:all:target:[x86_64]')
-        result.contains('spack mirror add seqera-spack s3://bucket/cache')
+        result.contains('spack mirror add seqera_spack s3://bucket/cache')
         result.contains('fingerprint="$(spack gpg trust /mnt/key 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\\1/p")"')
 
         cleanup:
@@ -309,7 +309,7 @@ class ContainerBuildServiceTest extends Specification {
                 'From: spack-builder:2.0\n' +
                 'Stage: build')
         result.contains('spack config add packages:all:target:[x86_64]')
-        result.contains('spack mirror add seqera-spack s3://bucket/cache')
+        result.contains('spack mirror add seqera_spack s3://bucket/cache')
         result.contains('fingerprint="$(spack gpg trust /mnt/key 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\\1/p")"')
         result.contains('/some/context/dir/spack.yaml /opt/spack-env/spack.yaml')
 


### PR DESCRIPTION
I believe the Seqera binary mirror should take priority over the Spack team one in our builds; this PR actions this.

@bebosudo  FYI