### PR TITLE
Do not retry on build failure

### DIFF
--- a/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
@@ -121,6 +121,10 @@ class BuildConfig {
     @Value('${wave.build.force-compression:false}')
     Boolean forceCompression
 
+    /**
+     * The number of times a build job should be retries. Since failures are expected due to
+     * invalid Dockerfile or Conda environment, retry is disabled.
+     */
     @Value('${wave.build.retry-attempts:0}')
     int retryAttempts
 

--- a/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
@@ -121,7 +121,7 @@ class BuildConfig {
     @Value('${wave.build.force-compression:false}')
     Boolean forceCompression
 
-    @Value('${wave.build.retry-attempts:3}')
+    @Value('${wave.build.retry-attempts:0}')
     int retryAttempts
 
     @PostConstruct


### PR DESCRIPTION
This PR disables retry on build jobs, because it's expected they can fail due to invalid/broken  Dockerfile. Therefore it's useless to retry it 