### PR TITLE
Fix legacy tower endpoint validation

### DIFF
--- a/src/main/groovy/io/seqera/wave/controller/ContainerController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ContainerController.groovy
@@ -171,14 +171,15 @@ class ContainerController {
     }
 
     protected CompletableFuture<HttpResponse<SubmitContainerTokenResponse>> getContainerImpl(HttpRequest httpRequest, SubmitContainerTokenRequest req, boolean v2) {
+        // patch platform endpoint
+        req.towerEndpoint = patchPlatformEndpoint(req.towerEndpoint)
+
+        // validate request
         validateContainerRequest(req)
 
         // this is needed for backward compatibility with old clients
         if( !req.towerEndpoint ) {
             req.towerEndpoint = towerEndpointUrl
-        }
-        else {
-            req.towerEndpoint = patchPlatformEndpoint(req.towerEndpoint)
         }
 
         // anonymous access

--- a/src/main/groovy/io/seqera/wave/util/ContainerHelper.groovy
+++ b/src/main/groovy/io/seqera/wave/util/ContainerHelper.groovy
@@ -180,6 +180,9 @@ class ContainerHelper {
     }
 
     static String patchPlatformEndpoint(String endpoint) {
+        if( !endpoint )
+            return null
+
         // api.stage-tower.net --> api.cloud.stage-seqera.io
         // api.tower.nf --> api.cloud.seqera.io
         final result = endpoint

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -406,6 +406,7 @@ class ContainerHelperTest extends Specification {
 
         where:
         ENDPOINT                        | EXPECTED
+        null                            | null
         'http://foo.com'                | 'http://foo.com'
         'https://api.tower.nf'          | 'https://api.cloud.seqera.io'
         'https://api.stage-tower.net'   | 'https://api.cloud.stage-seqera.io'


### PR DESCRIPTION
This PR fixes the endpoint validation for the legacy tower.nf hostname 