### PR TITLE
Update metric service to get aggregated metrics 

### DIFF
--- a/src/main/groovy/io/seqera/wave/controller/MetricsController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/MetricsController.groovy
@@ -18,6 +18,7 @@
 
 package io.seqera.wave.controller
 
+import java.util.regex.Pattern
 import javax.annotation.Nullable
 
 import groovy.transform.CompileStatic
@@ -56,11 +57,13 @@ class MetricsController {
     @Inject
     private MetricsService metricsService
 
+    static Pattern datePattern = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+
     @Get(uri = "/v1alpha2/metrics/builds", produces = MediaType.APPLICATION_JSON)
     HttpResponse<?> getBuildsMetrics(@Nullable @QueryValue String date, @Nullable @QueryValue String org) {
         if(!date && !org)
             return HttpResponse.ok(metricsService.getOrgCount(MetricConstants.PREFIX_BUILDS))
-        validateQueryParams(date, org)
+        validateQueryParams(date)
         final count = metricsService.getBuildsMetrics(date, org)
         return HttpResponse.ok(new GetBuildsCountResponse(count))
     }
@@ -69,7 +72,7 @@ class MetricsController {
     HttpResponse<?> getPullsMetrics(@Nullable @QueryValue String date, @Nullable @QueryValue String org) {
         if(!date && !org)
             return HttpResponse.ok(metricsService.getOrgCount(MetricConstants.PREFIX_PULLS))
-        validateQueryParams(date, org)
+        validateQueryParams(date)
         final count = metricsService.getPullsMetrics(date, org)
         return HttpResponse.ok(new GetPullsCountResponse(count))
     }
@@ -78,7 +81,7 @@ class MetricsController {
     HttpResponse<?> getFusionPullsMetrics(@Nullable @QueryValue String date, @Nullable @QueryValue String org) {
         if(!date && !org)
             return HttpResponse.ok(metricsService.getOrgCount(MetricConstants.PREFIX_FUSION))
-        validateQueryParams(date, org)
+        validateQueryParams(date)
         final count = metricsService.getFusionPullsMetrics(date, org)
         return HttpResponse.ok(new GetFusionPullsCountResponse(count))
 
@@ -90,11 +93,8 @@ class MetricsController {
                 .header(WWW_AUTHENTICATE, "Basic realm=Wave Authentication")
     }
 
-    static void validateQueryParams(String date, String org) {
-        if(!date && !org)
-            throw new BadRequestException('Either date or org query parameter must be provided')
-        def pattern = ~/\d{4}-\d{2}-\d{2}/
-        if(date && !(date ==~ pattern)){
+    static void validateQueryParams(String date) {
+        if(date && !datePattern.matcher(date).matches()) {
             throw new BadRequestException('date format should be yyyy-MM-dd')
         }
     }

--- a/src/main/groovy/io/seqera/wave/controller/MetricsController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/MetricsController.groovy
@@ -33,6 +33,7 @@ import io.micronaut.security.annotation.Secured
 import io.micronaut.security.authentication.AuthorizationException
 import io.micronaut.security.rules.SecurityRule
 import io.seqera.wave.exception.BadRequestException
+import io.seqera.wave.service.metric.MetricConstants
 import io.seqera.wave.service.metric.MetricsService
 import io.seqera.wave.service.metric.model.GetBuildsCountResponse
 import io.seqera.wave.service.metric.model.GetFusionPullsCountResponse
@@ -57,6 +58,8 @@ class MetricsController {
 
     @Get(uri = "/v1alpha2/metrics/builds", produces = MediaType.APPLICATION_JSON)
     HttpResponse<?> getBuildsMetrics(@Nullable @QueryValue String date, @Nullable @QueryValue String org) {
+        if(!date && !org)
+            return HttpResponse.ok(metricsService.getOrgCount(MetricConstants.PREFIX_BUILDS))
         validateQueryParams(date, org)
         final count = metricsService.getBuildsMetrics(date, org)
         return HttpResponse.ok(new GetBuildsCountResponse(count))
@@ -64,6 +67,8 @@ class MetricsController {
 
     @Get(uri = "/v1alpha2/metrics/pulls", produces = MediaType.APPLICATION_JSON)
     HttpResponse<?> getPullsMetrics(@Nullable @QueryValue String date, @Nullable @QueryValue String org) {
+        if(!date && !org)
+            return HttpResponse.ok(metricsService.getOrgCount(MetricConstants.PREFIX_PULLS))
         validateQueryParams(date, org)
         final count = metricsService.getPullsMetrics(date, org)
         return HttpResponse.ok(new GetPullsCountResponse(count))
@@ -71,6 +76,8 @@ class MetricsController {
 
     @Get(uri = "/v1alpha2/metrics/fusion/pulls", produces = MediaType.APPLICATION_JSON)
     HttpResponse<?> getFusionPullsMetrics(@Nullable @QueryValue String date, @Nullable @QueryValue String org) {
+        if(!date && !org)
+            return HttpResponse.ok(metricsService.getOrgCount(MetricConstants.PREFIX_FUSION))
         validateQueryParams(date, org)
         final count = metricsService.getFusionPullsMetrics(date, org)
         return HttpResponse.ok(new GetFusionPullsCountResponse(count))

--- a/src/main/groovy/io/seqera/wave/controller/MetricsController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/MetricsController.groovy
@@ -60,7 +60,7 @@ class MetricsController {
     @Inject
     private MetricsService metricsService
 
-    static Pattern datePattern = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+    static final private Pattern DATE_PATTERN = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
 
     @Get(uri = "/v1alpha2/metrics/builds", produces = MediaType.APPLICATION_JSON)
     HttpResponse<?> getBuildsMetrics(@Nullable @QueryValue String date, @Nullable @QueryValue String org) {
@@ -97,7 +97,7 @@ class MetricsController {
     }
 
     static void validateQueryParams(String date) {
-        if(date && !datePattern.matcher(date).matches()) {
+        if(date && !DATE_PATTERN.matcher(date).matches()) {
             throw new BadRequestException('date format should be yyyy-MM-dd')
         }
     }

--- a/src/main/groovy/io/seqera/wave/service/counter/AbstractCounterStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/AbstractCounterStore.groovy
@@ -52,7 +52,7 @@ abstract class AbstractCounterStore implements CounterStore {
     }
 
     @Override
-    Map<String, Long> getAllMatchingEntries(String key) {
-        provider.getAllMatchingEntries(getPrefix(), key)
+    Map<String, Long> getAllMatchingEntries(String pattern) {
+        provider.getAllMatchingEntries(getPrefix(), pattern)
     }
 }

--- a/src/main/groovy/io/seqera/wave/service/counter/AbstractCounterStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/AbstractCounterStore.groovy
@@ -51,4 +51,8 @@ abstract class AbstractCounterStore implements CounterStore {
         provider.get(getPrefix(), key)
     }
 
+    @Override
+    Map<String, Long> getAllMatchingEntries(String key) {
+        provider.getAllMatchingEntries(getPrefix(), key)
+    }
 }

--- a/src/main/groovy/io/seqera/wave/service/counter/CounterStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/CounterStore.groovy
@@ -30,8 +30,8 @@ interface CounterStore {
     Long get(String key)
 
     /**
-     * @param partialKey
-     * @return all the entries whose field matches 'key*
+     * @param pattern
+     * @return all the entries whose field matches 'pattern*'
      */
-    Map<String, Long> getAllMatchingEntries(String key)
+    Map<String, Long> getAllMatchingEntries(String pattern)
 }

--- a/src/main/groovy/io/seqera/wave/service/counter/CounterStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/CounterStore.groovy
@@ -31,7 +31,7 @@ interface CounterStore {
 
     /**
      * @param pattern
-     * @return all the entries whose field matches 'pattern*'
+     * @return all the entries whose field matches 'pattern'
      */
     Map<String, Long> getAllMatchingEntries(String pattern)
 }

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/CounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/CounterProvider.groovy
@@ -31,7 +31,7 @@ interface CounterProvider {
      *
      * @param key
      * @param pattern
-     * @return all the entries whose field matches 'pattern*'
+     * @return all the entries whose field matches 'pattern'
      */
     Map<String, Long> getAllMatchingEntries(String key, String pattern)
 }

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/CounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/CounterProvider.groovy
@@ -29,9 +29,9 @@ interface CounterProvider {
 
     /**
      *
-     * @param partialKey
+     * @param key
      * @param pattern
-     * @return all the entries whose field matches 'pattern*
+     * @return all the entries whose field matches 'pattern*'
      */
-    Map<String, Long> getAllMatchingEntries(String partialKey, String pattern)
+    Map<String, Long> getAllMatchingEntries(String key, String pattern)
 }

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/CounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/CounterProvider.groovy
@@ -18,6 +18,7 @@
 
 package io.seqera.wave.service.counter.impl
 /**
+ * Contract interface for a generic distributed "counter" service
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/CounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/CounterProvider.groovy
@@ -27,4 +27,11 @@ interface CounterProvider {
 
     Long get(String key, String field)
 
+    /**
+     *
+     * @param partialKey
+     * @param pattern
+     * @return all the entries whose field matches 'pattern*
+     */
+    Map<String, Long> getAllMatchingEntries(String partialKey, String pattern)
 }

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/LocalCounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/LocalCounterProvider.groovy
@@ -50,9 +50,7 @@ class LocalCounterProvider implements CounterProvider {
     @Override
     Map<String, Long> getAllMatchingEntries(String key, String pattern) {
         def keyStore = store.get(key)
-        def matchingPairs = keyStore.findAll { k, v ->
-            k.contains(pattern)
-        }
+        def matchingPairs = keyStore.findAll { k, v -> k =~pattern}
         Map<String, Long> result = [:]
         matchingPairs.each { k, v ->
             result.put(k, v as Long)

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/LocalCounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/LocalCounterProvider.groovy
@@ -47,4 +47,16 @@ class LocalCounterProvider implements CounterProvider {
         return store.get(key)?.get(field)?.get()
     }
 
+    @Override
+    Map<String, Long> getAllMatchingEntries(String key, String pattern) {
+        def keyStore = store.get(key)
+        def matchingPairs = keyStore.findAll { k, v ->
+            k.contains(pattern)
+        }
+        Map<String, Long> result = [:]
+        matchingPairs.each { k, v ->
+            result.put(k, v as Long)
+        }
+        return result
+    }
 }

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/LocalCounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/LocalCounterProvider.groovy
@@ -50,10 +50,12 @@ class LocalCounterProvider implements CounterProvider {
     @Override
     Map<String, Long> getAllMatchingEntries(String key, String pattern) {
         def keyStore = store.get(key)
-        def matchingPairs = keyStore.findAll { k, v -> k =~ pattern}
         Map<String, Long> result = [:]
-        matchingPairs.each { k, v ->
+        if (keyStore){
+            def matchingPairs = keyStore.findAll { k, v -> k =~ pattern }
+            matchingPairs.each { k, v ->
             result.put(k, v as Long)
+            }
         }
         return result
     }

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/LocalCounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/LocalCounterProvider.groovy
@@ -50,7 +50,7 @@ class LocalCounterProvider implements CounterProvider {
     @Override
     Map<String, Long> getAllMatchingEntries(String key, String pattern) {
         def keyStore = store.get(key)
-        def matchingPairs = keyStore.findAll { k, v -> k =~pattern}
+        def matchingPairs = keyStore.findAll { k, v -> k =~ pattern}
         Map<String, Long> result = [:]
         matchingPairs.each { k, v ->
             result.put(k, v as Long)

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
@@ -57,6 +57,7 @@ class RedisCounterProvider implements CounterProvider {
         try(Jedis conn=pool.getResource() ) {
             final scanResult = conn.hscan(key, "0", new ScanParams().match(pattern))
             final result = new HashMap<String, Long>()
+            if( scanResult )
             for(String entry : scanResult.result) {
                 final parts = entry.tokenize('=')
                 result.put(parts[0], parts[1] as Long)

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
@@ -25,7 +25,6 @@ import jakarta.inject.Singleton
 import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPool
 import redis.clients.jedis.params.ScanParams
-
 /**
  * Implement a counter based on Redis cache
  *
@@ -56,12 +55,12 @@ class RedisCounterProvider implements CounterProvider {
     @Override
     Map<String, Long> getAllMatchingEntries(String key, String pattern) {
         try(Jedis conn=pool.getResource() ) {
-            Map<String, Long> result = [:]
-                def scanResult = conn.hscan(key, "0", new ScanParams().match(pattern))
-                for(String entry : scanResult.result) {
-                    def parts = entry.split('=')
-                    result.put(parts[0], parts[1] as Long)
-                }
+            def scanResult = conn.hscan(key, "0", new ScanParams().match(pattern))
+            def result = new HashMap<String, Long>()
+            for(String entry : scanResult.result) {
+                def parts = entry.split('=')
+                result.put(parts[0], parts[1] as Long)
+            }
             return result
         }
     }

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
@@ -55,10 +55,10 @@ class RedisCounterProvider implements CounterProvider {
     @Override
     Map<String, Long> getAllMatchingEntries(String key, String pattern) {
         try(Jedis conn=pool.getResource() ) {
-            def scanResult = conn.hscan(key, "0", new ScanParams().match(pattern))
-            def result = new HashMap<String, Long>()
+            final scanResult = conn.hscan(key, "0", new ScanParams().match(pattern))
+            final result = new HashMap<String, Long>()
             for(String entry : scanResult.result) {
-                def parts = entry.tokenize('=')
+                final parts = entry.tokenize('=')
                 result.put(parts[0], parts[1] as Long)
             }
             return result

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
@@ -58,7 +58,7 @@ class RedisCounterProvider implements CounterProvider {
             def scanResult = conn.hscan(key, "0", new ScanParams().match(pattern))
             def result = new HashMap<String, Long>()
             for(String entry : scanResult.result) {
-                def parts = entry.split('=')
+                def parts = entry.tokenize('=')
                 result.put(parts[0], parts[1] as Long)
             }
             return result

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
@@ -57,7 +57,7 @@ class RedisCounterProvider implements CounterProvider {
     Map<String, Long> getAllMatchingEntries(String key, String pattern) {
         try(Jedis conn=pool.getResource() ) {
             Map<String, Long> result = [:]
-                def scanResult = conn.hscan(key, "0", new ScanParams().match("$pattern*"))
+                def scanResult = conn.hscan(key, "0", new ScanParams().match(pattern))
                 for(String entry : scanResult.result) {
                     def parts = entry.split('=')
                     result.put(parts[0], parts[1] as Long)

--- a/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
+++ b/src/main/groovy/io/seqera/wave/service/counter/impl/RedisCounterProvider.groovy
@@ -56,8 +56,9 @@ class RedisCounterProvider implements CounterProvider {
     Map<String, Long> getAllMatchingEntries(String key, String pattern) {
         try(Jedis conn=pool.getResource() ) {
             final scanResult = conn.hscan(key, "0", new ScanParams().match(pattern))
+            if( !scanResult )
+                return Map.<String, Long>of()
             final result = new HashMap<String, Long>()
-            if( scanResult )
             for(String entry : scanResult.result) {
                 final parts = entry.tokenize('=')
                 result.put(parts[0], parts[1] as Long)

--- a/src/main/groovy/io/seqera/wave/service/metric/MetricsService.groovy
+++ b/src/main/groovy/io/seqera/wave/service/metric/MetricsService.groovy
@@ -77,8 +77,8 @@ interface MetricsService {
     /**
      * Get counts of all organisations
      *
-     * @param metrics
+     * @param metric
      * @return GetOrgCountResponse
      */
-    GetOrgCountResponse getOrgCount(String metrics)
+    GetOrgCountResponse getOrgCount(String metric)
 }

--- a/src/main/groovy/io/seqera/wave/service/metric/MetricsService.groovy
+++ b/src/main/groovy/io/seqera/wave/service/metric/MetricsService.groovy
@@ -18,6 +18,7 @@
 
 package io.seqera.wave.service.metric
 
+import io.seqera.wave.service.metric.model.GetOrgCountResponse
 import io.seqera.wave.tower.PlatformId
 /**
  * Defines the interface to store and retrieve wave metrics
@@ -72,4 +73,12 @@ interface MetricsService {
      * @param seqera platform id
      */
     void incrementPullsCounter(PlatformId platformId)
+
+    /**
+     * Get counts of all organisations
+     *
+     * @param metrics
+     * @return GetOrgCountResponse
+     */
+    GetOrgCountResponse getOrgCount(String metrics)
 }

--- a/src/main/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImpl.groovy
@@ -63,10 +63,8 @@ class MetricsServiceImpl implements MetricsService {
     @Override
     GetOrgCountResponse getOrgCount(String metrics){
         GetOrgCountResponse response = new GetOrgCountResponse(metrics, 0, [:])
-        def orgCounts = metricsCounterStore.getAllMatchingEntries("$metrics/$MetricConstants.PREFIX_ORG")
-        log.info("Found ${orgCounts.size()} orgs for key: $metrics/$MetricConstants.PREFIX_ORG")
+        def orgCounts = metricsCounterStore.getAllMatchingEntries("$metrics/$MetricConstants.PREFIX_ORG/*")
         for(def entry : orgCounts) {
-            log.info(entry.key+" -> "+entry.value)
             if(!entry.key.contains("/$MetricConstants.PREFIX_DAY/")) {
                 response.count += entry.value
                 response.orgs.put(entry.key.split("/$MetricConstants.PREFIX_ORG/").last(), entry.value)

--- a/src/main/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImpl.groovy
@@ -65,7 +65,7 @@ class MetricsServiceImpl implements MetricsService {
         GetOrgCountResponse response = new GetOrgCountResponse(metrics, 0, [:])
         def orgCounts = metricsCounterStore.getAllMatchingEntries("$metrics/$MetricConstants.PREFIX_ORG/*")
         for(def entry : orgCounts) {
-            // this patter also return the records with org and date, so here we will filter out the records with date
+            // orgCounts also contains the records with org and date, so here it filter out the records with date
             if(!entry.key.contains("/$MetricConstants.PREFIX_DAY/")) {
                 response.count += entry.value
                 //split is used to extract the org name from the key like "metrics/o/seqera.io" => seqera.io

--- a/src/main/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImpl.groovy
@@ -65,8 +65,10 @@ class MetricsServiceImpl implements MetricsService {
         GetOrgCountResponse response = new GetOrgCountResponse(metrics, 0, [:])
         def orgCounts = metricsCounterStore.getAllMatchingEntries("$metrics/$MetricConstants.PREFIX_ORG/*")
         for(def entry : orgCounts) {
+            // this patter also return the records with org and date, so here we will filter out the records with date
             if(!entry.key.contains("/$MetricConstants.PREFIX_DAY/")) {
                 response.count += entry.value
+                //split is used to extract the org name from the key like "metrics/o/seqera.io" => seqera.io
                 response.orgs.put(entry.key.split("/$MetricConstants.PREFIX_ORG/").last(), entry.value)
             }
         }

--- a/src/main/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImpl.groovy
@@ -61,9 +61,9 @@ class MetricsServiceImpl implements MetricsService {
     }
 
     @Override
-    GetOrgCountResponse getOrgCount(String metrics){
-        GetOrgCountResponse response = new GetOrgCountResponse(metrics, 0, [:])
-        def orgCounts = metricsCounterStore.getAllMatchingEntries("$metrics/$MetricConstants.PREFIX_ORG/*")
+    GetOrgCountResponse getOrgCount(String metric){
+        final response = new GetOrgCountResponse(metric, 0, [:])
+        final orgCounts = metricsCounterStore.getAllMatchingEntries("$metric/$MetricConstants.PREFIX_ORG/*")
         for(def entry : orgCounts) {
             // orgCounts also contains the records with org and date, so here it filter out the records with date
             if(!entry.key.contains("/$MetricConstants.PREFIX_DAY/")) {

--- a/src/main/groovy/io/seqera/wave/service/metric/model/GetOrgCountResponse.groovy
+++ b/src/main/groovy/io/seqera/wave/service/metric/model/GetOrgCountResponse.groovy
@@ -1,6 +1,6 @@
 /*
  *  Wave, containers provisioning service
- *  Copyright (c) 2023-2024, Seqera Labs
+ *  Copyright (c) 2024, Seqera Labs
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published by
@@ -18,7 +18,7 @@
 package io.seqera.wave.service.metric.model
 
 /**
- * Model for org metrics
+ * Model organisations counts response
  *
  * @author Munish Chouhan <munish.chouhan@seqera.io>
  */

--- a/src/main/groovy/io/seqera/wave/service/metric/model/GetOrgCountResponse.groovy
+++ b/src/main/groovy/io/seqera/wave/service/metric/model/GetOrgCountResponse.groovy
@@ -15,23 +15,21 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-package io.seqera.wave.service.counter
+package io.seqera.wave.service.metric.model
 
 /**
- * Define the interface of a generic counter service
+ * Model for org metrics
  *
- * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ * @author Munish Chouhan <munish.chouhan@seqera.io>
  */
-interface CounterStore {
+class GetOrgCountResponse {
+    String metrics
+    Long count
+    Map<String, Long> orgs
 
-    long inc(String key, long value)
-
-    Long get(String key)
-
-    /**
-     * @param partialKey
-     * @return all the entries whose field matches 'key*
-     */
-    Map<String, Long> getAllMatchingEntries(String key)
+    GetOrgCountResponse(String metrics, Long count, Map<String, Long> orgs) {
+        this.metrics = metrics
+        this.count = count
+        this.orgs = orgs
+    }
 }

--- a/src/main/groovy/io/seqera/wave/service/metric/model/GetOrgCountResponse.groovy
+++ b/src/main/groovy/io/seqera/wave/service/metric/model/GetOrgCountResponse.groovy
@@ -23,12 +23,12 @@ package io.seqera.wave.service.metric.model
  * @author Munish Chouhan <munish.chouhan@seqera.io>
  */
 class GetOrgCountResponse {
-    String metrics
+    String metric
     Long count
     Map<String, Long> orgs
 
-    GetOrgCountResponse(String metrics, Long count, Map<String, Long> orgs) {
-        this.metrics = metrics
+    GetOrgCountResponse(String metric, Long count, Map<String, Long> orgs) {
+        this.metric = metric
         this.count = count
         this.orgs = orgs
     }

--- a/src/test/groovy/io/seqera/wave/controller/MetricsControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/MetricsControllerTest.groovy
@@ -99,7 +99,7 @@ class MetricsControllerTest extends Specification {
         res = client.toBlocking().exchange(req, Map)
 
         then: 'should get the correct org count'
-        res.body() == [metrics:'builds', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
+        res.body() == [metric:'builds', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
         res.status.code == 200
     }
 
@@ -143,7 +143,7 @@ class MetricsControllerTest extends Specification {
         res = client.toBlocking().exchange(req, Map)
 
         then: 'should get the correct org count'
-        res.body() == [metrics:'pulls', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
+        res.body() == [metric:'pulls', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
         res.status.code == 200
     }
 
@@ -187,7 +187,7 @@ class MetricsControllerTest extends Specification {
         res = client.toBlocking().exchange(req, Map)
 
         then: 'should get the correct org count'
-        res.body() == [metrics:'fusion', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
+        res.body() == [metric:'fusion', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
         res.status.code == 200
     }
 

--- a/src/test/groovy/io/seqera/wave/controller/MetricsControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/MetricsControllerTest.groovy
@@ -143,7 +143,7 @@ class MetricsControllerTest extends Specification {
         res = client.toBlocking().exchange(req, Map)
 
         then: 'should get the correct org count'
-        res.body() == [metrics:'builds', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
+        res.body() == [metrics:'pulls', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
         res.status.code == 200
     }
 
@@ -187,7 +187,7 @@ class MetricsControllerTest extends Specification {
         res = client.toBlocking().exchange(req, Map)
 
         then: 'should get the correct org count'
-        res.body() == [metrics:'builds', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
+        res.body() == [metrics:'fusion', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
         res.status.code == 200
     }
 

--- a/src/test/groovy/io/seqera/wave/controller/MetricsControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/MetricsControllerTest.groovy
@@ -93,6 +93,14 @@ class MetricsControllerTest extends Specification {
         then: 'should get the correct count'
         res.body() == [count: 1]
         res.status.code == 200
+
+        when: 'no param is provided'
+        req = HttpRequest.GET("/v1alpha2/metrics/builds").basicAuth("username", "password")
+        res = client.toBlocking().exchange(req, Map)
+
+        then: 'should get the correct org count'
+        res.body() == [metrics:'builds', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
+        res.status.code == 200
     }
 
     def 'should get the correct pulls count and http status code 200'() {
@@ -128,6 +136,14 @@ class MetricsControllerTest extends Specification {
 
         then: 'should get the correct count'
         res.body() == [count: 1]
+        res.status.code == 200
+
+        when: 'no param is provided'
+        req = HttpRequest.GET("/v1alpha2/metrics/pulls").basicAuth("username", "password")
+        res = client.toBlocking().exchange(req, Map)
+
+        then: 'should get the correct org count'
+        res.body() == [metrics:'builds', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
         res.status.code == 200
     }
 
@@ -165,6 +181,14 @@ class MetricsControllerTest extends Specification {
         then: 'should get the correct count'
         res.body() == [count: 1]
         res.status.code == 200
+
+        when: 'no param is provided'
+        req = HttpRequest.GET("/v1alpha2/metrics/fusion/pulls").basicAuth("username", "password")
+        res = client.toBlocking().exchange(req, Map)
+
+        then: 'should get the correct org count'
+        res.body() == [metrics:'builds', count:2, orgs:['org1.com': 1, 'org2.com': 1]]
+        res.status.code == 200
     }
 
     def 'should validate query parameters'() {
@@ -175,15 +199,6 @@ class MetricsControllerTest extends Specification {
         then: 'should get 400 response code and message'
         def e = thrown(HttpClientResponseException)
         e.message == 'date format should be yyyy-MM-dd'
-        e.status.code == 400
-
-        when: 'no query parameter is provided'
-        req = HttpRequest.GET("/v1alpha2/metrics/builds").basicAuth("username", "password")
-        client.toBlocking().exchange(req, Map)
-
-        then: 'should get 400 response code and message'
-        e = thrown(HttpClientResponseException)
-        e.message == 'Either date or org query parameter must be provided'
         e.status.code == 400
     }
 }

--- a/src/test/groovy/io/seqera/wave/service/counter/impl/LocalCounterProviderTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/counter/impl/LocalCounterProviderTest.groovy
@@ -54,4 +54,19 @@ class LocalCounterProviderTest extends Specification {
         localCounterProvider.get('metrics-x', 'foo') == 1
     }
 
+    def 'should get correct org count' () {
+        when:
+        localCounterProvider.inc('metrics/v1', '/builds/o/foo', 1)
+        localCounterProvider.inc('metrics/v1', '/builds/o/bar', 1)
+        localCounterProvider.inc('metrics/v1', '/builds/o/abc', 2)
+        localCounterProvider.inc('metrics/v1', '/pulls/o/foo', 1)
+        localCounterProvider.inc('metrics/v1', '/pulls/o/bar', 2)
+        localCounterProvider.inc('metrics/v1', '/pulls/o/abc', 3)
+        localCounterProvider.inc('metrics/v1', '/pulls/o/abc/date/yyyy-mm-dd', 1)
+
+        then:
+        localCounterProvider.getAllMatchingEntries('metrics/v1', '/pulls/o') ==
+                ['/pulls/o/foo':1, '/pulls/o/bar':2, '/pulls/o/abc':3, '/pulls/o/abc/date/yyyy-mm-dd': 1]
+    }
+
 }

--- a/src/test/groovy/io/seqera/wave/service/counter/impl/LocalCounterProviderTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/counter/impl/LocalCounterProviderTest.groovy
@@ -56,17 +56,17 @@ class LocalCounterProviderTest extends Specification {
 
     def 'should get correct org count' () {
         when:
-        localCounterProvider.inc('metrics/v1', '/builds/o/foo', 1)
-        localCounterProvider.inc('metrics/v1', '/builds/o/bar', 1)
-        localCounterProvider.inc('metrics/v1', '/builds/o/abc', 2)
-        localCounterProvider.inc('metrics/v1', '/pulls/o/foo', 1)
-        localCounterProvider.inc('metrics/v1', '/pulls/o/bar', 2)
-        localCounterProvider.inc('metrics/v1', '/pulls/o/abc', 3)
-        localCounterProvider.inc('metrics/v1', '/pulls/o/abc/date/yyyy-mm-dd', 1)
+        localCounterProvider.inc('metrics/v1', 'builds/o/foo.com', 1)
+        localCounterProvider.inc('metrics/v1', 'builds/o/bar.io', 1)
+        localCounterProvider.inc('metrics/v1', 'builds/o/abc.org', 2)
+        localCounterProvider.inc('metrics/v1', 'pulls/o/foo.it', 1)
+        localCounterProvider.inc('metrics/v1', 'pulls/o/bar.es', 2)
+        localCounterProvider.inc('metrics/v1', 'pulls/o/abc.in', 3)
+        localCounterProvider.inc('metrics/v1', 'pulls/o/abc.com.au/date/yyyy-mm-dd', 1)
 
         then:
-        localCounterProvider.getAllMatchingEntries('metrics/v1', '/pulls/o') ==
-                ['/pulls/o/foo':1, '/pulls/o/bar':2, '/pulls/o/abc':3, '/pulls/o/abc/date/yyyy-mm-dd': 1]
+        localCounterProvider.getAllMatchingEntries('metrics/v1', 'pulls/o/*') ==
+                ['pulls/o/foo.it':1, 'pulls/o/bar.es':2, 'pulls/o/abc.in':3, 'pulls/o/abc/date/yyyy-mm-dd': 1]
     }
 
 }

--- a/src/test/groovy/io/seqera/wave/service/counter/impl/LocalCounterProviderTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/counter/impl/LocalCounterProviderTest.groovy
@@ -66,7 +66,7 @@ class LocalCounterProviderTest extends Specification {
 
         then:
         localCounterProvider.getAllMatchingEntries('metrics/v1', 'pulls/o/*') ==
-                ['pulls/o/foo.it':1, 'pulls/o/bar.es':2, 'pulls/o/abc.in':3, 'pulls/o/abc/date/yyyy-mm-dd': 1]
+                ['pulls/o/abc.com.au/date/yyyy-mm-dd':1, 'pulls/o/abc.in':3, 'pulls/o/bar.es':2, 'pulls/o/foo.it':1]
     }
 
 }

--- a/src/test/groovy/io/seqera/wave/service/counter/impl/RedisCounterProviderTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/counter/impl/RedisCounterProviderTest.groovy
@@ -66,16 +66,16 @@ class RedisCounterProviderTest extends Specification implements RedisTestContain
 
     def 'should get correct org count' () {
         when:
-        redisCounterProvider.inc('metrics/v1', 'builds/o/foo', 1)
-        redisCounterProvider.inc('metrics/v1', 'builds/o/bar', 1)
-        redisCounterProvider.inc('metrics/v1', 'builds/o/abc', 2)
-        redisCounterProvider.inc('metrics/v1', 'pulls/o/foo', 1)
-        redisCounterProvider.inc('metrics/v1', 'pulls/o/bar', 2)
-        redisCounterProvider.inc('metrics/v1', 'pulls/o/abc', 3)
-        redisCounterProvider.inc('metrics/v1', 'pulls/o/abc/date/yyyy-mm-dd', 1)
+        redisCounterProvider.inc('metrics/v1', 'builds/o/foo.com', 1)
+        redisCounterProvider.inc('metrics/v1', 'builds/o/bar.org', 1)
+        redisCounterProvider.inc('metrics/v1', 'builds/o/abc.it', 2)
+        redisCounterProvider.inc('metrics/v1', 'pulls/o/foo.es', 1)
+        redisCounterProvider.inc('metrics/v1', 'pulls/o/bar.in', 2)
+        redisCounterProvider.inc('metrics/v1', 'pulls/o/abc.au', 3)
+        redisCounterProvider.inc('metrics/v1', 'pulls/o/abc.com/date/yyyy-mm-dd', 1)
 
         then:
-        redisCounterProvider.getAllMatchingEntries('metrics/v1', 'pulls/o') ==
-                ['pulls/o/foo':1, 'pulls/o/bar':2, 'pulls/o/abc':3, 'pulls/o/abc/date/yyyy-mm-dd': 1]
+        redisCounterProvider.getAllMatchingEntries('metrics/v1', 'pulls/o/*') ==
+                ['pulls/o/foo.es':1, 'pulls/o/bar.in':2, 'pulls/o/abc.au':3, 'pulls/o/abc.com/date/yyyy-mm-dd': 1]
     }
 }

--- a/src/test/groovy/io/seqera/wave/service/counter/impl/RedisCounterProviderTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/counter/impl/RedisCounterProviderTest.groovy
@@ -64,4 +64,18 @@ class RedisCounterProviderTest extends Specification implements RedisTestContain
         redisCounterProvider.get('metrics-x', 'foo') == 1
     }
 
+    def 'should get correct org count' () {
+        when:
+        redisCounterProvider.inc('metrics/v1', 'builds/o/foo', 1)
+        redisCounterProvider.inc('metrics/v1', 'builds/o/bar', 1)
+        redisCounterProvider.inc('metrics/v1', 'builds/o/abc', 2)
+        redisCounterProvider.inc('metrics/v1', 'pulls/o/foo', 1)
+        redisCounterProvider.inc('metrics/v1', 'pulls/o/bar', 2)
+        redisCounterProvider.inc('metrics/v1', 'pulls/o/abc', 3)
+        redisCounterProvider.inc('metrics/v1', 'pulls/o/abc/date/yyyy-mm-dd', 1)
+
+        then:
+        redisCounterProvider.getAllMatchingEntries('metrics/v1', 'pulls/o') ==
+                ['pulls/o/foo':1, 'pulls/o/bar':2, 'pulls/o/abc':3, 'pulls/o/abc/date/yyyy-mm-dd': 1]
+    }
 }

--- a/src/test/groovy/io/seqera/wave/service/counter/impl/RedisCounterProviderTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/counter/impl/RedisCounterProviderTest.groovy
@@ -77,5 +77,7 @@ class RedisCounterProviderTest extends Specification implements RedisTestContain
         then:
         redisCounterProvider.getAllMatchingEntries('metrics/v1', 'pulls/o/*') ==
                 ['pulls/o/foo.es':1, 'pulls/o/bar.in':2, 'pulls/o/abc.au':3, 'pulls/o/abc.com/date/yyyy-mm-dd': 1]
+        and:
+        redisCounterProvider.getAllMatchingEntries('metrics/v1', 'fusion/o/*') == [:]
     }
 }

--- a/src/test/groovy/io/seqera/wave/service/metric/MetricsCounterStoreLocalTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/metric/MetricsCounterStoreLocalTest.groovy
@@ -43,4 +43,14 @@ class MetricsCounterStoreLocalTest extends Specification {
         metricsCounterStore.get('bar') == 1
     }
 
+    def 'should get correct org count value' () {
+        when:
+        metricsCounterStore.inc('builds/o/foo.com')
+        metricsCounterStore.inc('builds/o/bar.org')
+        metricsCounterStore.inc('pulls/o/bar.in')
+
+        then:
+        metricsCounterStore.getAllMatchingEntries('builds/o*') == ['builds/o/foo.com':1, 'builds/o/bar.org':1]
+        metricsCounterStore.getAllMatchingEntries('pulls/o*') == ['pulls/o/bar.in':1]
+    }
 }

--- a/src/test/groovy/io/seqera/wave/service/metric/MetricsCounterStoreRedisTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/metric/MetricsCounterStoreRedisTest.groovy
@@ -60,4 +60,18 @@ class MetricsCounterStoreRedisTest  extends Specification implements RedisTestCo
         metricsCounterStore.get('foo') == 2
         metricsCounterStore.get('bar') == 1
     }
+
+    def 'should get correct org count value' () {
+        given:
+        def metricsCounterStore = applicationContext.getBean(MetricsCounterStore)
+
+        when:
+        metricsCounterStore.inc('builds/o/foo.com')
+        metricsCounterStore.inc('builds/o/bar.org')
+        metricsCounterStore.inc('pulls/o/bar.in')
+
+        then:
+        metricsCounterStore.getAllMatchingEntries('builds/o*') == ['builds/o/foo.com':1, 'builds/o/bar.org':1]
+        metricsCounterStore.getAllMatchingEntries('pulls/o*') == ['pulls/o/bar.in':1]
+    }
 }

--- a/src/test/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImplTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImplTest.groovy
@@ -165,19 +165,19 @@ class MetricsServiceImplTest extends Specification {
         def emptyOrgCounts = metricsService.getOrgCount(null)
 
         then:
-        buildOrgCounts.metrics == MetricConstants.PREFIX_BUILDS
+        buildOrgCounts.metric == MetricConstants.PREFIX_BUILDS
         buildOrgCounts.count == 2
         buildOrgCounts.orgs == ['org1.com': 1, 'org2.com': 1]
         and:
-        pullOrgCounts.metrics == MetricConstants.PREFIX_PULLS
+        pullOrgCounts.metric == MetricConstants.PREFIX_PULLS
         pullOrgCounts.count == 2
         pullOrgCounts.orgs == ['org1.com': 1, 'org2.com': 1]
         and:
-        fusionOrgCounts.metrics == MetricConstants.PREFIX_FUSION
+        fusionOrgCounts.metric == MetricConstants.PREFIX_FUSION
         fusionOrgCounts.count == 2
         fusionOrgCounts.orgs == ['org1.com': 1, 'org2.com': 1]
         and:
-        emptyOrgCounts.metrics == null
+        emptyOrgCounts.metric == null
         emptyOrgCounts.count == 0
         emptyOrgCounts.orgs == [:]
     }

--- a/src/test/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImplTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImplTest.groovy
@@ -174,6 +174,5 @@ class MetricsServiceImplTest extends Specification {
         fusionOrgCounts.metrics == MetricConstants.PREFIX_FUSION
         fusionOrgCounts.count == 2
         fusionOrgCounts.orgs == ['org1.com': 1, 'org2.com': 1]
-
     }
 }

--- a/src/test/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImplTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/metric/impl/MetricsServiceImplTest.groovy
@@ -162,6 +162,8 @@ class MetricsServiceImplTest extends Specification {
         def buildOrgCounts = metricsService.getOrgCount(MetricConstants.PREFIX_BUILDS)
         def pullOrgCounts = metricsService.getOrgCount(MetricConstants.PREFIX_PULLS)
         def fusionOrgCounts = metricsService.getOrgCount(MetricConstants.PREFIX_FUSION)
+        def emptyOrgCounts = metricsService.getOrgCount(null)
+
         then:
         buildOrgCounts.metrics == MetricConstants.PREFIX_BUILDS
         buildOrgCounts.count == 2
@@ -174,5 +176,9 @@ class MetricsServiceImplTest extends Specification {
         fusionOrgCounts.metrics == MetricConstants.PREFIX_FUSION
         fusionOrgCounts.count == 2
         fusionOrgCounts.orgs == ['org1.com': 1, 'org2.com': 1]
+        and:
+        emptyOrgCounts.metrics == null
+        emptyOrgCounts.count == 0
+        emptyOrgCounts.orgs == [:]
     }
 }


### PR DESCRIPTION
closes https://github.com/seqeralabs/wave/issues/469
This PR will add the following
1. This PR will add a function in counterProvider to get all matching data data using hscan
2. This will add a method in metric service to get the count per org and total count
3. Add new model for the response

When no date or ord is provided then metrics endpoint will return the above 