### PR TITLE
Update buildlogs aws config to not initialize AwsS3Operations

### DIFF
--- a/src/main/resources/application-buildlogs-aws.yml
+++ b/src/main/resources/application-buildlogs-aws.yml
@@ -1,7 +1,7 @@
 ---
-micronaut:
-  object-storage:
-    aws:
-      build-logs:
-        bucket: "${wave.build.logs.bucket}"
+wave:
+  build:
+    logs:
+      bucket: "seqera-development-wave-store"
+      prefix: 'build-logs'
 ...


### PR DESCRIPTION
This PR will update buildlogs aws config  to not use micronaut default config