### PR TITLE
docs: Update wave rate limits

### DIFF
--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -39,8 +39,8 @@ The following usage limits apply:
   - 25 container builds per day
   - 250 container pulls per hour
 - Seqera Platform authenticated users
-  - 100 container images per hour
-  - 1,000 container images per minute
+  - 100 container builds per hour
+  - 1,000 container pulls per minute
 
 To authenticate with Seqera, define an access token in the `TOWER_ACCESS_TOKEN` environment variable or specify the token with the `--tower-token` CLI argument.
 


### PR DESCRIPTION
Noticed a small issue with the rate limit docs referencing images vs operation 

Note rate limits are mentioned on two pages https://docs.seqera.io/wave/guide#api-limits & https://docs.seqera.io/wave/cli#usage-limits

Could these potentially be consolidated to avoid duplication ? 