### PR TITLE
build CI: removing conditional within job definition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ on:
 jobs:
   build:
     name: Build Wave
-    if: "github.event == 'push' || github.repository != github.event.pull_request.head.repo.full_name"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   build:
     name: Build Wave
+    if: "github.event == 'push' || github.repository != github.event.pull_request.head.repo.full_name"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Build Wave
-    if: "github.event == 'push' || github.repository != github.event.pull_request.head.repo.full_name"
+#    if: "github.event == 'push' || github.repository != github.event.pull_request.head.repo.full_name"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -33,6 +33,11 @@ jobs:
         java_version: [19]
 
     steps:
+      - name: Debug GH context
+        run: echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
       - name: Environment
         run: env | sort
 

--- a/src/main/groovy/io/seqera/wave/proxy/LoginResponse.groovy
+++ b/src/main/groovy/io/seqera/wave/proxy/LoginResponse.groovy
@@ -38,3 +38,4 @@ class LoginResponse {
 
 
 // TEST MARCO
+// TEST 22

--- a/src/main/groovy/io/seqera/wave/proxy/LoginResponse.groovy
+++ b/src/main/groovy/io/seqera/wave/proxy/LoginResponse.groovy
@@ -39,3 +39,4 @@ class LoginResponse {
 
 // TEST MARCO
 // TEST 22
+// test alberto

--- a/src/main/groovy/io/seqera/wave/proxy/LoginResponse.groovy
+++ b/src/main/groovy/io/seqera/wave/proxy/LoginResponse.groovy
@@ -35,3 +35,6 @@ class LoginResponse {
     Integer expires_in
     String issued_at
 }
+
+
+// TEST MARCO


### PR DESCRIPTION
[added]  This PR removes the following conditional for the `build` CI workflow:
```
if: "github.event == 'push' || github.repository != github.event.pull_request.head.repo.full_name"
```

Before this PR, when working on a PR within this repo (not a fork), the CI workflow was skipped, which is undesirable.

(@munishchouhan rationale added, thank you)