### PR TITLE
Update Build containers via Job Manager

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/builder/BuildCacheStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildCacheStore.groovy
@@ -103,7 +103,7 @@ class BuildCacheStore extends AbstractCacheStore<BuildStoreEntry> implements Bui
      */
     private static class Waiter {
 
-        static BuildResult awaitCompletion(BuildCacheStore store, String imageName, BuildResult current) {
+        static BuildResult awaitCompletion(BuildCacheStore store, String imageName, BuildResult result) {
             final await = store.buildConfig.statusDelay
             final beg = System.currentTimeMillis()
             // await nearly double of the build timeout time because the build job
@@ -111,13 +111,13 @@ class BuildCacheStore extends AbstractCacheStore<BuildStoreEntry> implements Bui
             // note: see also #storeIfAbsent method
             final max = store.buildConfig.statusAwaitDuration.toMillis()
             while( true ) {
-                if( current==null ) {
+                if( result==null ) {
                     return BuildResult.unknown()
                 }
 
                 // check is completed
-                if( current.done() ) {
-                    return current
+                if( result.done() ) {
+                    return result
                 }
                 // check if it's timed out
                 final delta = System.currentTimeMillis()-beg
@@ -126,7 +126,7 @@ class BuildCacheStore extends AbstractCacheStore<BuildStoreEntry> implements Bui
                 // sleep a bit
                 Thread.sleep(await.toMillis())
                 // fetch the build status again
-                current = store.getBuild(imageName).result
+                result = store.getBuild(imageName).result
             }
         }
     }

--- a/src/main/groovy/io/seqera/wave/service/builder/BuildCacheStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildCacheStore.groovy
@@ -92,7 +92,7 @@ class BuildCacheStore extends AbstractCacheStore<BuildStoreEntry> implements Bui
 
     @Override
     CompletableFuture<BuildResult> awaitBuild(String imageName) {
-        final result = getBuild(imageName).result
+        final result = getBuild(imageName)?.result
         if( !result )
             return null
         return CompletableFuture<BuildResult>.supplyAsync(() -> Waiter.awaitCompletion(this,imageName,result), ioExecutor)

--- a/src/main/groovy/io/seqera/wave/service/builder/BuildCacheStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildCacheStore.groovy
@@ -54,7 +54,7 @@ class BuildCacheStore extends AbstractCacheStore<BuildStoreEntry> implements Bui
 
     @Override
     protected String getPrefix() {
-        return 'wave-build/v1:'
+        return 'wave-build/v2:'
     }
 
     @Override

--- a/src/main/groovy/io/seqera/wave/service/builder/BuildStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildStore.groovy
@@ -31,12 +31,24 @@ import groovy.transform.CompileStatic
 interface BuildStore {
 
     /**
-     * Retrieve a container image {@link BuildStoreEntry}
+     * Retrieve the build entry {@link BuildStoreEntry} for a given container image name
      *
-     * @param imageName The container image name
-     * @return The corresponding {@link BuildStoreEntry} or {@code null} otherwise
+     * @param imageName
+     *      The container image name
+     * @return
+     *      The corresponding {@link BuildStoreEntry} or {@code null} otherwise
      */
     BuildStoreEntry getBuild(String imageName)
+
+    /**
+     * Retrieve the build entry {@link BuildResult} for a given container image name
+     *
+     * @param imageName
+     *      The container image name
+     * @return
+     *      The corresponding {@link BuildStoreEntry} or {@code null} otherwise
+     */
+    BuildResult getBuildResult(String imageName)
 
     /**
      * Store a container image build request

--- a/src/main/groovy/io/seqera/wave/service/builder/BuildStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildStore.groovy
@@ -31,38 +31,38 @@ import groovy.transform.CompileStatic
 interface BuildStore {
 
     /**
-     * Retrieve a container image {@link BuildResult}
+     * Retrieve a container image {@link BuildStoreEntry}
      *
      * @param imageName The container image name
-     * @return The corresponding {@link BuildResult} or {@code null} otherwise
+     * @return The corresponding {@link BuildStoreEntry} or {@code null} otherwise
      */
-    BuildResult getBuild(String imageName)
+    BuildStoreEntry getBuild(String imageName)
 
     /**
      * Store a container image build request
      *
      * @param imageName The container image name
-     * @param request The {@link BuildResult} object associated to the image name
+     * @param request The {@link BuildStoreEntry} object associated to the image name
      */
-    void storeBuild(String imageName, BuildResult result)
+    void storeBuild(String imageName, BuildStoreEntry result)
 
     /**
      * Store a container image build request using the specified time-to-live duration
      *
      * @param imageName The container image name
-     * @param result The {@link BuildResult} object associated to the image name
+     * @param result The {@link BuildStoreEntry} object associated to the image name
      * @param ttl The {@link Duration} after which the entry is expired
      */
-    void storeBuild(String imageName, BuildResult result, Duration ttl)
+    void storeBuild(String imageName, BuildStoreEntry result, Duration ttl)
 
     /**
      * Store a build result only if the specified key does not exit
      *
      * @param imageName The container image unique key
-     * @param build The {@link BuildResult} desired status to be stored
-     * @return {@code true} if the {@link BuildResult} was stored, {@code false} otherwise
+     * @param build The {@link BuildStoreEntry} desired status to be stored
+     * @return {@code true} if the {@link BuildStoreEntry} was stored, {@code false} otherwise
      */
-    boolean storeIfAbsent(String imageName, BuildResult build)
+    boolean storeIfAbsent(String imageName, BuildStoreEntry build)
 
     /**
      * Remove the build status for the given image name

--- a/src/main/groovy/io/seqera/wave/service/builder/BuildStoreEntry.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildStoreEntry.groovy
@@ -1,0 +1,39 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.service.builder
+/**
+ * Class to store build request and result in cache
+ *
+ * @author Munish Chouhan <munish.chouhan@seqera.io>
+ */
+class BuildStoreEntry {
+
+    final BuildRequest request
+
+    final BuildResult result
+
+    BuildStoreEntry(BuildRequest request, BuildResult result) {
+        this.request = request
+        this.result = result
+    }
+
+    BuildStoreEntry withBuildResult(BuildResult result) {
+        new BuildStoreEntry(request, result)
+    }
+}

--- a/src/main/groovy/io/seqera/wave/service/builder/BuildStoreEntry.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildStoreEntry.groovy
@@ -17,11 +17,19 @@
  */
 
 package io.seqera.wave.service.builder
+
+import groovy.transform.CompileStatic
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+
 /**
  * Class to store build request and result in cache
  *
  * @author Munish Chouhan <munish.chouhan@seqera.io>
  */
+@ToString(includePackage = false, includeNames = true)
+@EqualsAndHashCode
+@CompileStatic
 class BuildStoreEntry {
 
     final BuildRequest request

--- a/src/main/groovy/io/seqera/wave/service/builder/BuildStoreEntry.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildStoreEntry.groovy
@@ -43,7 +43,7 @@ class BuildStoreEntry {
         this.result = result
     }
 
-    BuildStoreEntry withBuildResult(BuildResult result) {
+    BuildStoreEntry withResult(BuildResult result) {
         new BuildStoreEntry(request, result)
     }
 }

--- a/src/main/groovy/io/seqera/wave/service/builder/BuildStoreEntry.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/BuildStoreEntry.groovy
@@ -36,6 +36,8 @@ class BuildStoreEntry {
 
     final BuildResult result
 
+    protected BuildStoreEntry() {}
+
     BuildStoreEntry(BuildRequest request, BuildResult result) {
         this.request = request
         this.result = result

--- a/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
@@ -214,7 +214,7 @@ class ContainerBuildServiceImpl implements ContainerBuildService, JobHandler {
         catch (Throwable e) {
             log.error "== Ouch! Unable to build container req=$req", e
             final result = BuildResult.failed(req.buildId, e.message, req.startTime)
-            buildStore.storeBuild(req.targetImage, result, buildConfig.failureDuration)
+            buildStore.storeBuild(req.targetImage, new BuildStoreEntry(req, result), buildConfig.failureDuration)
             return null
         }
     }
@@ -249,7 +249,7 @@ class ContainerBuildServiceImpl implements ContainerBuildService, JobHandler {
         // try to store a new build status for the given target image
         // this returns true if and only if such container image was not set yet
         final ret1 = BuildResult.create(request)
-        if( buildStore.storeIfAbsent(request.targetImage, ret1) ) {
+        if( buildStore.storeIfAbsent(request.targetImage, new BuildStoreEntry(request, ret1)) ) {
             // go ahead
             log.info "== Submit build request: $request"
             launchAsync(request)
@@ -257,7 +257,7 @@ class ContainerBuildServiceImpl implements ContainerBuildService, JobHandler {
         }
         // since it was unable to initialise the build result status
         // this means the build status already exists, retrieve it
-        final ret2 = buildStore.getBuild(request.targetImage)
+        final ret2 = buildStore.getBuild(request.targetImage).result
         if( ret2 ) {
             log.info "== Hit build cache for request: $request"
             // note: mark as cached only if the build result is 'done'
@@ -345,26 +345,26 @@ class ContainerBuildServiceImpl implements ContainerBuildService, JobHandler {
             log.error "Build result unknown for job=${event.job.id}; event=${event}"
             return
         }
-        if( build.done() ) {
+        if( build.result.done() ) {
             log.warn "Build result already marked as completed for job=${event.job.id}; event=${event}"
             return
         }
 
         if( event.type == JobEvent.Type.Complete ) {
-            handleJobCompletion(event.job as BuildJobSpec, event.state)
+            handleJobCompletion(build, event.job as BuildJobSpec, event.state)
         }
         else if( event.type == JobEvent.Type.Error ) {
-          handleJobException(event.job as BuildJobSpec, event.error)
+          handleJobException(build, event.job as BuildJobSpec, event.error)
         }
         else if( event.type == JobEvent.Type.Timeout ) {
-            handleJobTimeout(event.job as BuildJobSpec)
+            handleJobTimeout(build, event.job as BuildJobSpec)
         }
         else {
             throw new IllegalStateException("Unknown container build job event type=$event")
         }
     }
 
-    protected void handleJobCompletion(BuildJobSpec job, JobState state) {
+    protected void handleJobCompletion(BuildStoreEntry build, BuildJobSpec job, JobState state) {
         final buildId = job.buildId
         final identity = job.identity
         final digest = state.succeeded()
@@ -378,23 +378,23 @@ class ContainerBuildServiceImpl implements ContainerBuildService, JobHandler {
                 : buildConfig.failureDuration
         // update build status store
         final result = state.completed()
-                ? BuildResult.completed(buildId, state.exitCode!=null ? state.exitCode : -1, state.stdout, job.request.startTime, digest)
-                : BuildResult.failed(buildId, state.stdout, job.request.startTime)
-        buildStore.storeBuild(job.id, result, ttl)
+                ? BuildResult.completed(buildId, state.exitCode!=null ? state.exitCode : -1, state.stdout, job.creationTime, digest)
+                : BuildResult.failed(buildId, state.stdout, job.creationTime)
+        buildStore.storeBuild(job.id, build.withBuildResult(result), ttl)
         // finally notify completion
-        eventPublisher.publishEvent(new BuildEvent(job.request, result))
+        eventPublisher.publishEvent(new BuildEvent(build.request, result))
     }
 
-    protected void handleJobException(BuildJobSpec job, Throwable error) {
-        final result= BuildResult.failed(job.buildId as String, error.message, job.request.startTime)
+    protected void handleJobException(BuildStoreEntry build, BuildJobSpec job, Throwable error) {
+        final result= BuildResult.failed(job.buildId as String, error.message, job.creationTime)
         log.error("Unable to build container image '${job.id}'; job name=${job.schedulerId}; cause=${error.message}", error)
-        buildStore.storeBuild(job.id, result, buildConfig.failureDuration)
+        buildStore.storeBuild(job.id, build.withBuildResult(result), buildConfig.failureDuration)
     }
 
-    protected void handleJobTimeout(BuildJobSpec job) {
-        final result= BuildResult.failed(job.buildId, "Container image build timed out '${job.buildId}'", job.request.startTime)
+    protected void handleJobTimeout(BuildStoreEntry build, BuildJobSpec job) {
+        final result= BuildResult.failed(job.buildId, "Container image build timed out '${job.buildId}'", job.creationTime)
         log.warn "== Blob cache completed for object '${job.buildId}'; job name=${job.schedulerId}; duration=${result.duration}"
-        buildStore.storeBuild(job.id, result, buildConfig.failureDuration)
+        buildStore.storeBuild(job.id, build.withBuildResult(result), buildConfig.failureDuration)
     }
 
     // **************************************************************

--- a/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
@@ -365,10 +365,11 @@ class ContainerBuildServiceImpl implements ContainerBuildService, JobHandler {
     }
 
     protected void handleJobCompletion(BuildStoreEntry build, BuildJobSpec job, JobState state) {
-        final buildId = job.buildId
-        final identity = job.identity
+        final buildId = build.request.buildId
+        final identity = build.request.identity
+        final targetImage = build.request.targetImage
         final digest = state.succeeded()
-                        ? proxyService.getImageDigest(job.id, identity, true)
+                        ? proxyService.getImageDigest(targetImage, identity, true)
                         : null
         // use a short time-to-live for failed build
         // this is needed to allow re-try builds failed for

--- a/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
@@ -257,7 +257,7 @@ class ContainerBuildServiceImpl implements ContainerBuildService, JobHandler {
         }
         // since it was unable to initialise the build result status
         // this means the build status already exists, retrieve it
-        final ret2 = buildStore.getBuild(request.targetImage).result
+        final ret2 = buildStore.getBuildResult(request.targetImage)
         if( ret2 ) {
             log.info "== Hit build cache for request: $request"
             // note: mark as cached only if the build result is 'done'

--- a/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
@@ -381,7 +381,7 @@ class ContainerBuildServiceImpl implements ContainerBuildService, JobHandler {
         final result = state.completed()
                 ? BuildResult.completed(buildId, state.exitCode!=null ? state.exitCode : -1, state.stdout, job.creationTime, digest)
                 : BuildResult.failed(buildId, state.stdout, job.creationTime)
-        buildStore.storeBuild(job.id, build.withBuildResult(result), ttl)
+        buildStore.storeBuild(job.id, build.withResult(result), ttl)
         // finally notify completion
         eventPublisher.publishEvent(new BuildEvent(build.request, result))
     }
@@ -389,14 +389,14 @@ class ContainerBuildServiceImpl implements ContainerBuildService, JobHandler {
     protected void handleJobException(BuildJobSpec job, BuildStoreEntry build, Throwable error) {
         final result= BuildResult.failed(build.request.buildId, error.message, job.creationTime)
         log.error("Unable to build container image '${job.id}'; job name=${job.schedulerId}; cause=${error.message}", error)
-        buildStore.storeBuild(job.id, build.withBuildResult(result), buildConfig.failureDuration)
+        buildStore.storeBuild(job.id, build.withResult(result), buildConfig.failureDuration)
     }
 
     protected void handleJobTimeout(BuildJobSpec job, BuildStoreEntry build) {
         final buildId = build.request.buildId
         final result= BuildResult.failed(buildId, "Container image build timed out '${buildId}'", job.creationTime)
         log.warn "== Blob cache completed for object '${buildId}'; job name=${job.schedulerId}; duration=${result.duration}"
-        buildStore.storeBuild(job.id, build.withBuildResult(result), buildConfig.failureDuration)
+        buildStore.storeBuild(job.id, build.withResult(result), buildConfig.failureDuration)
     }
 
     // **************************************************************

--- a/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/ContainerBuildServiceImpl.groovy
@@ -387,14 +387,15 @@ class ContainerBuildServiceImpl implements ContainerBuildService, JobHandler {
     }
 
     protected void handleJobException(BuildStoreEntry build, BuildJobSpec job, Throwable error) {
-        final result= BuildResult.failed(job.buildId as String, error.message, job.creationTime)
+        final result= BuildResult.failed(build.request.buildId, error.message, job.creationTime)
         log.error("Unable to build container image '${job.id}'; job name=${job.schedulerId}; cause=${error.message}", error)
         buildStore.storeBuild(job.id, build.withBuildResult(result), buildConfig.failureDuration)
     }
 
     protected void handleJobTimeout(BuildStoreEntry build, BuildJobSpec job) {
-        final result= BuildResult.failed(job.buildId, "Container image build timed out '${job.buildId}'", job.creationTime)
-        log.warn "== Blob cache completed for object '${job.buildId}'; job name=${job.schedulerId}; duration=${result.duration}"
+        final buildId = build.request.buildId
+        final result= BuildResult.failed(buildId, "Container image build timed out '${buildId}'", job.creationTime)
+        log.warn "== Blob cache completed for object '${buildId}'; job name=${job.schedulerId}; duration=${result.duration}"
         buildStore.storeBuild(job.id, build.withBuildResult(result), buildConfig.failureDuration)
     }
 

--- a/src/main/groovy/io/seqera/wave/service/job/JobFactory.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobFactory.groovy
@@ -58,7 +58,6 @@ class JobFactory {
                 request.startTime,
                 request.maxDuration,
                 "build-" + request.buildId.replace('_', '-'),
-                request.buildId,
                 request.targetImage,
                 request.workDir
         )

--- a/src/main/groovy/io/seqera/wave/service/job/JobFactory.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobFactory.groovy
@@ -60,7 +60,6 @@ class JobFactory {
                 "build-" + request.buildId.replace('_', '-'),
                 request.buildId,
                 request.targetImage,
-                request.identity,
                 request.workDir
         )
     }

--- a/src/main/groovy/io/seqera/wave/service/job/JobFactory.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobFactory.groovy
@@ -53,7 +53,16 @@ class JobFactory {
     }
 
     BuildJobSpec build(BuildRequest request) {
-        return new BuildJobSpec(request)
+        return new BuildJobSpec(
+                request.targetImage,
+                request.startTime,
+                request.maxDuration,
+                "build-" + request.buildId.replace('_', '-'),
+                request.buildId,
+                request.targetImage,
+                request.identity,
+                request.workDir
+        )
     }
 
     static private String generate(String type, String id, Instant creationTime) {

--- a/src/main/groovy/io/seqera/wave/service/job/spec/BuildJobSpec.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/spec/BuildJobSpec.groovy
@@ -24,10 +24,8 @@ import java.time.Instant
 
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
-import io.seqera.wave.service.job.JobSpec
 import io.seqera.wave.service.job.CleanableAware
-import io.seqera.wave.tower.PlatformId
-
+import io.seqera.wave.service.job.JobSpec
 /**
  * JobSpec implementation or container builds
  *
@@ -42,7 +40,6 @@ class BuildJobSpec implements JobSpec, CleanableAware {
     final String schedulerId
     final String buildId
     final String targetImage
-    final PlatformId identity
     final Path cleanableDir
 
     Type getType() { Type.Build }

--- a/src/main/groovy/io/seqera/wave/service/job/spec/BuildJobSpec.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/spec/BuildJobSpec.groovy
@@ -38,7 +38,6 @@ class BuildJobSpec implements JobSpec, CleanableAware {
     final Instant creationTime
     final Duration maxDuration
     final String schedulerId
-    final String buildId
     final String targetImage
     final Path cleanableDir
 

--- a/src/main/groovy/io/seqera/wave/service/job/spec/BuildJobSpec.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/spec/BuildJobSpec.groovy
@@ -24,7 +24,6 @@ import java.time.Instant
 
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
-import io.seqera.wave.service.builder.BuildRequest
 import io.seqera.wave.service.job.JobSpec
 import io.seqera.wave.service.job.CleanableAware
 import io.seqera.wave.tower.PlatformId
@@ -37,46 +36,15 @@ import io.seqera.wave.tower.PlatformId
 @Canonical
 @CompileStatic
 class BuildJobSpec implements JobSpec, CleanableAware {
+    final String id
+    final Instant creationTime
+    final Duration maxDuration
+    final String schedulerId
+    final String buildId
+    final String targetImage
+    final PlatformId identity
+    final Path cleanableDir
 
-    final BuildRequest request
+    Type getType() { Type.Build }
 
-    Type getType() {
-        return Type.Build
-    }
-
-    @Override
-    String getId() {
-        return request.getTargetImage()
-    }
-
-    @Override
-    Instant getCreationTime() {
-        return request.getStartTime()
-    }
-
-    @Override
-    Duration getMaxDuration() {
-        return request.getMaxDuration()
-    }
-
-    @Override
-    String getSchedulerId() {
-        return "build-" + request.buildId.replace('_', '-')
-    }
-
-    String getBuildId() {
-        return request.buildId
-    }
-
-    String getTargetImage() {
-        return request.getTargetImage()
-    }
-
-    PlatformId getIdentity() {
-        return request.getIdentity()
-    }
-
-    Path getCleanableDir() {
-        return request.getWorkDir()
-    }
 }

--- a/src/test/groovy/io/seqera/wave/controller/RegistryControllerRedisTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/RegistryControllerRedisTest.groovy
@@ -63,10 +63,10 @@ class RegistryControllerRedisTest extends Specification implements DockerRegistr
 
         jedis = new Jedis(redisHostName, redisPort as int)
         initRegistryContainer(applicationContext)
+        jedis.flushAll()
     }
 
     def cleanup(){
-        jedis.flushAll()
         jedis.close()
     }
 

--- a/src/test/groovy/io/seqera/wave/controller/RegistryControllerRedisTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/RegistryControllerRedisTest.groovy
@@ -114,7 +114,7 @@ class RegistryControllerRedisTest extends Specification implements DockerRegistr
         HttpClient client = applicationContext.createBean(HttpClient)
         and:
         jedis.set("wave-tokens/v1:1234", '{"containerImage":"library/hello-world"}')
-        jedis.set("wave-build/v1:library/hello-world", '{"containerImage":"library/hello-world"}')
+        jedis.set("wave-build/v1:library/hello-world", '{"request":{"buildId":"1234","containerImage":"library/hello-world","startTime":"2021-09-29T15:00:00Z"},"result":{"containerImage":"library/hello-world","id":"1234","exitStatus":1}}')
         when:
         HttpRequest request = HttpRequest.GET("http://localhost:$port/v2/wt/1234/library/hello-world/manifests/latest").headers({h->
             h.add('Accept', ContentType.DOCKER_MANIFEST_V2_TYPE)

--- a/src/test/groovy/io/seqera/wave/controller/RegistryControllerRedisTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/RegistryControllerRedisTest.groovy
@@ -114,7 +114,7 @@ class RegistryControllerRedisTest extends Specification implements DockerRegistr
         HttpClient client = applicationContext.createBean(HttpClient)
         and:
         jedis.set("wave-tokens/v1:1234", '{"containerImage":"library/hello-world"}')
-        jedis.set("wave-build/v1:library/hello-world", '{"request":{"buildId":"1234","containerImage":"library/hello-world","startTime":"2021-09-29T15:00:00Z"},"result":{"containerImage":"library/hello-world","id":"1234","exitStatus":1}}')
+        jedis.set("wave-build/v2:library/hello-world", '{"request":{"buildId":"1234","containerImage":"library/hello-world","startTime":"2021-09-29T15:00:00Z"},"result":{"containerImage":"library/hello-world","id":"1234","exitStatus":1}}')
         when:
         HttpRequest request = HttpRequest.GET("http://localhost:$port/v2/wt/1234/library/hello-world/manifests/latest").headers({h->
             h.add('Accept', ContentType.DOCKER_MANIFEST_V2_TYPE)

--- a/src/test/groovy/io/seqera/wave/encoder/MoshiEncodingStrategyTest.groovy
+++ b/src/test/groovy/io/seqera/wave/encoder/MoshiEncodingStrategyTest.groovy
@@ -438,6 +438,7 @@ class MoshiEncodingStrategyTest extends Specification {
                 scanId: 'scan12345',
                 buildContext: context )
                 .withBuildId('1')
+        and:
         def entry = new BuildStoreEntry(req, res)
         when:
         def json = encoder.encode(entry)

--- a/src/test/groovy/io/seqera/wave/encoder/MoshiEncodingStrategyTest.groovy
+++ b/src/test/groovy/io/seqera/wave/encoder/MoshiEncodingStrategyTest.groovy
@@ -26,7 +26,6 @@ import java.time.Instant
 
 import io.seqera.wave.api.BuildContext
 import io.seqera.wave.api.ContainerConfig
-import io.seqera.wave.api.SubmitContainerTokenRequest
 import io.seqera.wave.auth.RegistryAuth
 import io.seqera.wave.core.ContainerPlatform
 import io.seqera.wave.service.ContainerRequestData
@@ -396,17 +395,14 @@ class MoshiEncodingStrategyTest extends Specification {
         given:
         def encoder = new MoshiEncodeStrategy<JobSpec>() { }
         and:
-        def id = PlatformId.of(new User(id: 1), Mock(SubmitContainerTokenRequest))
         def ts = Instant.parse('2024-08-18T19:23:33.650722Z')
         and:
         def build = new BuildJobSpec(
                 'docker.io/foo:bar',
                 ts,
                 Duration.ofMinutes(1),
-                'build-12345-1',
                 '12345',
                 'docker.io/foo:bar',
-                id,
                 Path.of('/some/path')
         )
 

--- a/src/test/groovy/io/seqera/wave/encoder/MoshiEncodingStrategyTest.groovy
+++ b/src/test/groovy/io/seqera/wave/encoder/MoshiEncodingStrategyTest.groovy
@@ -398,15 +398,16 @@ class MoshiEncodingStrategyTest extends Specification {
         def id = PlatformId.of(new User(id: 1), Mock(SubmitContainerTokenRequest))
         def ts = Instant.parse('2024-08-18T19:23:33.650722Z')
         and:
-        def request = new BuildRequest(
-                targetImage: 'docker.io/foo:bar',
-                buildId: '12345',
-                startTime: ts,
-                maxDuration: Duration.ofMinutes(1),
-                identity: id
+        def build = new BuildJobSpec(
+                'docker.io/foo:bar',
+                ts,
+                Duration.ofMinutes(1),
+                'build-12345-1',
+                '12345',
+                'docker.io/foo:bar',
+                id,
+                Path.of('/some/path')
         )
-        and:
-        def build = new BuildJobSpec(request)
 
         when:
         def json = encoder.encode(build)

--- a/src/test/groovy/io/seqera/wave/service/builder/BuildCacheStoreLocalTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/BuildCacheStoreLocalTest.groovy
@@ -45,10 +45,40 @@ class BuildCacheStoreLocalTest extends Specification {
     @Named(TaskExecutors.IO)
     ExecutorService ioExecutor
 
-    BuildResult zero = BuildResult.create('0')
-    BuildResult one = BuildResult.completed('1', 0, 'done', Instant.now(), 'abc')
-    BuildResult two = BuildResult.completed('2', 0, 'done', Instant.now(), 'abc')
-    BuildResult three = BuildResult.completed('3', 0, 'done', Instant.now(), 'abc')
+    BuildResult zeroResult = BuildResult.create('0')
+    BuildResult oneResult = BuildResult.completed('1', 0, 'done', Instant.now(), 'abc')
+    BuildResult twoResult = BuildResult.completed('2', 0, 'done', Instant.now(), 'abc')
+    BuildResult threeResult = BuildResult.completed('3', 0, 'done', Instant.now(), 'abc')
+
+    def zeroRequest = new BuildRequest(
+            targetImage: 'docker.io/foo:0',
+            buildId: '0',
+            startTime: Instant.now(),
+            maxDuration: Duration.ofMinutes(1)
+    )
+    def oneRequest = new BuildRequest(
+            targetImage: 'docker.io/foo:1',
+            buildId: '1',
+            startTime: Instant.now(),
+            maxDuration: Duration.ofMinutes(1)
+    )
+    def twoRequest = new BuildRequest(
+            targetImage: 'docker.io/foo:2',
+            buildId: '2',
+            startTime: Instant.now(),
+            maxDuration: Duration.ofMinutes(1)
+    )
+    def threeRequest = new BuildRequest(
+            targetImage: 'docker.io/foo:3',
+            buildId: '3',
+            startTime: Instant.now(),
+            maxDuration: Duration.ofMinutes(1)
+    )
+
+    def zero = new BuildStoreEntry(zeroRequest, zeroResult)
+    def one = new BuildStoreEntry(oneRequest, oneResult)
+    def two = new BuildStoreEntry(twoRequest, twoResult)
+    def three = new BuildStoreEntry(threeRequest, threeResult)
 
     def 'should get and put key values' () {
         given:
@@ -145,14 +175,13 @@ class BuildCacheStoreLocalTest extends Specification {
         // stops until the value is updated
         def result = cache.awaitBuild('foo')
         then:
-        result.get() == one
+        result.get() == one.result
 
         when:
         cache.storeBuild('foo',two)
         cache.storeBuild('foo',three)
         then:
-        cache.awaitBuild('foo').get()==three
-
+        cache.awaitBuild('foo').get() == three.result
     }
 
 }

--- a/src/test/groovy/io/seqera/wave/service/builder/BuildCacheStoreRedisTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/BuildCacheStoreRedisTest.groovy
@@ -195,7 +195,7 @@ class BuildCacheStoreRedisTest extends Specification implements RedisTestContain
         // update a value in a separate thread
         Thread.start {
             res = BuildResult.completed('1', 0, '', Instant.now(), null)
-            entry = entry.withBuildResult(res)
+            entry = entry.withResult(res)
             cacheStore.storeBuild('foo', entry)
         }
 

--- a/src/test/groovy/io/seqera/wave/service/builder/BuildCacheStoreRedisTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/BuildCacheStoreRedisTest.groovy
@@ -55,7 +55,14 @@ class BuildCacheStoreRedisTest extends Specification implements RedisTestContain
 
     def 'should get and put key values' () {
         given:
-        def req1 = BuildResult.create('1')
+        def res = BuildResult.create('1')
+        def req = new BuildRequest(
+                targetImage: 'docker.io/foo:0',
+                buildId: '1',
+                startTime: Instant.now(),
+                maxDuration: Duration.ofMinutes(1)
+        )
+        def entry = new BuildStoreEntry(req, res)
         and:
         def cacheStore = applicationContext.getBean(BuildStore)
         
@@ -63,9 +70,9 @@ class BuildCacheStoreRedisTest extends Specification implements RedisTestContain
         cacheStore.getBuild('foo') == null
 
         when:
-        cacheStore.storeBuild('foo', req1)
+        cacheStore.storeBuild('foo', entry)
         then:
-        cacheStore.getBuild('foo') == req1
+        cacheStore.getBuild('foo') == entry
         and:
         jedis.get("wave-build:foo").toString()
 
@@ -73,7 +80,14 @@ class BuildCacheStoreRedisTest extends Specification implements RedisTestContain
 
     def 'should expire entry' () {
         given:
-        def req1 = BuildResult.create('1')
+        def res = BuildResult.create('1')
+        def req = new BuildRequest(
+                targetImage: 'docker.io/foo:0',
+                buildId: '1',
+                startTime: Instant.now(),
+                maxDuration: Duration.ofMinutes(1)
+        )
+        def entry = new BuildStoreEntry(req, res)
         and:
         def cacheStore = applicationContext.getBean(BuildStore)
 
@@ -81,20 +95,20 @@ class BuildCacheStoreRedisTest extends Specification implements RedisTestContain
         cacheStore.getBuild('foo') == null
 
         when:
-        cacheStore.storeBuild('foo', req1)
+        cacheStore.storeBuild('foo', entry)
         then:
-        cacheStore.getBuild('foo') == req1
+        cacheStore.getBuild('foo') == entry
         and:
         sleep 1000
-        cacheStore.getBuild('foo') == req1
+        cacheStore.getBuild('foo') == entry
 
         when:
-        cacheStore.storeBuild('foo', req1, Duration.ofSeconds(1))
+        cacheStore.storeBuild('foo', entry, Duration.ofSeconds(1))
         then:
-        cacheStore.getBuild('foo') == req1
+        cacheStore.getBuild('foo') == entry
         and:
         sleep 500
-        cacheStore.getBuild('foo') == req1
+        cacheStore.getBuild('foo') == entry
         and:
         sleep 1_500
         cacheStore.getBuild('foo') == null
@@ -102,35 +116,56 @@ class BuildCacheStoreRedisTest extends Specification implements RedisTestContain
 
     def 'should store if absent' () {
         given:
-        def req1 = BuildResult.create('1')
-        def req2 = BuildResult.create('2')
+        def res1 = BuildResult.create('1')
+        def req1 = new BuildRequest(
+                targetImage: 'docker.io/foo:1',
+                buildId: '1',
+                startTime: Instant.now(),
+                maxDuration: Duration.ofMinutes(1)
+        )
+        def entry1 = new BuildStoreEntry(req1, res1)
+        def res2 = BuildResult.create('2')
+        def req2 = new BuildRequest(
+                targetImage: 'docker.io/foo:2',
+                buildId: '2',
+                startTime: Instant.now(),
+                maxDuration: Duration.ofMinutes(1)
+        )
+        def entry2 = new BuildStoreEntry(req2, res2)
         and:
         def store = applicationContext.getBean(BuildStore)
 
         expect:
         // the value is store because the key does not exists
-        store.storeIfAbsent('foo', req1)
+        store.storeIfAbsent('foo', entry1)
         and:
         // the value is return
-        store.getBuild('foo') == req1
+        store.getBuild('foo') == entry1
         and:
         // storing a new value fails because the key already exist
-        !store.storeIfAbsent('foo', req2)
+        !store.storeIfAbsent('foo', entry2)
         and:
         // the previous value is returned
-        store.getBuild('foo') == req1
+        store.getBuild('foo') == entry1
 
     }
 
     def 'should remove a build entry' () {
         given:
-        def zero = BuildResult.create('1')
+        def res = BuildResult.create('0')
+        def req = new BuildRequest(
+                targetImage: 'docker.io/foo:0',
+                buildId: '0',
+                startTime: Instant.now(),
+                maxDuration: Duration.ofMinutes(1)
+        )
+        def entry = new BuildStoreEntry(req, res)
         def cache = applicationContext.getBean(BuildStore)
 
         when:
-        cache.storeBuild('foo', zero)
+        cache.storeBuild('foo', entry)
         then:
-        cache.getBuild('foo') == zero
+        cache.getBuild('foo') == entry
 
         when:
         cache.removeBuild('foo')
@@ -142,18 +177,26 @@ class BuildCacheStoreRedisTest extends Specification implements RedisTestContain
     @Timeout(value=10)
     def 'should await for a value' () {
         given:
-        def req1 = BuildResult.create('1')
+        def res = BuildResult.create('1')
+        def req = new BuildRequest(
+                targetImage: 'docker.io/foo:1',
+                buildId: '1',
+                startTime: Instant.now(),
+                maxDuration: Duration.ofSeconds(10)
+        )
+        def entry = new BuildStoreEntry(req, res)
         and:
         def cacheStore = applicationContext.getBean(BuildStore) as BuildStore
 
         when:
         // insert a value
-        cacheStore.storeBuild('foo', req1)
+        cacheStore.storeBuild('foo', entry)
 
         // update a value in a separate thread
         Thread.start {
-            req1 = BuildResult.completed('1', 0, '', Instant.now(), null)
-            cacheStore.storeBuild('foo',req1)
+            res = BuildResult.completed('1', 0, '', Instant.now(), null)
+            entry = entry.withBuildResult(res)
+            cacheStore.storeBuild('foo', entry)
         }
 
         // wait the value is updated
@@ -161,17 +204,24 @@ class BuildCacheStoreRedisTest extends Specification implements RedisTestContain
         def result = cacheStore.awaitBuild('foo')
 
         then:
-        result.get() == req1
+        result.get() == entry.result
     }
 
     @Timeout(value=30)
     def 'should abort an await if build never finish' () {
         given:
-        def req1 = BuildResult.create('1')
+        def res = BuildResult.create('1')
+        def req = new BuildRequest(
+                targetImage: 'docker.io/foo:1',
+                buildId: '1',
+                startTime: Instant.now(),
+                maxDuration: Duration.ofMinutes(1)
+        )
+        def entry = new BuildStoreEntry(req, res)
         and:
         def cacheStore = applicationContext.getBean(BuildStore) as BuildStore
         // insert a value
-        cacheStore.storeBuild('foo', req1)
+        cacheStore.storeBuild('foo', entry)
 
         when: "wait for an update never will arrive"
         cacheStore.awaitBuild('foo').get()

--- a/src/test/groovy/io/seqera/wave/service/builder/FutureContainerBuildServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/FutureContainerBuildServiceTest.groovy
@@ -49,11 +49,12 @@ class FutureContainerBuildServiceTest extends Specification {
         def containerId = ContainerHelper.makeContainerId(dockerfile, null, null, ContainerPlatform.of('amd64'), buildRepo, null)
         def targetImage = ContainerHelper.makeTargetImage(BuildFormat.DOCKER, buildRepo, containerId, null, null, null)
         def req = new BuildRequest(containerId, dockerfile, null, null, folder, targetImage, Mock(PlatformId), ContainerPlatform.of('amd64'), cacheRepo, "10.20.30.40", '{"config":"json"}', null,null , null, null, BuildFormat.DOCKER, Duration.ofMinutes(1)).withBuildId('1')
+        def res = new BuildResult("", 0, "a fake build result in a test", Instant.now(), Duration.ofSeconds(3), 'abc')
         and:
         def buildStore = Mock(BuildStore)
         def buildCounter = Mock(BuildCounterStore)
-        buildStore.getBuild(targetImage) >> new BuildResult("", 0, "a fake build result in a test", Instant.now(), Duration.ofSeconds(3), 'abc')
-        buildStore.awaitBuild(targetImage) >> CompletableFuture.completedFuture(new BuildResult("", 0, "a fake build result in a test", Instant.now(), Duration.ofSeconds(3), 'abc'))
+        buildStore.getBuild(targetImage) >> new BuildStoreEntry(req, res)
+        buildStore.awaitBuild(targetImage) >> CompletableFuture.completedFuture(res)
         def service = new ContainerBuildServiceImpl(buildStore: buildStore, buildCounter: buildCounter)
 
         when:
@@ -83,11 +84,12 @@ class FutureContainerBuildServiceTest extends Specification {
         def containerId = ContainerHelper.makeContainerId(dockerfile, null, null, ContainerPlatform.of('amd64'), buildRepo, null)
         def targetImage = ContainerHelper.makeTargetImage(BuildFormat.DOCKER, buildRepo, containerId, null, null, null)
         def req = new BuildRequest(containerId, dockerfile, null, null, folder, targetImage, Mock(PlatformId), ContainerPlatform.of('amd64'), cacheRepo, "10.20.30.40", '{"config":"json"}', null,null , null, null, BuildFormat.DOCKER, Duration.ofMinutes(1)).withBuildId('1')
+        def res = new BuildResult("", 1, "a fake build result in a test", Instant.now(), Duration.ofSeconds(3), 'abc')
         and:
         def buildStore = Mock(BuildStore)
         def buildCounter = Mock(BuildCounterStore)
-        buildStore.getBuild(targetImage) >> new BuildResult("", 1, "a fake build result in a test", Instant.now(), Duration.ofSeconds(3), 'abc')
-        buildStore.awaitBuild(targetImage) >> CompletableFuture.completedFuture(new BuildResult("", 1, "a fake build result in a test", Instant.now(), Duration.ofSeconds(3), 'abc'))
+        buildStore.getBuild(targetImage) >> new BuildStoreEntry(req, res)
+        buildStore.awaitBuild(targetImage) >> CompletableFuture.completedFuture(res)
         def service = new ContainerBuildServiceImpl(buildStore: buildStore, buildCounter: buildCounter)
 
         when:

--- a/src/test/groovy/io/seqera/wave/service/builder/FutureContainerBuildServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/FutureContainerBuildServiceTest.groovy
@@ -53,7 +53,7 @@ class FutureContainerBuildServiceTest extends Specification {
         and:
         def buildStore = Mock(BuildStore)
         def buildCounter = Mock(BuildCounterStore)
-        buildStore.getBuild(targetImage) >> new BuildStoreEntry(req, res)
+        buildStore.getBuildResult(targetImage) >> res
         buildStore.awaitBuild(targetImage) >> CompletableFuture.completedFuture(res)
         def service = new ContainerBuildServiceImpl(buildStore: buildStore, buildCounter: buildCounter)
 
@@ -88,7 +88,7 @@ class FutureContainerBuildServiceTest extends Specification {
         and:
         def buildStore = Mock(BuildStore)
         def buildCounter = Mock(BuildCounterStore)
-        buildStore.getBuild(targetImage) >> new BuildStoreEntry(req, res)
+        buildStore.getBuildResult(targetImage) >> res
         buildStore.awaitBuild(targetImage) >> CompletableFuture.completedFuture(res)
         def service = new ContainerBuildServiceImpl(buildStore: buildStore, buildCounter: buildCounter)
 

--- a/src/test/groovy/io/seqera/wave/service/job/JobFactoryTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/job/JobFactoryTest.groovy
@@ -23,12 +23,8 @@ import spock.lang.Specification
 import java.time.Duration
 import java.time.Instant
 
-import io.seqera.wave.api.SubmitContainerTokenRequest
 import io.seqera.wave.configuration.BlobCacheConfig
 import io.seqera.wave.service.builder.BuildRequest
-import io.seqera.wave.tower.PlatformId
-import io.seqera.wave.tower.User
-
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -37,29 +33,26 @@ class JobFactoryTest extends Specification {
 
     def 'should create job id' () {
         given:
-        def id = PlatformId.of(new User(id: 1), Mock(SubmitContainerTokenRequest))
         def ts = Instant.parse('2024-08-18T19:23:33.650722Z')
         def factory = new JobFactory()
         and:
         def request = new BuildRequest(
                 targetImage: 'docker.io/foo:bar',
-                buildId: '12345',
+                buildId: '12345_9',
                 startTime: ts,
-                maxDuration: Duration.ofMinutes(1),
-                identity: id
+                maxDuration: Duration.ofMinutes(1)
         )
 
         when:
         def job = factory.build(request)
         then:
         job.id == 'docker.io/foo:bar'
-        job.schedulerId == 'build-12345'
+        job.schedulerId == 'build-12345-9'
         job.creationTime == ts
         job.type == JobSpec.Type.Build
         job.maxDuration == Duration.ofMinutes(1)
-        job.getBuildId() == '12345'
+        job.getBuildId() == '12345_9'
         job.getTargetImage() == 'docker.io/foo:bar'
-        job.getIdentity() == id
     }
 
     def 'should create transfer job' () {

--- a/src/test/groovy/io/seqera/wave/service/job/JobFactoryTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/job/JobFactoryTest.groovy
@@ -51,7 +51,6 @@ class JobFactoryTest extends Specification {
         job.creationTime == ts
         job.type == JobSpec.Type.Build
         job.maxDuration == Duration.ofMinutes(1)
-        job.getBuildId() == '12345_9'
         job.getTargetImage() == 'docker.io/foo:bar'
     }
 

--- a/src/test/groovy/io/seqera/wave/service/job/spec/BuildJobSpecTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/job/spec/BuildJobSpecTest.groovy
@@ -23,11 +23,6 @@ import spock.lang.Specification
 import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant
-
-import io.seqera.wave.api.SubmitContainerTokenRequest
-import io.seqera.wave.service.builder.BuildRequest
-import io.seqera.wave.tower.PlatformId
-import io.seqera.wave.tower.User
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -36,7 +31,6 @@ class BuildJobSpecTest extends Specification {
 
     def 'should create build job spec' () {
         given:
-        def id = PlatformId.of(new User(id: 1), Mock(SubmitContainerTokenRequest))
         def ts = Instant.parse('2024-08-18T19:23:33.650722Z')
 
         when:
@@ -45,9 +39,7 @@ class BuildJobSpecTest extends Specification {
                 ts,
                 Duration.ofMinutes(1),
                 'build-12345-1',
-                '12345',
                 'docker.io/foo:bar',
-                id,
                 Path.of('/some/path')
         )
         then:
@@ -55,9 +47,7 @@ class BuildJobSpecTest extends Specification {
         spec.creationTime == ts
         spec.maxDuration == Duration.ofMinutes(1)
         spec.getSchedulerId() == 'build-12345-1'
-        spec.getBuildId() == '12345'
         spec.getTargetImage() == spec.id
-        spec.identity == id
     }
 
 }

--- a/src/test/groovy/io/seqera/wave/service/job/spec/BuildJobSpecTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/job/spec/BuildJobSpecTest.groovy
@@ -20,6 +20,7 @@ package io.seqera.wave.service.job.spec
 
 import spock.lang.Specification
 
+import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant
 
@@ -37,22 +38,23 @@ class BuildJobSpecTest extends Specification {
         given:
         def id = PlatformId.of(new User(id: 1), Mock(SubmitContainerTokenRequest))
         def ts = Instant.parse('2024-08-18T19:23:33.650722Z')
-        and:
-        def request = new BuildRequest(
-                targetImage: 'docker.io/foo:bar',
-                buildId: '12345',
-                startTime: ts,
-                maxDuration: Duration.ofMinutes(1),
-                identity: id
-        )
 
         when:
-        def spec = new BuildJobSpec(request)
+        def spec = new BuildJobSpec(
+                'docker.io/foo:bar',
+                ts,
+                Duration.ofMinutes(1),
+                'build-12345-1',
+                '12345',
+                'docker.io/foo:bar',
+                id,
+                Path.of('/some/path')
+        )
         then:
         spec.id == 'docker.io/foo:bar'
         spec.creationTime == ts
         spec.maxDuration == Duration.ofMinutes(1)
-        spec.getSchedulerId() == 'build-12345'
+        spec.getSchedulerId() == 'build-12345-1'
         spec.getBuildId() == '12345'
         spec.getTargetImage() == spec.id
         spec.identity == id


### PR DESCRIPTION
This PR will do the following:

1. Add new class class BuildStoreEntry { BuildRequest request; BuildResult result }
2. Using it in place of BuildResult in [BuildCacheStore](https://github.com/seqeralabs/wave/blob/6f83ad4c099ad35a19cd0e332de137df892218d8/src/main/groovy/io/seqera/wave/service/builder/BuildCacheStore.groovy#L43-L43)
3. Modify BuildJobSpecto behave more similar to TransferJobSpec
4. Move the [schedulerId normalization logic](https://github.com/seqeralabs/wave/blob/6f83ad4c099ad35a19cd0e332de137df892218d8/src/main/groovy/io/seqera/wave/service/job/spec/BuildJobSpec.groovy#L64-L64) in the [JobFactory](https://github.com/seqeralabs/wave/blob/6f83ad4c099ad35a19cd0e332de137df892218d8/src/main/groovy/io/seqera/wave/service/job/JobFactory.groovy#L39-L39)