### PR TITLE
Add homebrew install doc

### DIFF
--- a/docs/cli/install.mdx
+++ b/docs/cli/install.mdx
@@ -5,12 +5,18 @@ title: Install the Wave CLI
 To install the `wave` CLI for your platform, complete the following steps:
 
 1.  Download the [latest version of the Wave CLI][download] for your platform.
+
 2.  In a new terminal, complete the following steps:
 
     1. Move the executable from your downloads folder to a location in your `PATH`, such as `~/bin`. For example: `mv wave-cli-0.8.0-macos-x86_64 ~/bin/wave`
     2. Ensure that the executable bit is set. For example: `chmod u+x ~/bin/wave`
 
-3.  Verify that you can build containers with Wave:
+3. You can also use [Homebrew](https://brew.sh/), you can install like this:
+   ```bash
+   brew install seqeralabs/tap/wave-cli
+   ```
+
+4.  Verify that you can build containers with Wave:
 
     1.  Create a basic `Dockerfile`:
 

--- a/docs/cli/install.mdx
+++ b/docs/cli/install.mdx
@@ -11,7 +11,7 @@ To install the `wave` CLI for your platform, complete the following steps:
     1. Move the executable from your downloads folder to a location in your `PATH`, such as `~/bin`. For example: `mv wave-cli-0.8.0-macos-x86_64 ~/bin/wave`
     2. Ensure that the executable bit is set. For example: `chmod u+x ~/bin/wave`
 
-3. You can also use [Homebrew](https://brew.sh/), you can install like this:
+3. You can also use [Homebrew](https://brew.sh/) in macos and linux, you can install like this:
    ```bash
    brew install seqeralabs/tap/wave-cli
    ```


### PR DESCRIPTION
I have noticed that seqera docs does not mention homebrew option of wave-cli installation. https://docs.seqera.io/wave/cli/install
This PR will add that