### PR TITLE
build ci: accept slash in branch name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Wave CI
 on:
   push:
     branches:
-      - '*'
+      - '**'
       - '!refs/tags/.*'
     tags-ignore:
-      - '*'
+      - '**'
     paths-ignore:
       - 'docs/**'
       - mkdocs.yml


### PR DESCRIPTION
This PR fixes a CI problem, where CI workflows on push would be skipped if the branch contains slashes in its name, e.g. `update/feature`. 

@bebosudo (thank you!)  and I were able to identify the root cause of what were mysterious CI skips on push I was experiencing, which other people, for instance Munish, were not experiencing. They were indeed due to different habits in branch naming.

Reference Github doc page for single vs double asterisk in GH workflows: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
