### PR TITLE
Enable Cleanup for blob transfer pods

### DIFF
--- a/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
@@ -87,6 +87,9 @@ class BlobCacheConfig {
     @Value('${wave.blobCache.url-signature-duration:30m}')
     Duration urlSignatureDuration
 
+    @Value('${wave.blobCache.k8s.pod.delete.timeout:20s}')
+    Duration podDeleteTimeout
+
     Map<String,String> getEnvironment() {
         final result = new HashMap<String,String>(10)
         if( storageRegion ) {

--- a/src/main/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategy.groovy
+++ b/src/main/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategy.groovy
@@ -27,7 +27,6 @@ import io.seqera.wave.configuration.BlobCacheConfig
 import io.seqera.wave.service.blob.BlobCacheInfo
 import io.seqera.wave.service.blob.TransferStrategy
 import io.seqera.wave.service.k8s.K8sService
-import io.seqera.wave.service.scan.ScanResult
 import jakarta.inject.Inject
 /**
  * Implements {@link TransferStrategy} that runs s5cmd using a

--- a/src/main/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategy.groovy
+++ b/src/main/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategy.groovy
@@ -66,7 +66,7 @@ class KubeTransferStrategy implements TransferStrategy {
         final pod = k8sService.transferContainer(podName, blobConfig.s5Image, command, blobConfig)
         final terminated = k8sService.waitPod(pod, blobConfig.transferTimeout.toMillis())
         final stdout = k8sService.logsPod(podName)
-        final result =  terminated
+        final result = terminated
                 ? info.completed(terminated.exitCode, stdout)
                 : info.failed(stdout)
         if( cleanup.shouldCleanup(terminated.exitCode) ) {

--- a/src/main/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategy.groovy
+++ b/src/main/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategy.groovy
@@ -58,7 +58,7 @@ class KubeTransferStrategy implements TransferStrategy {
                     ? info.completed(terminated.exitCode, stdout)
                     : info.failed(stdout)
         }catch (Exception e){
-            log.error("Error while scanning with id: ${info.locationUri} - cause: ${e.message}", e)
+            log.error("Error while transfer blob with location: ${info.locationUri} - cause: ${e.message}", e)
             return info.failed(e.message)
         }
         finally {

--- a/src/main/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategy.groovy
+++ b/src/main/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategy.groovy
@@ -62,16 +62,16 @@ class KubeTransferStrategy implements TransferStrategy {
 
     @Override
     BlobCacheInfo transfer(BlobCacheInfo info, List<String> command) {
-            final podName = podName(info)
-            final pod = k8sService.transferContainer(podName, blobConfig.s5Image, command, blobConfig)
-            final terminated = k8sService.waitPod(pod, blobConfig.transferTimeout.toMillis())
-            final stdout = k8sService.logsPod(podName)
-            final result =  terminated
-                    ? info.completed(terminated.exitCode, stdout)
-                    : info.failed(stdout)
-            if( cleanup.shouldCleanup(terminated.exitCode) ) {
-                CompletableFuture.supplyAsync (() -> cleanup(podName), executor)
-            }
+        final podName = podName(info)
+        final pod = k8sService.transferContainer(podName, blobConfig.s5Image, command, blobConfig)
+        final terminated = k8sService.waitPod(pod, blobConfig.transferTimeout.toMillis())
+        final stdout = k8sService.logsPod(podName)
+        final result =  terminated
+                ? info.completed(terminated.exitCode, stdout)
+                : info.failed(stdout)
+        if( cleanup.shouldCleanup(terminated.exitCode) ) {
+            CompletableFuture.supplyAsync (() -> cleanup(podName), executor)
+        }
         return result
     }
 

--- a/src/main/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategy.groovy
+++ b/src/main/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategy.groovy
@@ -86,11 +86,11 @@ class KubeTransferStrategy implements TransferStrategy {
 
     void cleanup(String podName) {
         try {
-            if(k8sService.getPod(podName).status.phase == 'Succeeded') {
+            def pod = k8sService.getPod(podName)
+            if(pod.status.phase == 'Succeeded') {
                 k8sService.deletePod(podName)
-            }else if(k8sService.getPod(podName).status.phase == 'Running'){
-                sleep(5000) // sometimes pods is not completed when finally runs so wait for 5 seconds
-                k8sService.deletePod(podName)
+            }else if(pod.status.phase == 'Running'){
+                k8sService.deletePodWhenReachStatus(podName, 'Succeeded', blobConfig.podDeleteTimeout.toMillis())
             }
         }
         catch (Exception e) {

--- a/src/main/groovy/io/seqera/wave/service/k8s/K8sService.groovy
+++ b/src/main/groovy/io/seqera/wave/service/k8s/K8sService.groovy
@@ -54,4 +54,6 @@ interface K8sService {
     V1Pod transferContainer(String name, String containerImage, List<String> args, BlobCacheConfig blobConfig)
 
     V1ContainerStateTerminated waitPod(V1Pod pod, long timeout)
+
+    void deletePodWhenReachStatus(String podName, String statusName, long timeout)
 }

--- a/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
@@ -499,7 +499,7 @@ class K8sServiceImpl implements K8sService {
         final pod = getPod(podName)
         final start = System.currentTimeMillis()
         while( (System.currentTimeMillis() - start) < timeout ) {
-            if( pod && pod.status?.phase == statusName ) {
+            if( pod?.status?.phase == statusName ) {
                 deletePod(podName)
                 return
             }

--- a/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
@@ -487,6 +487,26 @@ class K8sServiceImpl implements K8sService {
                 .deleteNamespacedPod(name, namespace, (String)null, (String)null, (Integer)null, (Boolean)null, (String)null, (V1DeleteOptions)null)
     }
 
+    /**
+     * Delete a pod where the status is reached
+     *
+     * @param name The name of the pod to be deleted
+     * @param statusName The status to be reached
+     * @param timeout The max wait time in milliseconds
+     */
+    @Override
+    void deletePodWhenReachStatus(String podName, String statusName, long timeout){
+        final pod = getPod(podName)
+        final start = System.currentTimeMillis()
+        while( (System.currentTimeMillis() - start) < timeout ) {
+            if( pod && pod.status?.phase == statusName ) {
+                deletePod(podName)
+                return
+            }
+            sleep 5_000
+        }
+    }
+
     @Override
     V1Pod scanContainer(String name, String containerImage, List<String> args, Path workDir, Path creds, ScanConfig scanConfig, Map<String,String> nodeSelector) {
         final spec = scanSpec(name, containerImage, args, workDir, creds, scanConfig, nodeSelector)

--- a/src/test/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategyTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategyTest.groovy
@@ -79,27 +79,4 @@ class KubeTransferStrategyTest extends Specification {
         result.logs == "Transfer timeout"
     }
 
-    def "cleanup should delete completed pod"() {
-        given:
-        def podName = "transfer-unique-hash"
-        k8sService.getPod(podName) >> new V1Pod(status: new V1PodStatus(phase: 'Succeeded'))
-
-        when:
-        strategy.cleanup(podName)
-
-        then:
-        1 * k8sService.deletePod(podName)
-    }
-
-    def "cleanup should not delete Failed pod"() {
-        given:
-        def podName = "transfer-unique-hash"
-        k8sService.getPod(podName) >> new V1Pod(status: new V1PodStatus(phase: 'Failed'))
-
-        when:
-        strategy.cleanup(podName)
-
-        then:
-        0 * k8sService.deletePod(podName)
-    }
 }

--- a/src/test/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategyTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/blob/impl/KubeTransferStrategyTest.groovy
@@ -1,0 +1,115 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.service.blob.impl
+
+import spock.lang.Specification
+
+import java.time.Duration
+
+import io.kubernetes.client.openapi.models.V1ContainerStateTerminated
+import io.kubernetes.client.openapi.models.V1Pod
+import io.kubernetes.client.openapi.models.V1PodStatus
+import io.seqera.wave.configuration.BlobCacheConfig
+import io.seqera.wave.service.blob.BlobCacheInfo
+import io.seqera.wave.service.k8s.K8sService
+/**
+ *
+ * @author Munish Chouhan <munish.chouhan@seqera.io>
+ */
+class KubeTransferStrategyTest extends Specification {
+
+    K8sService k8sService = Mock(K8sService)
+    BlobCacheConfig blobConfig = new BlobCacheConfig(s5Image: 's5cmd', transferTimeout: Duration.ofSeconds(10))
+    KubeTransferStrategy strategy = new KubeTransferStrategy(k8sService: k8sService, blobConfig: blobConfig)
+
+    def "transfer should complete successfully with valid inputs"() {
+        given:
+        def uri = "s3://bucket/file.txt"
+        def info = BlobCacheInfo.create(uri, null, null)
+        def command = ["s5cmd", "cp", uri, "/local/path"]
+        k8sService.transferContainer(_, blobConfig.s5Image, command, blobConfig) >> new V1Pod(status: new V1PodStatus(phase: 'Succeeded'))
+        k8sService.getPod(_) >> new V1Pod(status: new V1PodStatus(phase: 'Succeeded'))
+        k8sService.waitPod(_, _) >> new V1ContainerStateTerminated(exitCode: 0)
+        k8sService.logsPod(_) >> "Transfer completed"
+
+        when:
+        def result = strategy.transfer(info, command)
+
+        then:
+        result.succeeded()
+        result.exitStatus == 0
+        result.logs == "Transfer completed"
+    }
+
+    def "transfer should fail when pod execution exceeds timeout"() {
+        given:
+        def uri = "s3://bucket/file.txt"
+        def info = BlobCacheInfo.create(uri, null, null)
+        def command = ["s5cmd", "cp", uri, "/local/path"]
+        k8sService.transferContainer(_, blobConfig.s5Image, command, blobConfig) >> new V1Pod(status: new V1PodStatus(phase: 'Running'))
+        k8sService.waitPod(_, blobConfig.transferTimeout.toMillis()) >> new V1ContainerStateTerminated(exitCode: 1)
+        k8sService.logsPod(_) >> "Transfer timeout"
+
+        when:
+        def result = strategy.transfer(info, command)
+
+        then:
+        result.failed("Transfer timeout")
+        result.logs == "Transfer timeout"
+    }
+
+    def "transfer should handle exception during transfer process"() {
+        given:
+        def uri = "s3://bucket/file.txt"
+        def info = BlobCacheInfo.create(uri, null, null)
+        def command = ["s5cmd", "cp", uri, "/local/path"]
+        def podName = "transfer-unique-hash"
+        k8sService.transferContainer(podName, blobConfig.s5Image, command, blobConfig) >> { throw new Exception("K8s error") }
+
+        when:
+        def result = strategy.transfer(info, command)
+
+        then:
+        result.failed("Error while scanning with id: s3://bucket/file.txt - cause: K8s error")
+    }
+
+    def "cleanup should delete completed pod"() {
+        given:
+        def podName = "transfer-unique-hash"
+        k8sService.getPod(podName) >> new V1Pod(status: new V1PodStatus(phase: 'Succeeded'))
+
+        when:
+        strategy.cleanup(podName)
+
+        then:
+        1 * k8sService.deletePod(podName)
+    }
+
+    def "cleanup should not delete Failed pod"() {
+        given:
+        def podName = "transfer-unique-hash"
+        k8sService.getPod(podName) >> new V1Pod(status: new V1PodStatus(phase: 'Failed'))
+
+        when:
+        strategy.cleanup(podName)
+
+        then:
+        0 * k8sService.deletePod(podName)
+    }
+}


### PR DESCRIPTION
This PR will add cleanup for completed blob transfer pods

tested in local:
```
(base) munish.chouhan@Munishs-MacBook-Pro ~ % kubectl get pods -n wave-local
NAME                        READY   STATUS    RESTARTS   AGE
transfer-b15025675b65bc93   1/1     Running   0          3s
transfer-d4cdd327859c19ba   1/1     Running   0          3s
transfer-71006a3e573a5c3a   1/1     Running   0          3s
(base) munish.chouhan@Munishs-MacBook-Pro ~ % kubectl get pods -n wave-local
NAME                        READY   STATUS    RESTARTS   AGE
transfer-71006a3e573a5c3a   1/1     Running   0          23s
transfer-1f419113e0d876a9   1/1     Running   0          2s
(base) munish.chouhan@Munishs-MacBook-Pro ~ % kubectl get pods -n wave-local
NAME                        READY   STATUS      RESTARTS   AGE
transfer-71006a3e573a5c3a   0/1     Completed   0          42s
(base) munish.chouhan@Munishs-MacBook-Pro ~ % kubectl get pods -n wave-local
No resources found in wave-local namespace.
```