### PR TITLE
Fixes the Community repo name composition when namingStrategy is not specified

### DIFF
--- a/src/main/groovy/io/seqera/wave/controller/ContainerController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ContainerController.groovy
@@ -265,10 +265,10 @@ class ContainerController {
         // ignore everything that's not a public (community) repo
         if( !buildConfig.defaultPublicRepository )
             return repo
-        if( !repo.startsWith(buildConfig.defaultPublicRepository))
+        if( !repo.startsWith(buildConfig.defaultPublicRepository) )
             return repo
 
-        // check if the repository does not ue any reserved word
+        // check if the repository does use any reserved word
         final parts = repo.tokenize('/')
         if( parts.size()>1 && buildConfig.reservedWords ) {
             for( String it : parts[1..-1] ) {
@@ -282,7 +282,7 @@ class ContainerController {
             return repo
         }
         else
-            return repo + (!strategy || strategy==ImageNameStrategy.imageSuffix ? '/library' : '/library/build')
+            return repo + (strategy==ImageNameStrategy.imageSuffix ? '/library' : '/library/build')
     }
 
     BuildRequest makeBuildRequest(SubmitContainerTokenRequest req, PlatformId identity, String ip) {

--- a/src/test/groovy/io/seqera/wave/controller/ContainerControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ContainerControllerTest.groovy
@@ -577,7 +577,7 @@ class ContainerControllerTest extends Specification {
         'foo.com/alpha/beta'| ImageNameStrategy.imageSuffix | 'foo.com'     | 'foo.com/alpha/beta'
         'foo.com/alpha/beta'| ImageNameStrategy.tagPrefix   | 'foo.com'     | 'foo.com/alpha/beta'
         and:
-        'foo.com'           | null                          | 'foo.com'     | 'foo.com/library'
+        'foo.com'           | null                          | 'foo.com'     | 'foo.com/library/build'
         'foo.com'           | ImageNameStrategy.imageSuffix | 'foo.com'     | 'foo.com/library'
         'foo.com'           | ImageNameStrategy.tagPrefix   | 'foo.com'     | 'foo.com/library/build'
         and:


### PR DESCRIPTION
This OR fixes the Community repo name composition when namingStrategy is not specified