### PR TITLE
Changed wave.build.public to wave.build.public-repo

### DIFF
--- a/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
@@ -53,7 +53,7 @@ class BuildConfig {
     String defaultCacheRepository
 
     @Nullable
-    @Value('${wave.build.publicRepo}')
+    @Value('${wave.build.public-repo}')
     String defaultPublicRepository
 
     /**

--- a/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
@@ -53,7 +53,7 @@ class BuildConfig {
     String defaultCacheRepository
 
     @Nullable
-    @Value('${wave.build.public}')
+    @Value('${wave.build.public.repo}')
     String defaultPublicRepository
 
     /**

--- a/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
@@ -53,7 +53,7 @@ class BuildConfig {
     String defaultCacheRepository
 
     @Nullable
-    @Value('${wave.build.public.repo}')
+    @Value('${wave.build.publicRepo}')
     String defaultPublicRepository
 
     /**


### PR DESCRIPTION
As discussed in https://github.com/seqeralabs/wave/pull/360#discussion_r1444497611
for clarity, changing the default public repo config property to wave.build.public.repo