### PR TITLE
Change k8s delete job propogation policy to foreground

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
@@ -675,7 +675,7 @@ class K8sServiceImpl implements K8sService {
     void deleteJob(String name) {
         k8sClient
                 .batchV1Api()
-                .deleteNamespacedJob(name, namespace, null, null, null, null,"Background", null)
+                .deleteNamespacedJob(name, namespace, null, null, null, null,"Foreground", null)
     }
 
 }


### PR DESCRIPTION
This PR will change the propagation policy from background to foreground.
Here is the definition from here https://github.com/kubernetes-client/java/blob/master/kubernetes/docs/V1DeleteOptions.md:

> Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.