### PR TITLE
Update/spack yaml package configs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Wave CI
 on:
   push:
     branches:
-      - '*'
+      - '**'
       - '!refs/tags/.*'
     tags-ignore:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - mkdocs.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ on:
 jobs:
   build:
     name: Build Wave
-    if: "github.event == 'push' || github.repository != github.event.pull_request.head.repo.full_name"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   build:
     name: Build Wave
+    if: "github.event == 'push' || github.repository != github.event.pull_request.head.repo.full_name"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
@@ -25,7 +25,21 @@ RUN mkdir -p /opt/spack-env \
 && spack config add concretizer:unify:true \
 && spack config add concretizer:reuse:true \
 && spack config add packages:all:target:[{{spack_arch}}] \
+&& spack -e . config add packages:all:providers:blas:[openblas] \
+&& spack -e . config add packages:all:providers:mkl:[intel-oneapi-mkl] \
+&& spack -e . config add packages:binutils:variants:"+ld +gold +headers +libiberty ~nls" \
+&& spack -e . config add packages:elfutils:variants:"+bzip2 ~nls +xz" \
+&& spack -e . config add packages:hdf5:variants:"+fortran +hl +shared" \
+&& spack -e . config add packages:libunwind:variants:"+pic +xz" \
+&& spack -e . config add packages:mesa:variants:~llvm \
+&& spack -e . config add packages:mesa18:variants:~llvm \
+&& spack -e . config add packages:ncurses:variants:+termlib \
+&& spack -e . config add packages:openblas:variants:threads=openmp \
+&& spack -e . config add packages:tbb:require:intel-tbb \
+&& spack -e . config add packages:xz:variants:+pic \
 && printf "  view: /opt/view\n" >> /opt/spack-env/spack.yaml
+# Above, additional defaults for packages are from e4s/ and aws-isc/ in
+# https://github.com/spack/spack/blob/develop/share/spack/gitlab/cloud_pipelines/stacks/
 
 # Install packages, clean afterward, finally strip binaries
 RUN cd /opt/spack-env \

--- a/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
@@ -32,7 +32,21 @@ EOF
     spack config add concretizer:unify:true
     spack config add concretizer:reuse:true
     spack config add packages:all:target:[{{spack_arch}}]
+    spack -e . config add packages:all:providers:blas:[openblas]
+    spack -e . config add packages:all:providers:mkl:[intel-oneapi-mkl]
+    spack -e . config add packages:binutils:variants:"+ld +gold +headers +libiberty ~nls"
+    spack -e . config add packages:elfutils:variants:"+bzip2 ~nls +xz"
+    spack -e . config add packages:hdf5:variants:"+fortran +hl +shared"
+    spack -e . config add packages:libunwind:variants:"+pic +xz"
+    spack -e . config add packages:mesa:variants:~llvm
+    spack -e . config add packages:mesa18:variants:~llvm
+    spack -e . config add packages:ncurses:variants:+termlib
+    spack -e . config add packages:openblas:variants:threads=openmp
+    spack -e . config add packages:tbb:require:intel-tbb
+    spack -e . config add packages:xz:variants:+pic
     printf "  view: /opt/view\n" >> /opt/spack-env/spack.yaml
+    # Above, additional wise defaults for packages are from e4s/ and aws-isc/ in
+    # https://github.com/spack/spack/blob/develop/share/spack/gitlab/cloud_pipelines/stacks/
 
     # Install packages, clean afterward, finally strip binaries
     fingerprint="$(spack gpg trust {{spack_key_file}} 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\1/p")"

--- a/src/test/groovy/io/seqera/wave/controller/ContainerTokenControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ContainerTokenControllerTest.groovy
@@ -261,12 +261,12 @@ class ContainerTokenControllerTest extends Specification {
         submit = new SubmitContainerTokenRequest(containerFile: encode('FROM foo'), spackFile: encode('some::spack-recipe'), containerPlatform: 'arm64')
         build = controller.makeBuildRequest(submit, null, "")
         then:
-        build.id == 'b7d730d274d1e057'
+        build.id == '51fe266951c187f1'
         build.containerFile.endsWith('\nFROM foo')
         build.containerFile.startsWith('# Builder image\n')
         build.condaFile == null
         build.spackFile == 'some::spack-recipe'
-        build.targetImage == 'wave/build:b7d730d274d1e057'
+        build.targetImage == 'wave/build:51fe266951c187f1'
         build.workDir == Path.of('/some/wsp').resolve(build.id)
         build.platform == ContainerPlatform.of('arm64')
     }


### PR DESCRIPTION
This PR adds extra configuration in the Spack templates, providing good defaults for a number of common dependency packages.

These lines were taken from two key Spack stacks within the Spack repo, i.e.
* [e4s](https://github.com/spack/spack/blob/develop/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml)
* [aws-isc](https://github.com/spack/spack/blob/develop/share/spack/gitlab/cloud_pipelines/stacks/aws-isc/spack.yaml)

Good side: I believe these defaults will improve overall stability of package builds at scale, as suggested by their adoption by E4S and AWS teams within the Spack repo.

Bad side: the Spack yaml gets more verbose.