### PR TITLE
Improve registry auth error handling

### DIFF
--- a/src/main/groovy/io/seqera/wave/WaveDefault.groovy
+++ b/src/main/groovy/io/seqera/wave/WaveDefault.groovy
@@ -17,11 +17,15 @@
  */
 
 package io.seqera.wave
+
+
+import groovy.transform.CompileStatic
 /**
  * Wave app defaults
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
+@CompileStatic
 interface WaveDefault {
 
     final static public String DOCKER_IO = 'docker.io'

--- a/src/main/groovy/io/seqera/wave/WaveDefault.groovy
+++ b/src/main/groovy/io/seqera/wave/WaveDefault.groovy
@@ -18,7 +18,6 @@
 
 package io.seqera.wave
 
-
 import groovy.transform.CompileStatic
 /**
  * Wave app defaults

--- a/src/main/groovy/io/seqera/wave/auth/RegistryAuthService.groovy
+++ b/src/main/groovy/io/seqera/wave/auth/RegistryAuthService.groovy
@@ -18,6 +18,8 @@
 
 package io.seqera.wave.auth
 
+import io.seqera.wave.exception.RegistryUnauthorizedAccessException
+
 /**
  * Declares container registry authentication & authorization operations
  *

--- a/src/main/groovy/io/seqera/wave/auth/RegistryAuthServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/auth/RegistryAuthServiceImpl.groovy
@@ -144,6 +144,9 @@ class RegistryAuthServiceImpl implements RegistryAuthService {
                 .header("Authorization", "Basic $basic")
                 .build()
         // retry strategy
+        // note: do not retry on 429 error code because it just continues to report the error
+        // for a while. better returning the error to the upstream client
+        // see also https://github.com/docker/hub-feedback/issues/1907#issuecomment-631028965
         final retryable = Retryable
                 .<HttpResponse<String>>of(httpConfig)
                 .retryIf((response) -> isServerError(response))
@@ -231,6 +234,9 @@ class RegistryAuthServiceImpl implements RegistryAuthService {
         log.trace "Token request=$req"
 
         // retry strategy
+        // note: do not retry on 429 error code because it just continues to report the error
+        // for a while. better returning the error to the upstream client
+        // see also https://github.com/docker/hub-feedback/issues/1907#issuecomment-631028965
         final retryable = Retryable
                 .<HttpResponse<String>>of(httpConfig)
                 .retryIf((response) -> isServerError(response))

--- a/src/main/groovy/io/seqera/wave/auth/RegistryAuthServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/auth/RegistryAuthServiceImpl.groovy
@@ -35,6 +35,8 @@ import groovy.transform.PackageScope
 import groovy.transform.ToString
 import groovy.util.logging.Slf4j
 import io.seqera.wave.configuration.HttpClientConfig
+import io.seqera.wave.exception.RegistryForwardException
+import io.seqera.wave.exception.RegistryUnauthorizedAccessException
 import io.seqera.wave.http.HttpClientFactory
 import io.seqera.wave.util.RegHelper
 import io.seqera.wave.util.Retryable
@@ -42,7 +44,7 @@ import io.seqera.wave.util.StringUtils
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import static io.seqera.wave.WaveDefault.DOCKER_IO
-import static io.seqera.wave.WaveDefault.HTTP_RETRYABLE_ERRORS
+import static io.seqera.wave.auth.RegistryUtils.isServerError
 /**
  * Implement Docker authentication & login service
  *
@@ -110,7 +112,6 @@ class RegistryAuthServiceImpl implements RegistryAuthService {
 
     @Inject RegistryCredentialsFactory credentialsFactory
 
-
     /**
      * Implements container registry login
      *
@@ -145,8 +146,8 @@ class RegistryAuthServiceImpl implements RegistryAuthService {
         // retry strategy
         final retryable = Retryable
                 .<HttpResponse<String>>of(httpConfig)
-                .retryIf( (response) -> response.statusCode() in HTTP_RETRYABLE_ERRORS)
-                .onRetry((event) -> log.warn("Unable to connect '$endpoint' - event: $event}"))
+                .retryIf((response) -> isServerError(response))
+                .onRetry((event) -> log.warn("Unable to connect '$endpoint' - attempt: ${event.attempt} status: ${event.result?.statusCode()}; body: ${event.result?.body()}"))
         // make the request
         final response = retryable.apply(()-> httpClient.send(request, HttpResponse.BodyHandlers.ofString()))
         final body = response.body()
@@ -232,8 +233,8 @@ class RegistryAuthServiceImpl implements RegistryAuthService {
         // retry strategy
         final retryable = Retryable
                 .<HttpResponse<String>>of(httpConfig)
-                .retryIf( (response) -> ((HttpResponse)response).statusCode() in HTTP_RETRYABLE_ERRORS )
-                .onRetry((event) -> log.warn("Unable to connect '$login' - event: $event"))
+                .retryIf((response) -> isServerError(response))
+                .onRetry((event) -> log.warn("Unable to connect '$login' - attempt: ${event.attempt} status: ${event.result?.statusCode()}; body: ${event.result?.body()}"))
         // submit http request
         final response = retryable.apply(()-> httpClient.send(req, HttpResponse.BodyHandlers.ofString()))
         // check the response
@@ -248,8 +249,7 @@ class RegistryAuthServiceImpl implements RegistryAuthService {
                 return token
             }
         }
-
-        throw new RegistryUnauthorizedAccessException("Unable to authorize request: $login", response.statusCode(), body)
+        throw new RegistryForwardException("Unexpected response acquiring token for '$login' [${response.statusCode()}]", response)
     }
 
     String buildLoginUrl(URI realm, String image, String service){

--- a/src/main/groovy/io/seqera/wave/auth/RegistryLookupServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/auth/RegistryLookupServiceImpl.groovy
@@ -20,21 +20,24 @@ package io.seqera.wave.auth
 
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
 import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
 import com.google.common.cache.LoadingCache
+import com.google.common.util.concurrent.UncheckedExecutionException
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.seqera.wave.configuration.HttpClientConfig
+import io.seqera.wave.exception.RegistryForwardException
 import io.seqera.wave.http.HttpClientFactory
 import io.seqera.wave.util.Retryable
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import static io.seqera.wave.WaveDefault.DOCKER_IO
 import static io.seqera.wave.WaveDefault.DOCKER_REGISTRY_1
-import static io.seqera.wave.WaveDefault.HTTP_RETRYABLE_ERRORS
+import static io.seqera.wave.auth.RegistryUtils.isServerError
 /**
  * Lookup service for container registry. The role of this component
  * is to registry the retrieve the registry authentication realm
@@ -83,11 +86,10 @@ class RegistryLookupServiceImpl implements RegistryLookupService {
         // retry strategy
         final retryable = Retryable
                 .<HttpResponse<String>>of(httpConfig)
-                .retryIf((response) -> response.statusCode() in HTTP_RETRYABLE_ERRORS )
-                .onRetry((event) -> log.warn("Unable to connect '$endpoint' - event: $event"))
+                .retryIf((response) -> isServerError(response))
+                .onRetry((event) -> log.warn("Unable to connect '$endpoint' - attempt: ${event.attempt} status: ${event.result?.statusCode()}; body: ${event.result?.body()}"))
         // submit the request
         final response = retryable.apply(()-> httpClient.send(request, HttpResponse.BodyHandlers.ofString()))
-        final body = response.body()
         // check response
         final code = response.statusCode()
         if( code == 401 ) {
@@ -102,9 +104,7 @@ class RegistryLookupServiceImpl implements RegistryLookupService {
         else if( code == 200 ) {
             return new RegistryAuth(endpoint)
         }
-        else {
-            throw new IllegalArgumentException("Request '$endpoint' unexpected response code: $code; message: ${body} ")
-        }
+        throw new RegistryForwardException("Unexpected response for '$endpoint' [${response.statusCode()}]", response)
     }
 
     /**
@@ -117,8 +117,10 @@ class RegistryLookupServiceImpl implements RegistryLookupService {
             final auth = cache.get(endpoint)
             return new RegistryInfo(registry, endpoint, auth)
         }
-        catch (Throwable t) {
-            throw new RegistryLookupException("Unable to lookup authority for registry '$registry'", t)
+        catch (UncheckedExecutionException | ExecutionException e) {
+            // this catches the exception thrown in the cache loader lookup
+            // and throws the causing exception that should be `RegistryUnauthorizedAccessException`
+            throw e.cause
         }
     }
 

--- a/src/main/groovy/io/seqera/wave/auth/RegistryLookupServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/auth/RegistryLookupServiceImpl.groovy
@@ -84,6 +84,9 @@ class RegistryLookupServiceImpl implements RegistryLookupService {
         final httpClient = HttpClientFactory.followRedirectsHttpClient()
         final request = HttpRequest.newBuilder() .uri(endpoint) .GET() .build()
         // retry strategy
+        // note: do not retry on 429 error code because it just continues to report the error
+        // for a while. better returning the error to the upstream client
+        // see also https://github.com/docker/hub-feedback/issues/1907#issuecomment-631028965
         final retryable = Retryable
                 .<HttpResponse<String>>of(httpConfig)
                 .retryIf((response) -> isServerError(response))

--- a/src/main/groovy/io/seqera/wave/auth/RegistryUtils.groovy
+++ b/src/main/groovy/io/seqera/wave/auth/RegistryUtils.groovy
@@ -18,37 +18,20 @@
 
 package io.seqera.wave.auth
 
-import groovy.transform.CompileStatic
-import io.seqera.wave.exception.WaveException
+import java.net.http.HttpResponse
 
+import groovy.transform.CompileStatic
+import io.seqera.wave.WaveDefault
 /**
- * Exception throw when the registry authorization failed
+ * Utility class for registry functions
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @CompileStatic
-class RegistryUnauthorizedAccessException extends WaveException {
+class RegistryUtils {
 
-    private String response
-    private Integer status
-
-    RegistryUnauthorizedAccessException(String message, Integer status=null, String response=null) {
-        super(message)
-        this.status = status
-        this.response = response
+    static boolean isServerError(HttpResponse response) {
+        response.statusCode() in WaveDefault.HTTP_SERVER_ERRORS
     }
 
-    String getResponse() {
-        return response
-    }
-
-    @Override
-    String getMessage() {
-        def result = super.getMessage()
-        if( status!=null )
-            result += " - HTTP status=$status"
-        if( response )
-            result += " - response=$response"
-        return result
-    }
 }

--- a/src/main/groovy/io/seqera/wave/controller/ErrorController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ErrorController.groovy
@@ -41,7 +41,7 @@ class ErrorController {
 
     @Error(global = true)
     HttpResponse<JsonError> handleException(HttpRequest request, Throwable exception) {
-        handler.handle(request, exception, (message, code)-> new JsonError(message))
+        handler.handle(request, exception, (String message, String code)-> new JsonError(message))
     }
     
 }

--- a/src/main/groovy/io/seqera/wave/controller/RegistryProxyController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/RegistryProxyController.groovy
@@ -104,7 +104,7 @@ class RegistryProxyController {
 
     @Error
     HttpResponse<RegistryErrorResponse> handleError(HttpRequest request, Throwable t) {
-        return errorHandler.handle(request, t, (msg, code) -> new RegistryErrorResponse(code,msg) )
+        return errorHandler.handle(request, t, (String msg, String code) -> new RegistryErrorResponse(code,msg) )
     }
 
     @Get

--- a/src/main/groovy/io/seqera/wave/exception/RegistryForwardException.groovy
+++ b/src/main/groovy/io/seqera/wave/exception/RegistryForwardException.groovy
@@ -1,0 +1,66 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.exception
+
+import java.net.http.HttpResponse
+
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+/**
+ * Exception thrown when a error response is returned by a target registry
+ * while authenticating a container request
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Canonical
+@CompileStatic
+class RegistryForwardException extends WaveException implements HttpError {
+
+    final int statusCode
+    final String response
+    final Map<String,String> headers
+
+    RegistryForwardException(String message, int status, String body, Map<String,List<String>> headers) {
+        super(message)
+        this.statusCode = status
+        this.response = body
+        this.headers = simpleMap(headers) ?: Map.<String,String>of()
+    }
+
+    RegistryForwardException(String message, HttpResponse<String> resp) {
+        super(message)
+        this.statusCode = resp.statusCode()
+        this.response = resp.body()
+        this.headers = simpleMap(resp.headers().map())
+    }
+
+    private Map<String,String> simpleMap(Map<String,List<String>> h) {
+        final result = new LinkedHashMap<String,String>()
+        for( Map.Entry<String,List<String>> it : h.entrySet()) {
+            result.put(it.key, it.value?.first() ?: '')
+        }
+        return result
+    }
+
+    String getMessage() {
+        def result = super.getMessage()
+        result += " - status=${statusCode}; response=${response}; headers=${headers}"
+        return result
+    }
+}

--- a/src/main/groovy/io/seqera/wave/exception/RegistryUnauthorizedAccessException.groovy
+++ b/src/main/groovy/io/seqera/wave/exception/RegistryUnauthorizedAccessException.groovy
@@ -16,32 +16,38 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package io.seqera.wave.controller
+package io.seqera.wave.exception
 
 import groovy.transform.CompileStatic
-import groovy.util.logging.Slf4j
-import io.micronaut.http.HttpRequest
-import io.micronaut.http.HttpResponse
-import io.micronaut.http.annotation.Controller
-import io.micronaut.http.annotation.Error
-import io.micronaut.http.hateoas.JsonError
-import io.seqera.wave.ErrorHandler
-import jakarta.inject.Inject
+
 /**
- * Handle application errors
- * 
+ * Exception throw when the registry authorization failed
+ *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
-@Slf4j
 @CompileStatic
-@Controller('/error')
-class ErrorController {
+class RegistryUnauthorizedAccessException extends WaveException {
 
-    @Inject ErrorHandler handler
+    private String response
+    private Integer status
 
-    @Error(global = true)
-    HttpResponse<JsonError> handleException(HttpRequest request, Throwable exception) {
-        handler.handle(request, exception, (message, code)-> new JsonError(message))
+    RegistryUnauthorizedAccessException(String message, Integer status=null, String response=null) {
+        super(message)
+        this.status = status
+        this.response = response
     }
-    
+
+    String getResponse() {
+        return response
+    }
+
+    @Override
+    String getMessage() {
+        def result = super.getMessage()
+        if( status!=null )
+            result += " - HTTP status=$status"
+        if( response )
+            result += " - response=$response"
+        return result
+    }
 }

--- a/src/main/groovy/io/seqera/wave/proxy/ProxyClient.groovy
+++ b/src/main/groovy/io/seqera/wave/proxy/ProxyClient.groovy
@@ -30,10 +30,11 @@ import io.micronaut.http.HttpMethod
 import io.micronaut.http.MutableHttpRequest
 import io.micronaut.http.server.exceptions.InternalServerException
 import io.micronaut.reactor.http.client.ReactorStreamingHttpClient
+import io.seqera.wave.exception.RegistryForwardException
 import io.seqera.wave.auth.RegistryAuthService
 import io.seqera.wave.auth.RegistryCredentials
 import io.seqera.wave.auth.RegistryInfo
-import io.seqera.wave.auth.RegistryUnauthorizedAccessException
+import io.seqera.wave.exception.RegistryUnauthorizedAccessException
 import io.seqera.wave.configuration.HttpClientConfig
 import io.seqera.wave.core.ContainerPath
 import io.seqera.wave.util.RegHelper
@@ -239,7 +240,7 @@ class ProxyClient {
             // just re-throw it so that it's managed by the retry policy
             throw e
         }
-        catch (RegistryUnauthorizedAccessException e) {
+        catch (RegistryForwardException | RegistryUnauthorizedAccessException e) {
             // just re-throw it because it's a known error condition
             throw e
         }

--- a/src/main/groovy/io/seqera/wave/util/Retryable.groovy
+++ b/src/main/groovy/io/seqera/wave/util/Retryable.groovy
@@ -73,7 +73,7 @@ class Retryable<R> {
 
     private Predicate<? extends Throwable> condition
 
-    private Consumer<Event> retryEvent
+    private Consumer<Event<R>> retryEvent
 
     private Predicate<R> handleResult
 
@@ -92,7 +92,7 @@ class Retryable<R> {
         return this
     }
 
-    Retryable<R> onRetry(Consumer<Event> event) {
+    Retryable<R> onRetry(Consumer<Event<R>> event) {
         this.retryEvent = event
         return this
     }

--- a/src/test/groovy/io/seqera/wave/auth/RegistryLookupServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/auth/RegistryLookupServiceTest.groovy
@@ -29,7 +29,8 @@ import jakarta.inject.Inject
 @MicronautTest
 class RegistryLookupServiceTest extends Specification {
 
-    @Inject RegistryLookupServiceImpl service
+    @Inject
+    RegistryLookupServiceImpl service
 
     def 'should find registry realm' () {
         given:

--- a/src/test/groovy/io/seqera/wave/controller/RegistryControllerLookupFailureTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/RegistryControllerLookupFailureTest.groovy
@@ -1,0 +1,73 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.controller
+
+import spock.lang.Specification
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.seqera.wave.auth.RegistryAuthService
+import io.seqera.wave.exception.RegistryForwardException
+import io.seqera.wave.model.ContentType
+import io.seqera.wave.test.DockerRegistryContainer
+import jakarta.inject.Inject
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@MicronautTest
+class RegistryControllerLookupFailureTest extends Specification implements DockerRegistryContainer {
+
+    @Inject
+    @Client("/")
+    HttpClient client
+
+    @MockBean(RegistryAuthService)
+    RegistryAuthService lookupService = Mock(RegistryAuthService)
+
+    def setupSpec() {
+        initRegistryContainer()
+    }
+
+    def 'should report registry lookup' () {
+        when:
+        def MESSAGE = 'Registry response body here'
+        def HEADERS = ['x-foo': ['this'], 'x-bar': ['that']]
+        lookupService.lookup(_) >> { throw new RegistryForwardException('Oops.. something went wrong', 400, MESSAGE, HEADERS) }
+        and:
+        HttpRequest request = HttpRequest.GET("/v2/library/hello-world/manifests/sha256:53641cd209a4fecfc68e21a99871ce8c6920b2e7502df0a20671c6fccc73a7c6").headers({ h->
+            h.add('Accept', ContentType.DOCKER_MANIFEST_V2_TYPE)
+            h.add('Accept', ContentType.DOCKER_MANIFEST_V1_JWS_TYPE)
+            h.add('Accept', MediaType.APPLICATION_JSON)
+        })
+        client.toBlocking().exchange(request,String)
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.status.code == 400
+        e.response.body() == MESSAGE
+        e.response.headers.get('x-foo') == 'this'
+        e.response.headers.get('x-bar') == 'that'
+    }
+
+}

--- a/src/test/groovy/io/seqera/wave/controller/RegistryControllerLookupFailureTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/RegistryControllerLookupFailureTest.groovy
@@ -27,7 +27,7 @@ import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import io.seqera.wave.auth.RegistryAuthService
+import io.seqera.wave.auth.RegistryLookupService
 import io.seqera.wave.exception.RegistryForwardException
 import io.seqera.wave.model.ContentType
 import io.seqera.wave.test.DockerRegistryContainer
@@ -43,8 +43,8 @@ class RegistryControllerLookupFailureTest extends Specification implements Docke
     @Client("/")
     HttpClient client
 
-    @MockBean(RegistryAuthService)
-    RegistryAuthService lookupService = Mock(RegistryAuthService)
+    @MockBean(RegistryLookupService)
+    RegistryLookupService lookupService = Mock(RegistryLookupService)
 
     def setupSpec() {
         initRegistryContainer()

--- a/src/test/groovy/io/seqera/wave/exchange/RegistryErrorResponseTest.groovy
+++ b/src/test/groovy/io/seqera/wave/exchange/RegistryErrorResponseTest.groovy
@@ -1,0 +1,47 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.exchange
+
+import spock.lang.Specification
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class RegistryErrorResponseTest extends Specification {
+
+    def 'should create an error response' () {
+        when:
+        def resp = new RegistryErrorResponse('FOO', 'Oops something went wrong')
+        then:
+        resp.getErrors().size()
+        resp.getErrors().first() == new RegistryErrorResponse.RegistryError('FOO', 'Oops something went wrong')
+    }
+
+    def 'should create from json' () {
+        given:
+        def json = '{"errors":[{"code":"DENIED","message":"Unauthenticated request. Unauthenticated requests do not have permission \"artifactregistry.repositories.downloadArtifacts\" on resource \"projects/wired-height-305919/locations/us-central1/repositories/fsdx-docker-dev\" (or it may not exist)"}]}'
+        when:
+        def resp = RegistryErrorResponse.parse(json)
+        then:
+        resp.errors.size() == 1
+        resp.errors[0].code == 'DENIED'
+        resp.errors[0].message == 'Unauthenticated request. Unauthenticated requests do not have permission \"artifactregistry.repositories.downloadArtifacts\" on resource \"projects/wired-height-305919/locations/us-central1/repositories/fsdx-docker-dev\" (or it may not exist)'
+    }
+}

--- a/src/test/groovy/io/seqera/wave/exchange/RegistryErrorResponseTest.groovy
+++ b/src/test/groovy/io/seqera/wave/exchange/RegistryErrorResponseTest.groovy
@@ -36,7 +36,7 @@ class RegistryErrorResponseTest extends Specification {
 
     def 'should create from json' () {
         given:
-        def json = '{"errors":[{"code":"DENIED","message":"Unauthenticated request. Unauthenticated requests do not have permission \"artifactregistry.repositories.downloadArtifacts\" on resource \"projects/wired-height-305919/locations/us-central1/repositories/fsdx-docker-dev\" (or it may not exist)"}]}'
+        def json = '{"errors":[{"code":"DENIED","message":"Unauthenticated request. Unauthenticated requests do not have permission \\"artifactregistry.repositories.downloadArtifacts\\" on resource \\"projects/wired-height-305919/locations/us-central1/repositories/fsdx-docker-dev\\" (or it may not exist)"}]}'
         when:
         def resp = RegistryErrorResponse.parse(json)
         then:


### PR DESCRIPTION
This PR improves the handling of http errors reported by target registry when authorising the access to a container repository. 

More in details 

- do not retry on 429 (too many requests) error code
- forward the error response reported by target registry to the upstream client (docker)
- improve the logging of retry attempts 
- improve error handler interface 