### PR TITLE
Extend build timeout

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/builder/BuildCacheStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildCacheStore.groovy
@@ -91,7 +91,7 @@ class BuildCacheStore extends AbstractCacheStore<BuildResult> implements BuildSt
     boolean storeIfAbsent(String imageName, BuildResult build) {
         // store up 1.5 time the build timeout to prevent a missed cache
         // update on job termination remains too long in the store
-        final ttl = Duration.ofMillis(Math.round(getTimeout().toMillis() * 1.5f))
+        final ttl = Duration.ofMillis(Math.round(getTimeout().toMillis() * 2.5f))
         return putIfAbsent(imageName, build, ttl)
     }
 
@@ -116,7 +116,7 @@ class BuildCacheStore extends AbstractCacheStore<BuildResult> implements BuildSt
         static BuildResult awaitCompletion(BuildStore store, String imageName, BuildResult current) {
             final beg = System.currentTimeMillis()
             // add 10% delay gap to prevent race condition with timeout expiration
-            final max = (store.timeout.toMillis() * 1.10) as long
+            final max = (store.timeout.toMillis() * 2) as long
             while( true ) {
                 if( current==null ) {
                     return BuildResult.unknown()

--- a/src/main/groovy/io/seqera/wave/service/builder/BuildCacheStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildCacheStore.groovy
@@ -89,8 +89,9 @@ class BuildCacheStore extends AbstractCacheStore<BuildResult> implements BuildSt
 
     @Override
     boolean storeIfAbsent(String imageName, BuildResult build) {
-        // store up 1.5 time the build timeout to prevent a missed cache
+        // store up 2.5 time the build timeout to prevent a missed cache
         // update on job termination remains too long in the store
+        // note: this should be longer than the max await time used in the Waiter#awaitCompletion method
         final ttl = Duration.ofMillis(Math.round(getTimeout().toMillis() * 2.5f))
         return putIfAbsent(imageName, build, ttl)
     }
@@ -115,8 +116,10 @@ class BuildCacheStore extends AbstractCacheStore<BuildResult> implements BuildSt
 
         static BuildResult awaitCompletion(BuildStore store, String imageName, BuildResult current) {
             final beg = System.currentTimeMillis()
-            // add 10% delay gap to prevent race condition with timeout expiration
-            final max = (store.timeout.toMillis() * 2) as long
+            // await nearly double of the build timeout time because the build job
+            // can require additional time, other than the build time, to be scheduled
+            // note: see also #storeIfAbsent method
+            final max = (store.timeout.toMillis() * 2.10) as long
             while( true ) {
                 if( current==null ) {
                     return BuildResult.unknown()

--- a/src/test/groovy/io/seqera/wave/controller/RegistryControllerRedisTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/RegistryControllerRedisTest.groovy
@@ -55,7 +55,7 @@ class RegistryControllerRedisTest extends Specification implements DockerRegistr
         embeddedServer = ApplicationContext.run(EmbeddedServer, [
                 REDIS_HOST   : redisHostName,
                 REDIS_PORT   : redisPort,
-                'wave.build.timeout':'3s',
+                'wave.build.timeout':'2s',
                 'micronaut.server.port': port,
                 'micronaut.http.services.default.url' : "http://localhost:$port".toString(),
         ], 'test', 'h2', 'redis')
@@ -107,7 +107,7 @@ class RegistryControllerRedisTest extends Specification implements DockerRegistr
         response.getContentLength() == 10242
     }
 
-    @Timeout(10)
+    @Timeout(15)
     void 'should render a timeout when build failed'() {
         given:
         HttpClient client = applicationContext.createBean(HttpClient)


### PR DESCRIPTION
This PR mitigates the issue with build timeout when the build cluster in congestioned. 

The overall idea is to double the overall build await the time, so the additional waiting scheduling time is taken into account before erroring the job build. 


This may be a stopgap solution. Another approach to be investigated is to use to extend the `BuildStrategy` to a method to check the current state of the build pod/container. 
 