### PR TITLE
Update Spack version to `develop` (signedoff commits)

### DIFF
--- a/src/main/groovy/io/seqera/wave/configuration/SpackConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/SpackConfig.groovy
@@ -61,7 +61,7 @@ class SpackConfig {
     /**
      * The container image used for Spack builds
      */
-    @Value('${wave.build.spack.builderImage:`spack/ubuntu-jammy:develop`}')
+    @Value('${wave.build.spack.builderImage:`cr.seqera.io/spack/wave/spack/ubuntu-jammy:develop`}')
     private String builderImage
 
     /**

--- a/src/main/groovy/io/seqera/wave/configuration/SpackConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/SpackConfig.groovy
@@ -67,7 +67,7 @@ class SpackConfig {
     /**
      * The container image used for Spack container
      */
-    @Value('${wave.build.spack.runnerImage:`ubuntu:22.04`}')
+    @Value('${wave.build.spack.runnerImage:`ubuntu:jammy`}')
     private String runnerImage
 
     String getCacheBucket() {

--- a/src/main/groovy/io/seqera/wave/configuration/SpackConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/SpackConfig.groovy
@@ -61,7 +61,7 @@ class SpackConfig {
     /**
      * The container image used for Spack builds
      */
-    @Value('${wave.build.spack.builderImage:`spack/ubuntu-jammy:v0.20.0`}')
+    @Value('${wave.build.spack.builderImage:`spack/ubuntu-jammy:develop`}')
     private String builderImage
 
     /**

--- a/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
@@ -31,7 +31,7 @@ RUN mkdir -p /opt/spack-env \
 RUN cd /opt/spack-env \
 && fingerprint="$(spack gpg trust {{spack_key_file}} 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\1/p")" \
 && spack mirror add seqera-spack {{spack_cache_bucket}} \
-&& spack mirror add binary_mirror  https://binaries.spack.io/releases/v0.20 \
+&& spack mirror add binary_mirror  https://binaries.spack.io/releases/develop \
 && spack buildcache keys --install --trust \
 && spack -e . concretize -f \
 && spack --env . install \

--- a/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
@@ -37,7 +37,7 @@ EOF
     # Install packages, clean afterward, finally strip binaries
     fingerprint="$(spack gpg trust {{spack_key_file}} 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\1/p")"
     spack mirror add seqera-spack {{spack_cache_bucket}}
-    spack mirror add binary_mirror  https://binaries.spack.io/releases/v0.20
+    spack mirror add binary_mirror  https://binaries.spack.io/releases/develop
     spack buildcache keys --install --trust
     spack -e . concretize -f
     spack --env . install

--- a/src/test/groovy/io/seqera/wave/controller/ContainerTokenControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ContainerTokenControllerTest.groovy
@@ -261,12 +261,12 @@ class ContainerTokenControllerTest extends Specification {
         submit = new SubmitContainerTokenRequest(containerFile: encode('FROM foo'), spackFile: encode('some::spack-recipe'), containerPlatform: 'arm64')
         build = controller.makeBuildRequest(submit, null, "")
         then:
-        build.id == 'b7d730d274d1e057'
+        build.id == 'ac5c7bb19d6c7227'
         build.containerFile.endsWith('\nFROM foo')
         build.containerFile.startsWith('# Builder image\n')
         build.condaFile == null
         build.spackFile == 'some::spack-recipe'
-        build.targetImage == 'wave/build:b7d730d274d1e057'
+        build.targetImage == 'wave/build:ac5c7bb19d6c7227'
         build.workDir == Path.of('/some/wsp').resolve(build.id)
         build.platform == ContainerPlatform.of('arm64')
     }

--- a/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceTest.groovy
@@ -274,7 +274,7 @@ class ContainerBuildServiceTest extends Specification {
         1* spack.getCacheBucket() >> 's3://bucket/cache'
         1* spack.getSecretMountPath() >> '/mnt/key'
         1* spack.getBuilderImage() >> 'spack-builder:2.0'
-        1* spack.getRunnerImage() >> 'ubuntu:22.04'
+        1* spack.getRunnerImage() >> 'ubuntu:jammy'
         and:
         result.contains('FROM spack-builder:2.0 as builder')
         result.contains('spack config add packages:all:target:[x86_64]')
@@ -303,7 +303,7 @@ class ContainerBuildServiceTest extends Specification {
         1* spack.getCacheBucket() >> 's3://bucket/cache'
         1* spack.getSecretMountPath() >> '/mnt/key'
         1* spack.getBuilderImage() >> 'spack-builder:2.0'
-        1* spack.getRunnerImage() >> 'ubuntu:22.04'
+        1* spack.getRunnerImage() >> 'ubuntu:jammy'
         and:
         result.contains('Bootstrap: docker\n' +
                 'From: spack-builder:2.0\n' +


### PR DESCRIPTION
Spack version in use for Wave is `default`, as per infrastructure design decision.

Identical to https://github.com/seqeralabs/wave/pull/354, but with signed-off commits.
