### PR TITLE
Use public repo for s5cmd

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -216,7 +216,7 @@ Wave offers a feature to provide a cache for Docker blobs, which improves the pe
 
 - **`wave.blobCache.enabled`**: whether to enable the blob cache. It is `false` by default. *Optional*.
 
-- **`wave.blobCache.s5cmdImage`**: the Docker image that supplies the [s5cmd tool](https://github.com/peak/s5cmd). This tool is used to upload blob binaries to the S3 bucket. The default image used by Wave is `cr.seqera.io/public/wave/s5cmd:v2.2.2`. *Optional*.
+- **`wave.blobCache.s5cmdImage`**: the Docker image that supplies the [s5cmd tool](https://github.com/peak/s5cmd). This tool is used to upload blob binaries to the S3 bucket. The default image used by Wave is `public.cr.seqera.io/wave/s5cmd:v2.2.2`. *Optional*.
 
 - **`wave.blobCache.status.delay`**: the time delay in checking the status of the transfer of the blob binary from the repository to the cache. Its default value is `5s`. *Optional*.
 

--- a/s5cmd/Makefile
+++ b/s5cmd/Makefile
@@ -5,5 +5,5 @@ build:
 			--push \
 			--platform linux/amd64,linux/arm64 \
 			--build-arg version=${version} \
-			--tag cr.seqera.io/public/wave/s5cmd:v${version} \
+			--tag public.cr.seqera.io/wave/s5cmd:v${version} \
 			.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,7 +85,7 @@ wave:
     image:
       name: aquasec/trivy:0.53.0
   blobCache:
-    s5cmdImage: cr.seqera.io/public/wave/s5cmd:v2.2.2
+    s5cmdImage: public.cr.seqera.io/wave/s5cmd:v2.2.2
 ---
 jackson:
   serialization:


### PR DESCRIPTION
This updates s5cmd image to `public.cr.seqera.io/wave/s5cmd` repository  