### PR TITLE
Add support for Spack target architecture - Wave

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -60,7 +60,8 @@ The endpoint returns the name of the container request made available by Wave.
 | `containerFile`                     | Dockerfile used for building a new container encoded in base64 (optional). When provided, the attribute `containerImage` should be omitted.                    |
 | `condaFile`                         | Conda environment file encoded as base64 string.                                                                                                               |
 | `spackFile`                         | Spack recipe file encoded as base64 string.                                                                                                                    |
-| `containerPlatform`                 | Target container architecture of the built container e.g. `linux/amd64` (optional). Currently only supporting amd64 and arm64.                                 |
+| `spackArch`                         | Target CPU architecture for Spack builds e.g. `x86_64_v3` (optional).                                                                                          |
+| `containerPlatform`                 | Target container platform of the built container e.g. `linux/amd64` (optional). Currently only supporting amd64 and arm64.                                     |
 | `buildRepository`                   | Container repository where container builds should be pushed e.g. `docker.io/user/my-image` (optional).                                                        |
 | `cacheRepository`                   | Container repository used to cache build layers `docker.io/user/my-cache` (optional).                                                                          |
 | `timestamp`                         | Request submission timestap using ISO-8601.                                                                                                                    |

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,7 +60,7 @@ The endpoint returns the name of the container request made available by Wave.
 | `containerFile`                     | Dockerfile used for building a new container encoded in base64 (optional). When provided, the attribute `containerImage` should be omitted.                    |
 | `condaFile`                         | Conda environment file encoded as base64 string.                                                                                                               |
 | `spackFile`                         | Spack recipe file encoded as base64 string.                                                                                                                    |
-| `spackArch`                         | Target CPU architecture for Spack builds e.g. `x86_64_v3` (optional).                                                                                          |
+| `spackTarget`                       | Target CPU architecture for Spack builds e.g. `x86_64_v3` (optional).                                                                                          |
 | `containerPlatform`                 | Target container platform of the built container e.g. `linux/amd64` (optional). Currently only supporting amd64 and arm64.                                     |
 | `buildRepository`                   | Container repository where container builds should be pushed e.g. `docker.io/user/my-image` (optional).                                                        |
 | `cacheRepository`                   | Container repository used to cache build layers `docker.io/user/my-cache` (optional).                                                                          |

--- a/src/main/groovy/io/seqera/wave/controller/ContainerTokenController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ContainerTokenController.groovy
@@ -192,7 +192,7 @@ class ContainerTokenController {
         final containerSpec = new String(req.containerFile.decodeBase64())
         final condaContent = req.condaFile ? new String(req.condaFile.decodeBase64()) : null as String
         final spackContent = req.spackFile ? new String(req.spackFile.decodeBase64()) : null as String
-        final spackArch = req.spackFile ? req.spackArch : null as String
+        final spackTarget = req.spackFile ? req.spackTarget : null as String
         final format = req.formatSingularity() ? SINGULARITY : DOCKER
         final platform = ContainerPlatform.of(req.containerPlatform)
         final build = req.buildRepository ?: (req.freeze && buildConfig.defaultPublicRepository ? buildConfig.defaultPublicRepository : buildConfig.defaultBuildRepository)
@@ -208,7 +208,7 @@ class ContainerTokenController {
                 build,
                 condaContent,
                 spackContent,
-                spackArch,
+                spackTarget,
                 format,
                 user,
                 containerConfig,

--- a/src/main/groovy/io/seqera/wave/controller/ContainerTokenController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ContainerTokenController.groovy
@@ -192,6 +192,7 @@ class ContainerTokenController {
         final containerSpec = new String(req.containerFile.decodeBase64())
         final condaContent = req.condaFile ? new String(req.condaFile.decodeBase64()) : null as String
         final spackContent = req.spackFile ? new String(req.spackFile.decodeBase64()) : null as String
+        final spackArch = req.spackFile ? req.spackArch : null as String
         final format = req.formatSingularity() ? SINGULARITY : DOCKER
         final platform = ContainerPlatform.of(req.containerPlatform)
         final build = req.buildRepository ?: (req.freeze && buildConfig.defaultPublicRepository ? buildConfig.defaultPublicRepository : buildConfig.defaultBuildRepository)
@@ -207,6 +208,7 @@ class ContainerTokenController {
                 build,
                 condaContent,
                 spackContent,
+                spackArch,
                 format,
                 user,
                 containerConfig,

--- a/src/main/groovy/io/seqera/wave/controller/ViewController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ViewController.groovy
@@ -81,7 +81,7 @@ class ViewController {
         binding.build_containerfile = result.dockerFile ?: '-'
         binding.build_condafile = result.condaFile
         binding.build_spackfile = result.spackFile
-        binding.build_spackarch = result.spackArch
+        binding.build_spacktarget = result.spackTarget
         binding.put('server_url', serverUrl)
         binding.scan_url = result.scanId && result.succeeded() ? "$serverUrl/view/scans/${result.scanId}" : null
         binding.scan_id = result.scanId

--- a/src/main/groovy/io/seqera/wave/controller/ViewController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ViewController.groovy
@@ -81,6 +81,7 @@ class ViewController {
         binding.build_containerfile = result.dockerFile ?: '-'
         binding.build_condafile = result.condaFile
         binding.build_spackfile = result.spackFile
+        binding.build_spackarch = result.spackArch
         binding.put('server_url', serverUrl)
         binding.scan_url = result.scanId && result.succeeded() ? "$serverUrl/view/scans/${result.scanId}" : null
         binding.scan_id = result.scanId

--- a/src/main/groovy/io/seqera/wave/service/builder/BuildRequest.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildRequest.groovy
@@ -62,9 +62,14 @@ class BuildRequest {
     final String condaFile
 
     /**
-     * The spock file recipe associated with this request
+     * The spack file recipe associated with this request
      */
     final String spackFile
+
+    /**
+     * Target architecture for Spack builds
+     */
+    final String spackArch
 
     /**
      * The build context work directory
@@ -146,13 +151,14 @@ class BuildRequest {
      */
     volatile boolean uncached
 
-    BuildRequest(String containerFile, Path workspace, String repo, String condaFile, String spackFile, BuildFormat format, User user, ContainerConfig containerConfig, BuildContext buildContext, ContainerPlatform platform, String configJson, String cacheRepo, String scanId, String ip, String offsetId) {
-        this.id = computeDigest(containerFile, condaFile, spackFile, platform, repo, buildContext)
+    BuildRequest(String containerFile, Path workspace, String repo, String condaFile, String spackFile, String spackArch, BuildFormat format, User user, ContainerConfig containerConfig, BuildContext buildContext, ContainerPlatform platform, String configJson, String cacheRepo, String scanId, String ip, String offsetId) {
+        this.id = computeDigest(containerFile, condaFile, spackFile, spackArch, platform, repo, buildContext)
         this.containerFile = containerFile
         this.containerConfig = containerConfig
         this.buildContext = buildContext
         this.condaFile = condaFile
         this.spackFile = spackFile
+        this.spackArch = spackArch
         this.targetImage = makeTarget(format, repo, id, condaFile, spackFile)
         this.format = format
         this.user = user
@@ -214,13 +220,14 @@ class BuildRequest {
         return tag ?: null
     }
 
-    static private String computeDigest(String containerFile, String condaFile, String spackFile, ContainerPlatform platform, String repository, BuildContext buildContext) {
+    static private String computeDigest(String containerFile, String condaFile, String spackFile, String spackArch, ContainerPlatform platform, String repository, BuildContext buildContext) {
         final attrs = new LinkedHashMap<String,String>(10)
         attrs.containerFile = containerFile
         attrs.condaFile = condaFile
         attrs.platform = platform?.toString()
         attrs.repository = repository
         if( spackFile ) attrs.spackFile = spackFile
+        if( spackFile && spackArch ) attrs.spackArch = spackArch
         if( buildContext ) attrs.buildContext = buildContext.tarDigest
         return RegHelper.sipHash(attrs)
     }
@@ -249,6 +256,10 @@ class BuildRequest {
 
     String getSpackFile() {
         return spackFile
+    }
+
+    String getSpackArch() {
+        return spackArch
     }
 
     Path getWorkDir() {

--- a/src/main/groovy/io/seqera/wave/service/builder/BuildRequest.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildRequest.groovy
@@ -69,7 +69,7 @@ class BuildRequest {
     /**
      * Target architecture for Spack builds
      */
-    final String spackArch
+    final String spackTarget
 
     /**
      * The build context work directory
@@ -151,14 +151,14 @@ class BuildRequest {
      */
     volatile boolean uncached
 
-    BuildRequest(String containerFile, Path workspace, String repo, String condaFile, String spackFile, String spackArch, BuildFormat format, User user, ContainerConfig containerConfig, BuildContext buildContext, ContainerPlatform platform, String configJson, String cacheRepo, String scanId, String ip, String offsetId) {
-        this.id = computeDigest(containerFile, condaFile, spackFile, spackArch, platform, repo, buildContext)
+    BuildRequest(String containerFile, Path workspace, String repo, String condaFile, String spackFile, String spackTarget, BuildFormat format, User user, ContainerConfig containerConfig, BuildContext buildContext, ContainerPlatform platform, String configJson, String cacheRepo, String scanId, String ip, String offsetId) {
+        this.id = computeDigest(containerFile, condaFile, spackFile, spackTarget, platform, repo, buildContext)
         this.containerFile = containerFile
         this.containerConfig = containerConfig
         this.buildContext = buildContext
         this.condaFile = condaFile
         this.spackFile = spackFile
-        this.spackArch = spackArch
+        this.spackTarget = spackTarget
         this.targetImage = makeTarget(format, repo, id, condaFile, spackFile)
         this.format = format
         this.user = user
@@ -220,14 +220,14 @@ class BuildRequest {
         return tag ?: null
     }
 
-    static private String computeDigest(String containerFile, String condaFile, String spackFile, String spackArch, ContainerPlatform platform, String repository, BuildContext buildContext) {
+    static private String computeDigest(String containerFile, String condaFile, String spackFile, String spackTarget, ContainerPlatform platform, String repository, BuildContext buildContext) {
         final attrs = new LinkedHashMap<String,String>(10)
         attrs.containerFile = containerFile
         attrs.condaFile = condaFile
         attrs.platform = platform?.toString()
         attrs.repository = repository
         if( spackFile ) attrs.spackFile = spackFile
-        if( spackFile && spackArch ) attrs.spackArch = spackArch
+        if( spackFile && spackTarget ) attrs.spackTarget = spackTarget
         if( buildContext ) attrs.buildContext = buildContext.tarDigest
         return RegHelper.sipHash(attrs)
     }
@@ -258,8 +258,8 @@ class BuildRequest {
         return spackFile
     }
 
-    String getSpackArch() {
-        return spackArch
+    String getSpackTarget() {
+        return spackTarget
     }
 
     Path getWorkDir() {

--- a/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
@@ -143,7 +143,7 @@ class ContainerBuildServiceImpl implements ContainerBuildService {
             final binding = new HashMap(2)
             binding.spack_builder_image = config.builderImage
             binding.spack_runner_image = config.runnerImage
-            binding.spack_arch = req.getSpackArch()
+            binding.spack_arch = req.getSpackTarget()
             binding.spack_cache_bucket = config.cacheBucket
             binding.spack_key_file = config.secretMountPath
             return new TemplateRenderer().render(containerFile, binding)

--- a/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
@@ -143,7 +143,7 @@ class ContainerBuildServiceImpl implements ContainerBuildService {
             final binding = new HashMap(2)
             binding.spack_builder_image = config.builderImage
             binding.spack_runner_image = config.runnerImage
-            binding.spack_arch = req.getSpackTarget()
+            binding.spack_target = req.getSpackTarget()
             binding.spack_cache_bucket = config.cacheBucket
             binding.spack_key_file = config.secretMountPath
             return new TemplateRenderer().render(containerFile, binding)

--- a/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
@@ -143,7 +143,7 @@ class ContainerBuildServiceImpl implements ContainerBuildService {
             final binding = new HashMap(2)
             binding.spack_builder_image = config.builderImage
             binding.spack_runner_image = config.runnerImage
-            binding.spack_arch = SpackHelper.toSpackArch(req.getPlatform())
+            binding.spack_arch = req.getSpackArch()
             binding.spack_cache_bucket = config.cacheBucket
             binding.spack_key_file = config.secretMountPath
             return new TemplateRenderer().render(containerFile, binding)

--- a/src/main/groovy/io/seqera/wave/service/mail/impl/MailServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/mail/impl/MailServiceImpl.groovy
@@ -98,7 +98,7 @@ class MailServiceImpl implements MailService {
         binding.build_containerfile = req.containerFile ?: '-'
         binding.build_condafile = req.condaFile
         binding.build_spackfile = req.spackFile
-        binding.build_spackarch = req.spackArch
+        binding.build_spacktarget = req.spackTarget
         binding.put('build_log_data', result.logs)
         binding.build_url = "$serverUrl/view/builds/${result.id}"
         binding.scan_url = req.scanId && result.succeeded() ? "$serverUrl/view/scans/${req.scanId}" : null

--- a/src/main/groovy/io/seqera/wave/service/mail/impl/MailServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/mail/impl/MailServiceImpl.groovy
@@ -98,6 +98,7 @@ class MailServiceImpl implements MailService {
         binding.build_containerfile = req.containerFile ?: '-'
         binding.build_condafile = req.condaFile
         binding.build_spackfile = req.spackFile
+        binding.build_spackarch = req.spackArch
         binding.put('build_log_data', result.logs)
         binding.build_url = "$serverUrl/view/builds/${result.id}"
         binding.scan_url = req.scanId && result.succeeded() ? "$serverUrl/view/scans/${req.scanId}" : null

--- a/src/main/groovy/io/seqera/wave/service/persistence/WaveBuildRecord.groovy
+++ b/src/main/groovy/io/seqera/wave/service/persistence/WaveBuildRecord.groovy
@@ -42,7 +42,7 @@ class WaveBuildRecord {
     String dockerFile
     String condaFile
     String spackFile
-    String spackArch
+    String spackTarget
     String targetImage
     String userName
     String userEmail
@@ -66,7 +66,7 @@ class WaveBuildRecord {
                 dockerFile: event.request.containerFile,
                 condaFile: event.request.condaFile,
                 spackFile: event.request.spackFile,
-                spackArch: event.request.spackArch,
+                spackTarget: event.request.spackTarget,
                 targetImage: event.request.targetImage,
                 userName: event.request.user?.userName,
                 userEmail: event.request.user?.email,

--- a/src/main/groovy/io/seqera/wave/service/persistence/WaveBuildRecord.groovy
+++ b/src/main/groovy/io/seqera/wave/service/persistence/WaveBuildRecord.groovy
@@ -42,6 +42,7 @@ class WaveBuildRecord {
     String dockerFile
     String condaFile
     String spackFile
+    String spackArch
     String targetImage
     String userName
     String userEmail
@@ -65,6 +66,7 @@ class WaveBuildRecord {
                 dockerFile: event.request.containerFile,
                 condaFile: event.request.condaFile,
                 spackFile: event.request.spackFile,
+                spackArch: event.request.spackArch,
                 targetImage: event.request.targetImage,
                 userName: event.request.user?.userName,
                 userEmail: event.request.user?.email,

--- a/src/main/groovy/io/seqera/wave/util/SpackHelper.groovy
+++ b/src/main/groovy/io/seqera/wave/util/SpackHelper.groovy
@@ -51,15 +51,4 @@ class SpackHelper {
             throw new IllegalStateException("Unexpected build format: $buildFormat")
     }
 
-    static String toSpackArch(ContainerPlatform platform) {
-        if( !platform )
-            throw new IllegalArgumentException("Missing container platform argument")
-        final value = platform.toString()
-        if( value=='linux/amd64' )
-            return 'x86_64'
-        if( value=='linux/arm64' )
-            return 'aarch64'
-        throw new IllegalArgumentException("Unable to map container platform '${platform}' to Spack architecture")
-    }
-
 }

--- a/src/main/resources/io/seqera/wave/build-notification.html
+++ b/src/main/resources/io/seqera/wave/build-notification.html
@@ -89,6 +89,8 @@
     <% } %>
 
     <% if (build_spackfile) { %>
+    <h3>Spack target architecture</h3>
+    <pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">${build_spackarch}</pre>
     <h3>Spack file</h3>
     <pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">${build_spackfile}</pre>
     <% } %>

--- a/src/main/resources/io/seqera/wave/build-notification.html
+++ b/src/main/resources/io/seqera/wave/build-notification.html
@@ -90,7 +90,7 @@
 
     <% if (build_spackfile) { %>
     <h3>Spack target architecture</h3>
-    <pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">${build_spackarch}</pre>
+    <pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">${build_spacktarget}</pre>
     <h3>Spack file</h3>
     <pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">${build_spackfile}</pre>
     <% } %>

--- a/src/main/resources/io/seqera/wave/build-view.hbs
+++ b/src/main/resources/io/seqera/wave/build-view.hbs
@@ -87,6 +87,8 @@
     {{/if}}
 
     {{#if build_spackfile}}
+    <h3>Spack target architecture</h3>
+    <pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">${build_spackarch}</pre>
     <h3>Spack file</h3>
     <pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">{{build_spackfile}}</pre>
     {{/if}}

--- a/src/main/resources/io/seqera/wave/build-view.hbs
+++ b/src/main/resources/io/seqera/wave/build-view.hbs
@@ -88,7 +88,7 @@
 
     {{#if build_spackfile}}
     <h3>Spack target architecture</h3>
-    <pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">${build_spackarch}</pre>
+    <pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">${build_spacktarget}</pre>
     <h3>Spack file</h3>
     <pre style="white-space: pre-wrap; overflow: visible; background-color: #ededed; padding: 15px; border-radius: 4px; margin-bottom:30px;">{{build_spackfile}}</pre>
     {{/if}}

--- a/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-dockerfile.txt
@@ -24,7 +24,7 @@ RUN mkdir -p /opt/spack-env \
 && spack config add config:install_tree:/opt/software \
 && spack config add concretizer:unify:true \
 && spack config add concretizer:reuse:true \
-&& spack config add packages:all:target:[{{spack_arch}}] \
+&& spack config add packages:all:target:[{{spack_target}}] \
 && printf "  view: /opt/view\n" >> /opt/spack-env/spack.yaml
 
 # Install packages, clean afterward, finally strip binaries

--- a/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
+++ b/src/main/resources/io/seqera/wave/spack/spack-builder-singularityfile.txt
@@ -31,7 +31,7 @@ EOF
     spack config add config:install_tree:/opt/software
     spack config add concretizer:unify:true
     spack config add concretizer:reuse:true
-    spack config add packages:all:target:[{{spack_arch}}]
+    spack config add packages:all:target:[{{spack_target}}]
     printf "  view: /opt/view\n" >> /opt/spack-env/spack.yaml
 
     # Install packages, clean afterward, finally strip binaries

--- a/src/test/groovy/io/seqera/wave/controller/ContainerBuildControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ContainerBuildControllerTest.groovy
@@ -70,6 +70,7 @@ class ContainerBuildControllerTest extends Specification {
                 "buildrepo",
                 'conda::recipe',
                 'some-spack-recipe',
+                'zen3',
                 BuildFormat.DOCKER,
                 null,
                 null,

--- a/src/test/groovy/io/seqera/wave/controller/ContainerTokenControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ContainerTokenControllerTest.groovy
@@ -258,16 +258,16 @@ class ContainerTokenControllerTest extends Specification {
         build.platform == ContainerPlatform.of('arm64')
 
         when:
-        submit = new SubmitContainerTokenRequest(containerFile: encode('FROM foo'), spackFile: encode('some::spack-recipe'), spackArch: 'neoverse_v1', containerPlatform: 'arm64')
+        submit = new SubmitContainerTokenRequest(containerFile: encode('FROM foo'), spackFile: encode('some::spack-recipe'), spackTarget: 'neoverse_v1', containerPlatform: 'arm64')
         build = controller.makeBuildRequest(submit, null, "")
         then:
-        build.id == '058696cf7b89f4a3'
+        build.id == '55f13a399562dfa9'
         build.containerFile.endsWith('\nFROM foo')
         build.containerFile.startsWith('# Builder image\n')
         build.condaFile == null
         build.spackFile == 'some::spack-recipe'
-        build.spackArch == 'neoverse_v1'
-        build.targetImage == 'wave/build:058696cf7b89f4a3'
+        build.spackTarget == 'neoverse_v1'
+        build.targetImage == 'wave/build:55f13a399562dfa9'
         build.workDir == Path.of('/some/wsp').resolve(build.id)
         build.platform == ContainerPlatform.of('arm64')
     }

--- a/src/test/groovy/io/seqera/wave/controller/ContainerTokenControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ContainerTokenControllerTest.groovy
@@ -258,15 +258,16 @@ class ContainerTokenControllerTest extends Specification {
         build.platform == ContainerPlatform.of('arm64')
 
         when:
-        submit = new SubmitContainerTokenRequest(containerFile: encode('FROM foo'), spackFile: encode('some::spack-recipe'), containerPlatform: 'arm64')
+        submit = new SubmitContainerTokenRequest(containerFile: encode('FROM foo'), spackFile: encode('some::spack-recipe'), spackArch: 'neoverse_v1', containerPlatform: 'arm64')
         build = controller.makeBuildRequest(submit, null, "")
         then:
-        build.id == 'b7d730d274d1e057'
+        build.id == '058696cf7b89f4a3'
         build.containerFile.endsWith('\nFROM foo')
         build.containerFile.startsWith('# Builder image\n')
         build.condaFile == null
         build.spackFile == 'some::spack-recipe'
-        build.targetImage == 'wave/build:b7d730d274d1e057'
+        build.spackArch == 'neoverse_v1'
+        build.targetImage == 'wave/build:058696cf7b89f4a3'
         build.workDir == Path.of('/some/wsp').resolve(build.id)
         build.platform == ContainerPlatform.of('arm64')
     }

--- a/src/test/groovy/io/seqera/wave/controller/ViewControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ViewControllerTest.groovy
@@ -71,6 +71,7 @@ class ViewControllerTest extends Specification {
                 dockerFile: 'FROM foo',
                 condaFile: 'conda::foo',
                 spackFile: 'some-spack-recipe',
+                spackArch: 'zen3',
                 targetImage: 'docker.io/some:image',
                 userName: 'paolo',
                 userEmail: 'paolo@seqera.io',
@@ -97,6 +98,7 @@ class ViewControllerTest extends Specification {
         binding.build_containerfile == 'FROM foo'
         binding.build_condafile == 'conda::foo'
         binding.build_spackfile == 'some-spack-recipe'
+        binding.build_spackarch == 'zen3'
         binding.build_format == 'Docker'
         binding.build_log_data == 'log content'
         binding.build_log_truncated == false
@@ -130,6 +132,7 @@ class ViewControllerTest extends Specification {
         and:
         !response.body().contains('Conda file')
         !response.body().contains('Spack file')
+        !response.body().contains('Spack target architecture')
     }
 
     def 'should render a build page with conda file' () {
@@ -161,13 +164,15 @@ class ViewControllerTest extends Specification {
         response.body().contains('conda::foo')
         and:
         !response.body().contains('Spack file')
+        !response.body().contains('Spack target architecture')
     }
 
     def 'should render a build page with spack file' () {
         given:
         def record1 = new WaveBuildRecord(
                 buildId: 'test',
-                spackFile: 'foo/conda/recipe',
+                spackFile: 'foo/spack/recipe',
+                spackArch: 'zen3',
                 targetImage: 'test',
                 userName: 'test',
                 userEmail: 'test',
@@ -191,7 +196,8 @@ class ViewControllerTest extends Specification {
         !response.body().contains('Conda file')
         and:
         response.body().contains('Spack file')
-        response.body().contains('foo/conda/recipe')
+        response.body().contains('Spack target architecture')
+        response.body().contains('foo/spack/recipe')
     }
 
     def 'should render container view page' () {

--- a/src/test/groovy/io/seqera/wave/controller/ViewControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ViewControllerTest.groovy
@@ -71,7 +71,7 @@ class ViewControllerTest extends Specification {
                 dockerFile: 'FROM foo',
                 condaFile: 'conda::foo',
                 spackFile: 'some-spack-recipe',
-                spackArch: 'zen3',
+                spackTarget: 'zen3',
                 targetImage: 'docker.io/some:image',
                 userName: 'paolo',
                 userEmail: 'paolo@seqera.io',
@@ -98,7 +98,7 @@ class ViewControllerTest extends Specification {
         binding.build_containerfile == 'FROM foo'
         binding.build_condafile == 'conda::foo'
         binding.build_spackfile == 'some-spack-recipe'
-        binding.build_spackarch == 'zen3'
+        binding.build_spacktarget == 'zen3'
         binding.build_format == 'Docker'
         binding.build_log_data == 'log content'
         binding.build_log_truncated == false
@@ -172,7 +172,7 @@ class ViewControllerTest extends Specification {
         def record1 = new WaveBuildRecord(
                 buildId: 'test',
                 spackFile: 'foo/spack/recipe',
-                spackArch: 'zen3',
+                spackTarget: 'zen3',
                 targetImage: 'test',
                 userName: 'test',
                 userEmail: 'test',

--- a/src/test/groovy/io/seqera/wave/ratelimit/BuildServiceRateLimitTest.groovy
+++ b/src/test/groovy/io/seqera/wave/ratelimit/BuildServiceRateLimitTest.groovy
@@ -71,7 +71,7 @@ class BuildServiceRateLimitTest extends Specification{
         RUN echo hi > hello.txt
         """.stripIndent()
         and:
-        def REQ = new BuildRequest(dockerfile, folder, buildRepo, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cacheRepo, null, "127.0.0.1", null)
+        def REQ = new BuildRequest(dockerfile, folder, buildRepo, null, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cacheRepo, null, "127.0.0.1", null)
 
         when:
         (0..configuration.build.authenticated.max).each {
@@ -93,7 +93,7 @@ class BuildServiceRateLimitTest extends Specification{
         RUN echo hi > hello.txt
         """.stripIndent()
         and:
-        def REQ = new BuildRequest(dockerfile, folder, buildRepo, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cacheRepo, null, "127.0.0.1", null)
+        def REQ = new BuildRequest(dockerfile, folder, buildRepo, null, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cacheRepo, null, "127.0.0.1", null)
 
         when:
         (0..configuration.build.anonymous.max).each {

--- a/src/test/groovy/io/seqera/wave/service/builder/BuildRequestTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/BuildRequestTest.groovy
@@ -54,6 +54,7 @@ class BuildRequestTest extends Specification {
                 BUILD_REPO,
                 null,
                 null,
+                null,
                 BuildFormat.DOCKER,
                 USER,
                 CONFIG,
@@ -76,6 +77,7 @@ class BuildRequestTest extends Specification {
         req.format == BuildFormat.DOCKER
         req.condaFile == null
         req.spackFile == null
+        req.spackArch == null
         req.platform == ContainerPlatform.of('amd64')
         req.configJson == '{auth}'
         req.scanId == SCAN_ID
@@ -99,6 +101,7 @@ class BuildRequestTest extends Specification {
                 BUILD_REPO,
                 CONDA_RECIPE,
                 null,
+                null,
                 BuildFormat.DOCKER,
                 USER,
                 CONFIG,
@@ -114,6 +117,7 @@ class BuildRequestTest extends Specification {
         req.targetImage == 'docker.io/wave:samtools-1.0--8026e3a63b5c863f'
         req.condaFile == CONDA_RECIPE
         req.spackFile == null
+        req.spackArch == null
         and:
         !req.isSpackBuild
 
@@ -122,6 +126,7 @@ class BuildRequestTest extends Specification {
             spack:
               specs: [bwa@0.7.15]
             '''
+        def SPACK_ARCH = 'zen3'
         and:
         when:
         req = new BuildRequest(
@@ -130,6 +135,7 @@ class BuildRequestTest extends Specification {
                 BUILD_REPO,
                 null,
                 SPACK_RECIPE,
+                SPACK_ARCH,
                 BuildFormat.DOCKER,
                 USER,
                 CONFIG,
@@ -141,9 +147,10 @@ class BuildRequestTest extends Specification {
                 IP_ADDR,
                 OFFSET)
         then:
-        req.id == '8726782b1d9bb8fb'
-        req.targetImage == 'docker.io/wave:bwa-0.7.15--8726782b1d9bb8fb'
+        req.id == '69319bfaa5818518'
+        req.targetImage == 'docker.io/wave:bwa-0.7.15--69319bfaa5818518'
         req.spackFile == SPACK_RECIPE
+        req.spackArch == SPACK_ARCH
         req.condaFile == null
         and:
         req.isSpackBuild
@@ -166,6 +173,7 @@ class BuildRequestTest extends Specification {
                 CONTENT,
                 PATH,
                 BUILD_REPO,
+                null,
                 null,
                 null,
                 BuildFormat.SINGULARITY,
@@ -206,13 +214,16 @@ class BuildRequestTest extends Specification {
         def repo = 'docker.io/wave'
         def cache = 'docker.io/cache'
         and:
-        def req1 = new BuildRequest('from foo', PATH, repo, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
-        def req2 = new BuildRequest('from foo', PATH, repo, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
-        def req3 = new BuildRequest('from bar', PATH, repo, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
-        def req4 = new BuildRequest('from bar', PATH, repo, 'salmon=1.2.3', null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
-        def req5 = new BuildRequest('from bar', PATH, repo, 'salmon=1.2.3', null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
-        def req6 = new BuildRequest('from bar', PATH, repo, 'salmon=1.2.5', null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
-        def req7 = new BuildRequest('from bar', PATH, repo, 'salmon=1.2.5', null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", "UTC+2")
+        def req1 = new BuildRequest('from foo', PATH, repo, null, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
+        def req2 = new BuildRequest('from foo', PATH, repo, null, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
+        def req3 = new BuildRequest('from bar', PATH, repo, null, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
+        def req4 = new BuildRequest('from bar', PATH, repo, 'salmon=1.2.3', null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
+        def req5 = new BuildRequest('from bar', PATH, repo, 'salmon=1.2.3', null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
+        def req6 = new BuildRequest('from bar', PATH, repo, 'salmon=1.2.5', null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
+        def req7 = new BuildRequest('from bar', PATH, repo, 'salmon=1.2.5', null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", "UTC+2")
+        def req8 = new BuildRequest('from bar', PATH, repo, null, 'salmon@1.2.5', null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
+        def req9 = new BuildRequest('from bar', PATH, repo, null, 'salmon@1.2.5', null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
+        def req10 = new BuildRequest('from bar', PATH, repo, null, 'salmon@1.2.5', 'zen3', BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
 
         expect:
         req1 == req2
@@ -224,6 +235,9 @@ class BuildRequestTest extends Specification {
         req1 != req5
         req1 != req6
         req1 != req7
+        and:
+        req8 == req9
+        req8 != req10
 
         and:
         req1.hashCode() == req2.hashCode()
@@ -238,6 +252,10 @@ class BuildRequestTest extends Specification {
         and:
         req1.offsetId == OffsetDateTime.now().offset.id
         req7.offsetId == 'UTC+2'
+
+        and:
+        req8.hashCode() == req9.hashCode()
+        req8.hashCode() != req10.hashCode()
     }
 
     def 'should make request target' () {

--- a/src/test/groovy/io/seqera/wave/service/builder/BuildRequestTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/BuildRequestTest.groovy
@@ -77,7 +77,7 @@ class BuildRequestTest extends Specification {
         req.format == BuildFormat.DOCKER
         req.condaFile == null
         req.spackFile == null
-        req.spackArch == null
+        req.spackTarget == null
         req.platform == ContainerPlatform.of('amd64')
         req.configJson == '{auth}'
         req.scanId == SCAN_ID
@@ -117,7 +117,7 @@ class BuildRequestTest extends Specification {
         req.targetImage == 'docker.io/wave:samtools-1.0--8026e3a63b5c863f'
         req.condaFile == CONDA_RECIPE
         req.spackFile == null
-        req.spackArch == null
+        req.spackTarget == null
         and:
         !req.isSpackBuild
 
@@ -147,10 +147,10 @@ class BuildRequestTest extends Specification {
                 IP_ADDR,
                 OFFSET)
         then:
-        req.id == '69319bfaa5818518'
-        req.targetImage == 'docker.io/wave:bwa-0.7.15--69319bfaa5818518'
+        req.id == '405a13bb5260e88e'
+        req.targetImage == 'docker.io/wave:bwa-0.7.15--405a13bb5260e88e'
         req.spackFile == SPACK_RECIPE
-        req.spackArch == SPACK_ARCH
+        req.spackTarget == SPACK_ARCH
         req.condaFile == null
         and:
         req.isSpackBuild

--- a/src/test/groovy/io/seqera/wave/service/builder/BuildStrategyTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/BuildStrategyTest.groovy
@@ -39,7 +39,7 @@ class BuildStrategyTest extends Specification {
         service.@buildConfig = new BuildConfig()
         and:
         def work = Path.of('/work/foo')
-        def REQ = new BuildRequest('from foo', work, 'quay.io/wave', null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
+        def REQ = new BuildRequest('from foo', work, 'quay.io/wave', null, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
 
         when:
         def cmd = service.launchCmd(REQ)
@@ -67,7 +67,7 @@ class BuildStrategyTest extends Specification {
         def build = Mock(BuildContext) {tarDigest >> '123'}
         and:
         def work = Path.of('/work/foo')
-        def REQ = new BuildRequest('from foo', work, 'quay.io/wave', null, null, BuildFormat.DOCKER, Mock(User), null, build, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
+        def REQ = new BuildRequest('from foo', work, 'quay.io/wave', null, null, null, BuildFormat.DOCKER, Mock(User), null, build, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
 
         when:
         def cmd = service.launchCmd(REQ)
@@ -93,7 +93,7 @@ class BuildStrategyTest extends Specification {
         def service = Spy(BuildStrategy)
         and:
         def work = Path.of('/work/foo')
-        def REQ = new BuildRequest('from foo', work, 'quay.io/wave', null, null, BuildFormat.SINGULARITY, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
+        def REQ = new BuildRequest('from foo', work, 'quay.io/wave', null, null, null, BuildFormat.SINGULARITY, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "", null)
 
         when:
         def cmd = service.launchCmd(REQ)

--- a/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceTest.groovy
@@ -76,7 +76,7 @@ class ContainerBuildServiceTest extends Specification {
         '''.stripIndent()
         and:
         def cfg = dockerAuthService.credentialsConfigJson(dockerFile, buildRepo, cacheRepo, null, null,null,null)
-        def REQ = new BuildRequest(dockerFile, folder, buildRepo, null, null, BuildFormat.DOCKER,Mock(User), null, null, ContainerPlatform.of('amd64'), cfg, cacheRepo, null, "", null)
+        def REQ = new BuildRequest(dockerFile, folder, buildRepo, null, null, null, BuildFormat.DOCKER,Mock(User), null, null, ContainerPlatform.of('amd64'), cfg, cacheRepo, null, "", null)
 
         when:
         def result = service.launch(REQ)
@@ -107,7 +107,7 @@ class ContainerBuildServiceTest extends Specification {
         buildRepo = "docker.io/pditommaso/wave-tests"
         and:
         def cfg = dockerAuthService.credentialsConfigJson(dockerFile, buildRepo, null, null, null,null,null)
-        def REQ = new BuildRequest(dockerFile, folder, buildRepo, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),cfg, null, null, null, null)
+        def REQ = new BuildRequest(dockerFile, folder, buildRepo, null, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),cfg, null, null, null, null)
 
         when:
         def result = service.launch(REQ)
@@ -137,7 +137,7 @@ class ContainerBuildServiceTest extends Specification {
         and:
         buildRepo = "quay.io/pditommaso/wave-tests"
         def cfg = dockerAuthService.credentialsConfigJson(dockerFile, buildRepo, null, null, null, null, null)
-        def REQ = new BuildRequest(dockerFile, folder, buildRepo, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),cfg, null, null, "", null)
+        def REQ = new BuildRequest(dockerFile, folder, buildRepo, null, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),cfg, null, null, "", null)
 
         when:
         def result = service.launch(REQ)
@@ -167,7 +167,7 @@ class ContainerBuildServiceTest extends Specification {
         and:
         buildRepo = "seqeralabs.azurecr.io/wave-tests"
         def cfg = dockerAuthService.credentialsConfigJson(dockerFile, buildRepo, null, null, null, null, null)
-        def REQ = new BuildRequest(dockerFile, folder, buildRepo, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),cfg, null, null, "", null)
+        def REQ = new BuildRequest(dockerFile, folder, buildRepo, null, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),cfg, null, null, "", null)
 
         when:
         def result = service.launch(REQ)
@@ -207,9 +207,10 @@ class ContainerBuildServiceTest extends Specification {
                   specs: [bwa@0.7.15, salmon@1.1.1]
                   concretizer: {unify: true, reuse: true}
                 '''
+        def spackArch = 'zen3'
         and:
         def spackConfig = new SpackConfig(cacheBucket: 's3://bucket/cache', secretMountPath: '/mnt/secret')
-        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', condaFile, spackFile, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'), cfg, null, null, "", null)
+        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', condaFile, spackFile, spackArch, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'), cfg, null, null, "", null)
         and:
         def store = Mock(BuildStore)
         def strategy = Mock(BuildStrategy)
@@ -240,7 +241,7 @@ class ContainerBuildServiceTest extends Specification {
         def cacheRepo = buildConfig.defaultCacheRepository
         and:
         def dockerFile = 'FROM something; {{foo}}'
-        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'), null, null, null, "", null)
+        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', null, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'), null, null, null, "", null)
         and:
         def spack = Mock(SpackConfig)
 
@@ -264,7 +265,8 @@ class ContainerBuildServiceTest extends Specification {
         and:
         def dockerFile = SpackHelper.builderDockerTemplate()
         def spackFile = 'some spack packages'
-        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', null, spackFile, BuildFormat.DOCKER, Mock(User),null, null,  ContainerPlatform.of('amd64'), null, null, null, "", null)
+        def spackArch = 'zen3'
+        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', null, spackFile, spackArch, BuildFormat.DOCKER, Mock(User),null, null,  ContainerPlatform.of('amd64'), null, null, null, "", null)
         and:
         def spack = Mock(SpackConfig)
 
@@ -277,7 +279,7 @@ class ContainerBuildServiceTest extends Specification {
         1* spack.getRunnerImage() >> 'ubuntu:22.04'
         and:
         result.contains('FROM spack-builder:2.0 as builder')
-        result.contains('spack config add packages:all:target:[x86_64]')
+        result.contains('spack config add packages:all:target:[zen3]')
         result.contains('spack mirror add seqera-spack s3://bucket/cache')
         result.contains('fingerprint="$(spack gpg trust /mnt/key 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\\1/p")"')
 
@@ -293,7 +295,8 @@ class ContainerBuildServiceTest extends Specification {
         def context = Path.of('/some/context/dir')
         def dockerFile = SpackHelper.builderSingularityTemplate()
         def spackFile = 'some spack packages'
-        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', null, spackFile, BuildFormat.SINGULARITY, Mock(User),null, null,  ContainerPlatform.of('amd64'), null, null, null, "", null)
+        def spackArch = 'zen3'
+        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', null, spackFile, spackArch, BuildFormat.SINGULARITY, Mock(User),null, null,  ContainerPlatform.of('amd64'), null, null, null, "", null)
         and:
         def spack = Mock(SpackConfig)
 
@@ -308,7 +311,7 @@ class ContainerBuildServiceTest extends Specification {
         result.contains('Bootstrap: docker\n' +
                 'From: spack-builder:2.0\n' +
                 'Stage: build')
-        result.contains('spack config add packages:all:target:[x86_64]')
+        result.contains('spack config add packages:all:target:[zen3]')
         result.contains('spack mirror add seqera-spack s3://bucket/cache')
         result.contains('fingerprint="$(spack gpg trust /mnt/key 2>&1 | tee /dev/stderr | sed -nr "s/^gpg: key ([0-9A-F]{16}): secret key imported$/\\1/p")"')
         result.contains('/some/context/dir/spack.yaml /opt/spack-env/spack.yaml')
@@ -328,7 +331,7 @@ class ContainerBuildServiceTest extends Specification {
         '''.stripIndent()
         and:
         def builder = new ContainerBuildServiceImpl()
-        def REQ = new BuildRequest(containerFile, folder, 'box:latest', null, null, BuildFormat.SINGULARITY, Mock(User),null, null,  ContainerPlatform.of('amd64'), null, null, null, "", null)
+        def REQ = new BuildRequest(containerFile, folder, 'box:latest', null, null, null, BuildFormat.SINGULARITY, Mock(User),null, null,  ContainerPlatform.of('amd64'), null, null, null, "", null)
 
         when:
         def result = builder.containerFile0(REQ, Path.of('/some/context/'), null)
@@ -363,7 +366,7 @@ class ContainerBuildServiceTest extends Specification {
         buildRepo = "docker.io/pditommaso/wave-tests"
         and:
         def cfg = dockerAuthService.credentialsConfigJson(dockerFile, buildRepo, null, null, null,null,null)
-        def REQ = new BuildRequest(dockerFile, context, buildRepo, null, null, BuildFormat.DOCKER, Mock(User), containerConfig, null, ContainerPlatform.of('amd64'),cfg, null, null, null, null)
+        def REQ = new BuildRequest(dockerFile, context, buildRepo, null, null, null, BuildFormat.DOCKER, Mock(User), containerConfig, null, ContainerPlatform.of('amd64'),cfg, null, null, null, null)
 
         when:
         def result = service.launch(REQ)
@@ -433,7 +436,7 @@ class ContainerBuildServiceTest extends Specification {
         server.createContext("/", handler);
         server.start()
         and:
-        def req = new BuildRequest('from foo', Path.of('/wsp'), 'quay.io/org/name', null, null, BuildFormat.DOCKER, Mock(User), config, null, ContainerPlatform.of('amd64'),'{auth}', null, null, "127.0.0.1", null)
+        def req = new BuildRequest('from foo', Path.of('/wsp'), 'quay.io/org/name', null, null, null, BuildFormat.DOCKER, Mock(User), config, null, ContainerPlatform.of('amd64'),'{auth}', null, null, "127.0.0.1", null)
         and:
         def service = new ContainerBuildServiceImpl(httpClientConfig: httpClientConfig)
 

--- a/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceTest.groovy
@@ -207,10 +207,10 @@ class ContainerBuildServiceTest extends Specification {
                   specs: [bwa@0.7.15, salmon@1.1.1]
                   concretizer: {unify: true, reuse: true}
                 '''
-        def spackArch = 'zen3'
+        def spackTarget = 'zen3'
         and:
         def spackConfig = new SpackConfig(cacheBucket: 's3://bucket/cache', secretMountPath: '/mnt/secret')
-        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', condaFile, spackFile, spackArch, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'), cfg, null, null, "", null)
+        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', condaFile, spackFile, spackTarget, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'), cfg, null, null, "", null)
         and:
         def store = Mock(BuildStore)
         def strategy = Mock(BuildStrategy)
@@ -265,8 +265,8 @@ class ContainerBuildServiceTest extends Specification {
         and:
         def dockerFile = SpackHelper.builderDockerTemplate()
         def spackFile = 'some spack packages'
-        def spackArch = 'zen3'
-        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', null, spackFile, spackArch, BuildFormat.DOCKER, Mock(User),null, null,  ContainerPlatform.of('amd64'), null, null, null, "", null)
+        def spackTarget = 'zen3'
+        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', null, spackFile, spackTarget, BuildFormat.DOCKER, Mock(User),null, null,  ContainerPlatform.of('amd64'), null, null, null, "", null)
         and:
         def spack = Mock(SpackConfig)
 
@@ -295,8 +295,8 @@ class ContainerBuildServiceTest extends Specification {
         def context = Path.of('/some/context/dir')
         def dockerFile = SpackHelper.builderSingularityTemplate()
         def spackFile = 'some spack packages'
-        def spackArch = 'zen3'
-        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', null, spackFile, spackArch, BuildFormat.SINGULARITY, Mock(User),null, null,  ContainerPlatform.of('amd64'), null, null, null, "", null)
+        def spackTarget = 'zen3'
+        def REQ = new BuildRequest(dockerFile, folder, 'box:latest', null, spackFile, spackTarget, BuildFormat.SINGULARITY, Mock(User),null, null,  ContainerPlatform.of('amd64'), null, null, null, "", null)
         and:
         def spack = Mock(SpackConfig)
 

--- a/src/test/groovy/io/seqera/wave/service/builder/DockerBuildStrategyTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/DockerBuildStrategyTest.groovy
@@ -88,7 +88,7 @@ class DockerBuildStrategyTest extends Specification {
         def work = Path.of('/work/foo')
         def creds = Path.of('/work/creds.json')
         def cache = 'reg.io/wave/build/cache'
-        def req = new BuildRequest('from foo', work, 'repo', null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "1.2.3.4", null)
+        def req = new BuildRequest('from foo', work, 'repo', null, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "1.2.3.4", null)
         when:
         def cmd = service.buildCmd(req, creds)
         then:
@@ -117,7 +117,7 @@ class DockerBuildStrategyTest extends Specification {
         and:
         def work = Path.of('/work/foo')
         def cache    = 'reg.io/wave/build/cache'
-        def req = new BuildRequest('from foo', work, 'repo', null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "1.2.3.4", null)
+        def req = new BuildRequest('from foo', work, 'repo', null, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cache, null, "1.2.3.4", null)
         when:
         def cmd = service.launchCmd(req)
         then:
@@ -147,7 +147,7 @@ class DockerBuildStrategyTest extends Specification {
         def work = Path.of('/work/foo')
         def creds = Path.of('/work/creds.json')
         def spackFile = '/work/spack.yaml'
-        def req = new BuildRequest('from foo', work, 'repo', null, spackFile, BuildFormat.SINGULARITY, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', null, null, "1.2.3.4", null)
+        def req = new BuildRequest('from foo', work, 'repo', null, spackFile, null, BuildFormat.SINGULARITY, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', null, null, "1.2.3.4", null)
         when:
         def cmd = service.buildCmd(req, creds)
         then:
@@ -184,7 +184,7 @@ class DockerBuildStrategyTest extends Specification {
         def work = Path.of('/work/foo')
         def creds = Path.of('/work/creds.json')
         def spackFile = '/work/spack.yaml'
-        def req = new BuildRequest('from foo', work, 'repo', null, spackFile, BuildFormat.SINGULARITY, Mock(User), null, null, ContainerPlatform.of('arm64'),'{auth}', null, null, "1.2.3.4", null)
+        def req = new BuildRequest('from foo', work, 'repo', null, spackFile, null, BuildFormat.SINGULARITY, Mock(User), null, null, ContainerPlatform.of('arm64'),'{auth}', null, null, "1.2.3.4", null)
         when:
         def cmd = service.buildCmd(req, creds)
         then:

--- a/src/test/groovy/io/seqera/wave/service/builder/FutureContainerBuildServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/FutureContainerBuildServiceTest.groovy
@@ -67,7 +67,7 @@ class FutureContainerBuildServiceTest extends Specification {
         RUN echo $EXIT_CODE > hello.txt
         """.stripIndent()
         and:
-        def REQ = new BuildRequest(dockerfile, folder, buildRepo, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cacheRepo, null, "", null)
+        def REQ = new BuildRequest(dockerfile, folder, buildRepo, null, null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', cacheRepo, null, "", null)
 
         when:
         exitCode = EXIT_CODE

--- a/src/test/groovy/io/seqera/wave/service/builder/KubeBuildStrategyTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/KubeBuildStrategyTest.groovy
@@ -64,7 +64,7 @@ class KubeBuildStrategyTest extends Specification {
         def cache = 'docker.io/cache'
 
         when:
-        def req = new BuildRequest('from foo', PATH, repo, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{}', cache, null, "", null)
+        def req = new BuildRequest('from foo', PATH, repo, null, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{}', cache, null, "", null)
         Files.createDirectories(req.workDir)
 
         def resp = strategy.build(req)
@@ -74,7 +74,7 @@ class KubeBuildStrategyTest extends Specification {
         1 * k8sService.buildContainer(_, _, _, _, _, _, [service:'wave-build']) >> null
 
         when:
-        def req2 = new BuildRequest('from foo', PATH, repo, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('arm64'),'{}', cache, null, "", null)
+        def req2 = new BuildRequest('from foo', PATH, repo, null, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('arm64'),'{}', cache, null, "", null)
         Files.createDirectories(req2.workDir)
 
         def resp2 = strategy.build(req2)
@@ -93,19 +93,19 @@ class KubeBuildStrategyTest extends Specification {
         def cache = 'docker.io/cache'
 
         when:'getting docker with amd64 arch in build request'
-        def req = new BuildRequest('from foo', PATH, repo, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{}', cache, null, "", null)
+        def req = new BuildRequest('from foo', PATH, repo, null, null, null, BuildFormat.DOCKER, USER, null, null, ContainerPlatform.of('amd64'),'{}', cache, null, "", null)
 
         then: 'should return kaniko image'
         strategy.getBuildImage(req) == 'gcr.io/kaniko-project/executor:v1.19.2'
 
         when:'getting singularity with amd64 arch in build request'
-        req = new BuildRequest('from foo', PATH, repo, null, null, BuildFormat.SINGULARITY, USER, null, null, ContainerPlatform.of('amd64'),'{}', cache, null, "", null)
+        req = new BuildRequest('from foo', PATH, repo, null, null, null, BuildFormat.SINGULARITY, USER, null, null, ContainerPlatform.of('amd64'),'{}', cache, null, "", null)
 
         then:'should return singularity amd64 image'
         strategy.getBuildImage(req) == 'quay.io/singularity/singularity:v3.11.4-slim'
 
         when:'getting singularity with arm64 arch in build request'
-        req = new BuildRequest('from foo', PATH, repo, null, null, BuildFormat.SINGULARITY, USER, null, null, ContainerPlatform.of('arm64'),'{}', cache, null, "", null)
+        req = new BuildRequest('from foo', PATH, repo, null, null, null, BuildFormat.SINGULARITY, USER, null, null, ContainerPlatform.of('arm64'),'{}', cache, null, "", null)
 
         then:'should return singularity arm64 image'
         strategy.getBuildImage(req) == 'quay.io/singularity/singularity:v3.11.4-slim-arm64'

--- a/src/test/groovy/io/seqera/wave/service/mail/MailServiceImplTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/mail/MailServiceImplTest.groovy
@@ -51,7 +51,7 @@ class MailServiceImplTest extends Specification {
         1* request.getPlatform() >> ContainerPlatform.DEFAULT
         1* request.getCondaFile() >> null
         1* request.getSpackFile() >> null
-        1* request.getSpackArch() >> null
+        1* request.getSpackTarget() >> null
         and:
         mail.to == recipient
         mail.body.contains('from foo')
@@ -79,7 +79,7 @@ class MailServiceImplTest extends Specification {
         1* request.getTargetImage() >> 'wave/build:xyz'
         1* request.getPlatform() >> ContainerPlatform.DEFAULT
         1* request.getSpackFile() >> 'some-spack-recipe'
-        1* request.getSpackArch() >> 'zen3'
+        1* request.getSpackTarget() >> 'zen3'
         and:
         mail.to == recipient
         mail.body.contains('Spack file')

--- a/src/test/groovy/io/seqera/wave/service/mail/MailServiceImplTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/mail/MailServiceImplTest.groovy
@@ -51,12 +51,14 @@ class MailServiceImplTest extends Specification {
         1* request.getPlatform() >> ContainerPlatform.DEFAULT
         1* request.getCondaFile() >> null
         1* request.getSpackFile() >> null
+        1* request.getSpackArch() >> null
         and:
         mail.to == recipient
         mail.body.contains('from foo')
         and:
         !mail.body.contains('Conda file')
         !mail.body.contains('Spack file')
+        !mail.body.contains('Spack target architecture')
 
         // check it adds the Conda file content
         when:
@@ -76,11 +78,14 @@ class MailServiceImplTest extends Specification {
         then:
         1* request.getTargetImage() >> 'wave/build:xyz'
         1* request.getPlatform() >> ContainerPlatform.DEFAULT
-        1* request.getSpackFile() >> 'some-spac-recipe'
+        1* request.getSpackFile() >> 'some-spack-recipe'
+        1* request.getSpackArch() >> 'zen3'
         and:
         mail.to == recipient
         mail.body.contains('Spack file')
-        mail.body.contains('some-spac-recipe')
+        mail.body.contains('some-spack-recipe')
+        mail.body.contains('Spack target architecture')
+        mail.body.contains('zen3')
     }
 
 }

--- a/src/test/groovy/io/seqera/wave/service/persistence/WaveBuildRecordTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/persistence/WaveBuildRecordTest.groovy
@@ -44,6 +44,7 @@ class WaveBuildRecordTest extends Specification {
                 "buildrepo",
                 'conda::recipe',
                 'some-spack-recipe',
+                'zen3',
                 BuildFormat.DOCKER,
                 null,
                 null,

--- a/src/test/groovy/io/seqera/wave/service/persistence/impl/SurrealPersistenceServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/persistence/impl/SurrealPersistenceServiceTest.groovy
@@ -100,7 +100,7 @@ class SurrealPersistenceServiceTest extends Specification implements SurrealDBTe
         HttpClient httpClient = HttpClient.create(new URL(surrealDbURL))
         SurrealPersistenceService storage = applicationContext.getBean(SurrealPersistenceService)
         BuildRequest request = new BuildRequest(dockerFile,
-                Path.of("."), "buildrepo", condaFile, null, BuildFormat.DOCKER,null, null, null,
+                Path.of("."), "buildrepo", condaFile, null, null, BuildFormat.DOCKER,null, null, null,
                 ContainerPlatform.of('amd64'),'{auth}', null, null, "127.0.0.1", null)
         BuildResult result = new BuildResult(request.id, -1, "ok", Instant.now(), Duration.ofSeconds(3))
         BuildEvent event = new BuildEvent(request, result)
@@ -158,7 +158,7 @@ class SurrealPersistenceServiceTest extends Specification implements SurrealDBTe
         def storage = applicationContext.getBean(SurrealPersistenceService)
         storage.initializeDb()
         final service = applicationContext.getBean(SurrealPersistenceService)
-        BuildRequest request = new BuildRequest("test", Path.of("."), "test", "test", null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', "test", null, "127.0.0.1", null)
+        BuildRequest request = new BuildRequest("test", Path.of("."), "test", "test", null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', "test", null, "127.0.0.1", null)
         BuildResult result = new BuildResult(request.id, 0, "content", Instant.now(), Duration.ofSeconds(1))
         BuildEvent event = new BuildEvent(request, result)
 
@@ -183,7 +183,7 @@ class SurrealPersistenceServiceTest extends Specification implements SurrealDBTe
         given:
         surrealContainer.stop()
         final service = applicationContext.getBean(SurrealPersistenceService)
-        BuildRequest request = new BuildRequest("test", Path.of("."), "test", "test", null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', "test", null, "127.0.0.1", null)
+        BuildRequest request = new BuildRequest("test", Path.of("."), "test", "test", null, null, BuildFormat.DOCKER, Mock(User), null, null, ContainerPlatform.of('amd64'),'{auth}', "test", null, "127.0.0.1", null)
         BuildResult result = new BuildResult(request.id, 0, "content", Instant.now(), Duration.ofSeconds(1))
         BuildEvent event = new BuildEvent(request, result)
 
@@ -202,6 +202,7 @@ class SurrealPersistenceServiceTest extends Specification implements SurrealDBTe
                 Path.of("/some/path"),
                 "buildrepo",
                 'conda::recipe',
+                null,
                 null,
                 BuildFormat.DOCKER,
                 null,

--- a/src/test/groovy/io/seqera/wave/service/scan/ScanRequestTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/scan/ScanRequestTest.groovy
@@ -38,7 +38,7 @@ class ScanRequestTest extends Specification {
         given:
         def workspace = Path.of('/some/workspace')
         def platform = ContainerPlatform.of('amd64')
-        def build = new BuildRequest('FROM ubuntu', workspace, 'docker.io', null, null, BuildFormat.DOCKER, Mock(User), Mock(ContainerConfig), Mock(BuildContext), platform, '{json}', null, null, "", null)
+        def build = new BuildRequest('FROM ubuntu', workspace, 'docker.io', null, null, null, BuildFormat.DOCKER, Mock(User), Mock(ContainerConfig), Mock(BuildContext), platform, '{json}', null, null, "", null)
 
         when:
         def scan = ScanRequest.fromBuild(build)

--- a/src/test/groovy/io/seqera/wave/util/SpackHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/SpackHelperTest.groovy
@@ -39,19 +39,4 @@ class SpackHelperTest extends Specification {
         SpackHelper.prependBuilderTemplate('foo', BuildFormat.DOCKER).startsWith('# Builder image')
         SpackHelper.prependBuilderTemplate('foo', BuildFormat.SINGULARITY).endsWith('\nfoo')
     }
-
-    def 'should map platform to spack arch' () {
-        expect:
-        SpackHelper.toSpackArch(ContainerPlatform.of('x86_64'))            == 'x86_64'
-        SpackHelper.toSpackArch(ContainerPlatform.of('linux/x86_64'))       == 'x86_64'
-        SpackHelper.toSpackArch(ContainerPlatform.of('amd64'))             == 'x86_64'
-        SpackHelper.toSpackArch(ContainerPlatform.of('aarch64'))           == 'aarch64'
-        SpackHelper.toSpackArch(ContainerPlatform.of('arm64'))             == 'aarch64'
-        SpackHelper.toSpackArch(ContainerPlatform.of('linux/arm64/v8'))    == 'aarch64'
-
-        when:
-        SpackHelper.toSpackArch(ContainerPlatform.of('linux/arm64/v7'))
-        then:
-        thrown(IllegalArgumentException)
-    }
 }


### PR DESCRIPTION
This PR reinstates support for the `spackTarget` attribute within Wave.

It comes in conjunction with this Nextflow PR: https://github.com/nextflow-io/nextflow/pull/4701 ,  and a corresponding Libseqera PR: https://github.com/seqeralabs/libseqera/pull/11.