### PR TITLE
enable cors for seqera.io and hub

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,14 @@ micronaut:
     thread-selection: AUTO
     # note this should be >= the build timeout (which is 15 minutes) see below
     idle-timeout: 910s
+    cors :
+      enabled : true
+      configurations :
+        ui :
+          allowed-origins :
+            - https://seqera.io
+            - https://seqera-hub.netlify.app
+            - http://localhost:9090
   views :
     folder : io/seqera/wave
   router:


### PR DESCRIPTION
This PR will enable CORS from seqera.io and hub to wave.

Tested with http://localhost:9090/
<img width="1627" alt="Screenshot 2024-04-19 at 14 24 18" src="https://github.com/seqeralabs/wave/assets/6575288/2ad6a593-2f6a-40f4-be75-00396a23b648">

Without CORS enable
<img width="1697" alt="Screenshot 2024-04-19 at 14 30 34" src="https://github.com/seqeralabs/wave/assets/6575288/13271523-d0d1-461c-966c-a293cbda6b51">
