### PR TITLE
Remove unneeded timeout logic

### DIFF
--- a/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
@@ -22,7 +22,6 @@ import javax.annotation.Nullable
 import javax.annotation.PostConstruct
 
 import groovy.transform.CompileStatic
-import groovy.transform.Memoized
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Value
 import io.seqera.wave.api.SubmitContainerTokenRequest
@@ -85,20 +84,6 @@ class BuildConfig {
 
     Duration getFailureDuration() {
         return failureDuration ?: statusDelay.multipliedBy(10)
-    }
-
-    @Memoized
-    Duration getStatusInitialDelay() {
-        final d1 = defaultTimeout.toMillis() * 2.5f
-        final d2 = trustedTimeout.toMillis() * 1.5f
-        return Duration.ofMillis(Math.round(Math.max(d1,d2)))
-    }
-
-    @Memoized
-    Duration getStatusAwaitDuration() {
-        final d1 = defaultTimeout.toMillis() * 2.1f
-        final d2 = trustedTimeout.toMillis() * 1.1f
-        return Duration.ofMillis(Math.round(Math.max(d1,d2)))
     }
 
     @Value('${wave.build.cleanup}')

--- a/src/main/groovy/io/seqera/wave/service/job/JobManager.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobManager.groovy
@@ -90,9 +90,9 @@ class JobManager {
             CompletableFuture.runAsync(()-> jobService.cleanup(jobSpec, state.exitCode), ioExecutor)
             return true
         }
-        // set the await timeout nearly double as the blob transfer timeout, this because the
-        // transfer pod can spend `timeout` time in pending status awaiting to be scheduled
-        // and the same `timeout` time amount carrying out the transfer (upload) operation
+        // set the await timeout nearly double as the job timeout, this because the
+        // job can spend `timeout` time in pending status awaiting to be scheduled
+        // and the same `timeout` time amount carrying out job operation
         final max = (jobSpec.maxDuration.toMillis() * 2.10) as long
         if( duration.toMillis()>max ) {
             dispatcher.notifyJobTimeout(jobSpec)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,7 +75,7 @@ wave:
     timeout: 900s
     status:
       delay: 5s
-      duration: 1d
+      duration: 90m
   httpclient:
     retry:
       delay: '500ms'

--- a/src/test/groovy/io/seqera/wave/controller/BuildConfigTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/BuildConfigTest.groovy
@@ -56,36 +56,6 @@ class BuildConfigTest extends Specification {
         config.singularityImage( ContainerPlatform.of('arm64') ) == 'bar'
     }
 
-    @Unroll
-    def 'should validate initial duration' () {
-        given:
-        def config = new BuildConfig(defaultTimeout:DEFAULT, trustedTimeout:TRUSTED)
-        expect:
-        config.statusInitialDelay == EXPECTED
-
-        where:
-        DEFAULT                     | TRUSTED                       | EXPECTED
-        Duration.ofMillis(1000)     | Duration.ofMillis(1000)       |  Duration.ofMillis(Math.round(1000 * 2.5))
-        Duration.ofMinutes(15)      | Duration.ofMinutes(15)        |  Duration.ofMillis(Math.round( 37.5 * 60 * 1000))
-        Duration.ofMinutes(15)      | Duration.ofMinutes(25)        |  Duration.ofMillis(Math.round( 2.5 * 15 * 60 * 1000))
-        Duration.ofMinutes(15)      | Duration.ofMinutes(25)        |  Duration.ofMillis(Math.round( 1.5 * 25 * 60 * 1000))
-        Duration.ofMinutes(15)      | Duration.ofMinutes(30)        |  Duration.ofMillis(Math.round( 1.5 * 30 * 60 * 1000))
-    }
-
-    @Unroll
-    def 'should validate await duration' () {
-        given:
-        def config = new BuildConfig(defaultTimeout:DEFAULT, trustedTimeout:TRUSTED)
-        expect:
-        config.statusAwaitDuration == EXPECTED
-
-        where:
-        DEFAULT                     | TRUSTED                       | EXPECTED
-        Duration.ofMillis(1000)     | Duration.ofMillis(1000)       |  Duration.ofMillis(Math.round(1000 * 2.1))
-        Duration.ofMinutes(15)      | Duration.ofMinutes(15)        |  Duration.ofMillis(Math.round( 2.1 * 15 * 60 * 1000))
-        Duration.ofMinutes(15)      | Duration.ofMinutes(25)        |  Duration.ofMillis(Math.round( 2.1 * 15 * 60 * 1000))
-        Duration.ofMinutes(15)      | Duration.ofMinutes(30)        |  Duration.ofMillis(Math.round( 1.1 * 30 * 60 * 1000))
-    }
 
     @Unroll
     def 'should validate build max duration' () {


### PR DESCRIPTION
This PR removes unneeded timeout logic with Waiter class. The job timeout is managed directly by the job Manager [here](https://github.com/seqeralabs/wave/blob/76354bb646af6d39af1e342d58bea45a28d0d942/src/main/groovy/io/seqera/wave/service/job/JobManager.groovy#L96-L100)