### PR TITLE
added null check for container image name

### DIFF
--- a/src/main/groovy/io/seqera/wave/controller/InspectController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/InspectController.groovy
@@ -76,6 +76,9 @@ class InspectController {
     @Post("/v1alpha1/inspect")
     CompletableFuture<HttpResponse<ContainerInspectResponse>> inspect(ContainerInspectRequest req) {
 
+        if( !req.containerImage )
+            throw new BadRequestException("Missing 'containerImage' parameter")
+
         // this is needed for backward compatibility with old clients
         if( !req.towerEndpoint ) {
             req.towerEndpoint = towerEndpointUrl

--- a/src/main/groovy/io/seqera/wave/controller/InspectController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/InspectController.groovy
@@ -77,7 +77,7 @@ class InspectController {
     CompletableFuture<HttpResponse<ContainerInspectResponse>> inspect(ContainerInspectRequest req) {
 
         if( !req.containerImage )
-            throw new BadRequestException("Missing 'containerImage' parameter")
+            throw new BadRequestException("Missing 'containerImage' attribute")
 
         // this is needed for backward compatibility with old clients
         if( !req.towerEndpoint ) {

--- a/src/main/groovy/io/seqera/wave/model/ContainerCoordinates.groovy
+++ b/src/main/groovy/io/seqera/wave/model/ContainerCoordinates.groovy
@@ -51,6 +51,8 @@ class ContainerCoordinates implements ContainerPath {
     }
 
     static ContainerCoordinates parse(String path) {
+        if( !path )
+            throw new IllegalArgumentException("Container image name is not provided")
 
         final scheme = StringUtils.getUrlProtocol(path)
         if( scheme ) {

--- a/src/test/groovy/io/seqera/wave/controller/InspectControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/InspectControllerTest.groovy
@@ -82,6 +82,6 @@ class InspectControllerTest extends Specification {
         client.toBlocking().exchange(req, ContainerInspectResponse)
         then:
         def e = thrown(HttpClientResponseException)
-        e.message == 'Missing \'containerImage\' parameter'
+        e.message == 'Missing \'containerImage\' attribute'
     }
 }

--- a/src/test/groovy/io/seqera/wave/controller/InspectControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/InspectControllerTest.groovy
@@ -24,10 +24,12 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.seqera.wave.api.ContainerInspectRequest
 import io.seqera.wave.api.ContainerInspectResponse
+import io.seqera.wave.exception.BadRequestException
 import io.seqera.wave.service.logs.BuildLogService
 import io.seqera.wave.service.logs.BuildLogServiceImpl
 import jakarta.inject.Inject
@@ -73,4 +75,13 @@ class InspectControllerTest extends Specification {
         resp.body().container.config.rootfs.diff_ids == ['sha256:95c4a60383f7b6eb6f7b8e153a07cd6e896de0476763bef39d0f6cf3400624bd']
     }
 
+    def 'should get BadRequestException, when container image name is not provided' () {
+        when:
+        def inspect = new ContainerInspectRequest()
+        def req = HttpRequest.POST("/v1alpha1/inspect", inspect)
+        client.toBlocking().exchange(req, ContainerInspectResponse)
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.message == 'Missing \'containerImage\' parameter'
+    }
 }

--- a/src/test/groovy/io/seqera/wave/model/ContainerCoordinatesTest.groovy
+++ b/src/test/groovy/io/seqera/wave/model/ContainerCoordinatesTest.groovy
@@ -93,4 +93,12 @@ class ContainerCoordinatesTest extends Specification {
         'http:foo.com:80'       | false
 
     }
+
+    def'should throw exception when container image name is not provided'() {
+        when:
+        ContainerCoordinates.parse(null)
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Container image name is not provided'
+    }
 }


### PR DESCRIPTION
This PR will fix the NPE thrown by parse method in ContainerCoordinates when path is not specified