### PR TITLE
bumped actions/upload-artifact to v4 and fix tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Publish tests report
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports-jdk-${{ matrix.java_version }}
           path: |

--- a/src/test/groovy/io/seqera/wave/controller/ContainerInspectControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ContainerInspectControllerTest.groovy
@@ -49,7 +49,8 @@ class ContainerInspectControllerTest extends Specification {
 
     def 'should inspect container' () {
         when:
-        def inspect = new ContainerInspectRequest(containerImage: 'busybox:1.36.1-glibc')
+        def inspect = new ContainerInspectRequest(containerImage:
+                'library/busybox@sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0')
         def req = HttpRequest.POST("/v1alpha1/inspect", inspect)
         def resp = client.toBlocking().exchange(req, ContainerInspectResponse)
         then:
@@ -57,19 +58,19 @@ class ContainerInspectControllerTest extends Specification {
         and:
         resp.body().container.registry == 'docker.io'
         resp.body().container.imageName == 'library/busybox'
-        resp.body().container.reference == '1.36.1-glibc'
-        resp.body().container.digest == 'sha256:e046063223f7eaafbfbc026aa3954d9a31b9f1053ba5db04a4f1fdc97abd8963'
+        resp.body().container.reference == 'sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0'
+        resp.body().container.digest == 'sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0'
         resp.body().container.config.architecture == 'amd64'
         resp.body().container.manifest.schemaVersion == 2
         resp.body().container.manifest.mediaType == 'application/vnd.oci.image.manifest.v1+json'
         resp.body().container.manifest.config.mediaType == 'application/vnd.oci.image.config.v1+json'
-        resp.body().container.manifest.config.digest == 'sha256:3f57d9401f8d42f986df300f0c69192fc41da28ccc8d797829467780db3dd741'
-        resp.body().container.manifest.config.size == 581
+        resp.body().container.manifest.config.digest == 'sha256:ba5dc23f65d4cc4a4535bce55cf9e63b068eb02946e3422d3587e8ce803b6aab'
+        resp.body().container.manifest.config.size == 372
         resp.body().container.manifest.layers[0].mediaType == 'application/vnd.oci.image.layer.v1.tar+gzip'
-        resp.body().container.manifest.layers[0].digest == 'sha256:9ad63333ebc97e32b987ae66aa3cff81300e4c2e6d2f2395cef8a3ae18b249fe'
-        resp.body().container.manifest.layers[0].size == 2220094
+        resp.body().container.manifest.layers[0].digest == 'sha256:7b2699543f22d5b8dc8d66a5873eb246767bca37232dee1e7a3b8c9956bceb0c'
+        resp.body().container.manifest.layers[0].size == 2152262
         resp.body().container.config.rootfs.type == 'layers'
-        resp.body().container.config.rootfs.diff_ids == ['sha256:2e112031b4b923a873c8b3d685d48037e4d5ccd967b658743d93a6e56c3064b9']
+        resp.body().container.config.rootfs.diff_ids == ['sha256:95c4a60383f7b6eb6f7b8e153a07cd6e896de0476763bef39d0f6cf3400624bd']
     }
 
 }

--- a/src/test/groovy/io/seqera/wave/controller/ContainerTokenControllerHttpTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ContainerTokenControllerHttpTest.groovy
@@ -226,8 +226,8 @@ class ContainerTokenControllerHttpTest extends Specification {
     def 'should create token request for anonymous user with include' () {
         given:
         def request = new SubmitContainerTokenRequest(
-                containerImage: 'ubuntu:latest',
-                containerIncludes: ['busybox'],
+                containerImage: 'ubuntu:sha256:aa772c98400ef833586d1d517d3e8de670f7e712bf581ce6053165081773259d',
+                containerIncludes: ['busybox:sha256:4be429a5fbb2e71ae7958bfa558bc637cf3a61baf40a708cb8fff532b39e52d0'],
                 containerConfig: new ContainerConfig(workingDir: '/foo'),
                 containerPlatform: 'arm64',)
         when:
@@ -248,10 +248,10 @@ class ContainerTokenControllerHttpTest extends Specification {
         then:
         def layers = resp2.body().request.containerConfig.layers
         layers.size()==1
-        layers[0].location == 'docker://docker.io/v2/library/busybox/blobs/sha256:9ad63333ebc97e32b987ae66aa3cff81300e4c2e6d2f2395cef8a3ae18b249fe'
-        layers[0].gzipDigest == 'sha256:9ad63333ebc97e32b987ae66aa3cff81300e4c2e6d2f2395cef8a3ae18b249fe'
-        layers[0].gzipSize == 2220094
-        layers[0].tarDigest == 'sha256:2e112031b4b923a873c8b3d685d48037e4d5ccd967b658743d93a6e56c3064b9'
+        layers[0].location == 'docker://docker.io/v2/library/busybox/blobs/sha256:7b2699543f22d5b8dc8d66a5873eb246767bca37232dee1e7a3b8c9956bceb0c'
+        layers[0].gzipDigest == 'sha256:7b2699543f22d5b8dc8d66a5873eb246767bca37232dee1e7a3b8c9956bceb0c'
+        layers[0].gzipSize == 2152262
+        layers[0].tarDigest == 'sha256:95c4a60383f7b6eb6f7b8e153a07cd6e896de0476763bef39d0f6cf3400624bd'
     }
 
 }


### PR DESCRIPTION
This PR will fix tests broken by new busybox docker image and update actions/upload-artifact to v4
<img width="1147" alt="Screenshot 2024-03-07 at 16 08 01" src="https://github.com/seqeralabs/wave/assets/6575288/dbeea6b8-e63f-49be-aada-73484141d77f">
