### PR TITLE
Fix CI errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Delete build workspace
         run: |
-          rm -rf /home/runner/work/wave/wave/build-workspace
+          sudo rm -rf /home/runner/work/wave/wave/build-workspace
 
       - name: Publish tests report
         if: failure()

--- a/src/test/groovy/io/seqera/wave/controller/RegistryControllerRedisTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/RegistryControllerRedisTest.groovy
@@ -61,11 +61,11 @@ class RegistryControllerRedisTest extends Specification implements DockerRegistr
         ], 'test', 'h2', 'redis')
 
         jedis = new Jedis(redisHostName, redisPort as int)
-        jedis.flushAll()
         initRegistryContainer(applicationContext)
     }
 
     def cleanup(){
+        jedis.flushAll()
         jedis.close()
     }
 

--- a/src/test/groovy/io/seqera/wave/ratelimit/SpillwayRedisRateLimiterTest.groovy
+++ b/src/test/groovy/io/seqera/wave/ratelimit/SpillwayRedisRateLimiterTest.groovy
@@ -47,10 +47,10 @@ class SpillwayRedisRateLimiterTest extends Specification implements RedisTestCon
         ], 'test', 'redis','rate-limit')
         rateLimiter = applicationContext.getBean(SpillwayRateLimiter)
         jedis = new Jedis(redisHostName, redisPort as int)
-        jedis.flushAll()
     }
 
     def cleanup(){
+        jedis.flushAll()
         jedis.close()
     }
 

--- a/src/test/groovy/io/seqera/wave/service/builder/BuildCacheStoreRedisTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/BuildCacheStoreRedisTest.groovy
@@ -46,10 +46,10 @@ class BuildCacheStoreRedisTest extends Specification implements RedisTestContain
                 REDIS_PORT: redisPort
         ], 'test', 'redis')
         jedis = new Jedis(redisHostName, redisPort as int)
-        jedis.flushAll()
     }
 
     def cleanup(){
+        jedis.flushAll()
         jedis.close()
     }
 

--- a/src/test/groovy/io/seqera/wave/service/metric/MetricsCounterStoreRedisTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/metric/MetricsCounterStoreRedisTest.groovy
@@ -40,10 +40,10 @@ class MetricsCounterStoreRedisTest  extends Specification implements RedisTestCo
                 REDIS_PORT: redisPort
         ], 'test', 'redis')
         jedis = new Jedis(redisHostName, redisPort as int)
-        jedis.flushAll()
     }
 
     def cleanup(){
+        jedis.flushAll()
         jedis.close()
     }
     


### PR DESCRIPTION
This PR will do the following
1. add sudo to delete workspace in ci
2. move jedis.flushAll() to cleanup in redis tests