### PR TITLE
Fix "Error: EACCES: permission denied" in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           QUAY_PAT: ${{ secrets.QUAY_PAT }}
           GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
 
-      - name: delete build workspace
+      - name: Delete build workspace
         run: |
           rm -rf /home/runner/work/wave/wave/build-workspace
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,10 @@ jobs:
           QUAY_PAT: ${{ secrets.QUAY_PAT }}
           GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
 
+      - name: delete build workspace
+        run: |
+          rm -rf /home/runner/work/wave/wave/build-workspace
+
       - name: Publish tests report
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Recently we are getting lots of permission denied errors, when tests fails and GHA tries to upload test reports

`Error: EACCES: permission denied, scandir '/home/runner/work/wave/wave/build-workspace/.trivy-cache/trivy'`

This PR will remove the build-workspace directory before uploading the test report

related issue:
https://github.com/actions/upload-artifact/issues/192