### PR TITLE
Add delete after finish to blob cache jobs

### DIFF
--- a/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
@@ -90,6 +90,9 @@ class BlobCacheConfig {
     @Value('${wave.blobCache.retryAttempts:3}')
     Integer retryAttempts
 
+    @Value('${wave.blobCache.deleteAfterFinished:10d}')
+    Duration deleteAfterFinished
+
     @Value('${wave.blobCache.k8s.pod.delete.timeout:20s}')
     Duration podDeleteTimeout
 

--- a/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
@@ -90,7 +90,7 @@ class BlobCacheConfig {
     @Value('${wave.blobCache.retryAttempts:3}')
     Integer retryAttempts
 
-    @Value('${wave.blobCache.deleteAfterFinished:10d}')
+    @Value('${wave.blobCache.deleteAfterFinished:7d}')
     Duration deleteAfterFinished
 
     @Value('${wave.blobCache.k8s.pod.delete.timeout:20s}')

--- a/src/main/groovy/io/seqera/wave/service/blob/impl/BlobCacheServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/blob/impl/BlobCacheServiceImpl.groovy
@@ -295,7 +295,7 @@ class BlobCacheServiceImpl implements BlobCacheService {
 
         static BlobCacheInfo awaitCompletion(BlobStore store, String key, BlobCacheInfo current) {
             final beg = System.currentTimeMillis()
-            // set the await timeout nealy double as the blob transfer timeout, this because the
+            // set the await timeout nearly double as the blob transfer timeout, this because the
             // transfer pod can spend `timeout` time in pending status awaiting to be scheduled
             // and the same `timeout` time amount carrying out the transfer (upload) operation
             final max = (store.timeout.toMillis() * 2.10) as long

--- a/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
@@ -612,6 +612,7 @@ class K8sServiceImpl implements K8sService {
         //spec section
         def spec = builder.withNewSpec()
                 .withBackoffLimit(blobConfig.retryAttempts)
+                .withTtlSecondsAfterFinished(blobConfig.deleteAfterFinished.toSeconds() as Integer)
                 .withNewTemplate()
                     .editOrNewSpec()
                     .withServiceAccount(serviceAccount)

--- a/src/test/groovy/io/seqera/wave/service/k8s/K8sServiceImplTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/k8s/K8sServiceImplTest.groovy
@@ -511,6 +511,7 @@ class K8sServiceImplTest extends Specification {
             getTransferTimeout() >> Duration.ofSeconds(20)
             getEnvironment() >> [:]
             getRetryAttempts() >> 5
+            getDeleteAfterFinished() >> Duration.ofDays(10)
         }
 
         when:
@@ -521,6 +522,7 @@ class K8sServiceImplTest extends Specification {
         result.metadata.namespace == 'my-ns'
         and:
         result.spec.backoffLimit == 5
+        result.spec.ttlSecondsAfterFinished == Duration.ofDays(10).seconds as Integer
         and:
         verifyAll(result.spec.template.spec) {
             activeDeadlineSeconds == 20
@@ -551,6 +553,7 @@ class K8sServiceImplTest extends Specification {
             getRequestsCpu() >> '2'
             getRequestsMemory() >> '8Gi'
             getRetryAttempts() >> 3
+            getDeleteAfterFinished() >> Duration.ofDays(1)
         }
 
         when:
@@ -560,6 +563,7 @@ class K8sServiceImplTest extends Specification {
         result.metadata.namespace == 'my-ns'
         and:
         result.spec.backoffLimit == 3
+        result.spec.ttlSecondsAfterFinished == Duration.ofDays(1).seconds as Integer
         and:
         verifyAll(result.spec.template.spec) {
             activeDeadlineSeconds == 20


### PR DESCRIPTION
This PR adds the ability to delete blob cache jobs automatically by using the `ttlSecondsAfterFinished` job spec. 

By default it used 10 days.
