### PR TITLE
Add entropy to cron services

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/cleanup/CleanupConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/service/cleanup/CleanupConfig.groovy
@@ -24,6 +24,7 @@ import javax.annotation.Nullable
 import groovy.transform.CompileStatic
 import groovy.transform.ToString
 import io.micronaut.context.annotation.Value
+import io.seqera.wave.util.DurationUtils
 import jakarta.inject.Singleton
 
 /**
@@ -55,4 +56,7 @@ class CleanupConfig {
     @Value('${wave.cleanup.run-interval:30s}')
     Duration cleanupRunInterval
 
+    Duration getCleanupStartupDelayRandomized() {
+        DurationUtils.randomDuration(cleanupStartupDelay, 0.4f)
+    }
 }

--- a/src/main/groovy/io/seqera/wave/service/cleanup/CleanupServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/cleanup/CleanupServiceImpl.groovy
@@ -61,7 +61,11 @@ class CleanupServiceImpl implements Runnable, CleanupService {
     @PostConstruct
     private init() {
         log.info "Creating cleanup service - config=$config"
-        scheduler.scheduleAtFixedRate(config.cleanupStartupDelay, config.cleanupRunInterval, this)
+        // use randomize initial delay to prevent multiple replicas running at the same time
+        scheduler.scheduleWithFixedDelay(
+                config.cleanupStartupDelayRandomized,
+                config.cleanupRunInterval,
+                this )
     }
 
     @Override

--- a/src/main/groovy/io/seqera/wave/tower/auth/JwtConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/tower/auth/JwtConfig.groovy
@@ -23,10 +23,12 @@ import java.time.Duration
 import groovy.transform.CompileStatic
 import groovy.transform.ToString
 import io.micronaut.context.annotation.Value
+import io.seqera.wave.util.DurationUtils
 import jakarta.inject.Singleton
 
 /**
- *
+ * Model JWT refreshing service config
+ * 
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Singleton
@@ -58,5 +60,9 @@ class JwtConfig {
      */
     @Value('${wave.jwt.monitor.count:10}')
     int monitorCount
+
+    Duration getMonitorDelayRandomized() {
+        DurationUtils.randomDuration(monitorDelay, 0.4f)
+    }
 
 }

--- a/src/main/groovy/io/seqera/wave/tower/auth/JwtMonitor.groovy
+++ b/src/main/groovy/io/seqera/wave/tower/auth/JwtMonitor.groovy
@@ -63,7 +63,11 @@ class JwtMonitor implements Runnable {
     @PostConstruct
     private init() {
         log.info "Creating JWT heartbeat - $jwtConfig"
-        scheduler.scheduleAtFixedRate(jwtConfig.monitorDelay, jwtConfig.monitorInterval, this)
+        // use randomize initial delay to prevent multiple replicas running at the same time
+        scheduler.scheduleAtFixedRate(
+                jwtConfig.monitorDelayRandomized,
+                jwtConfig.monitorInterval,
+                this )
     }
 
     void run() {

--- a/src/main/groovy/io/seqera/wave/util/DurationUtils.groovy
+++ b/src/main/groovy/io/seqera/wave/util/DurationUtils.groovy
@@ -1,0 +1,61 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.util
+
+import java.time.Duration
+import java.util.concurrent.ThreadLocalRandom
+
+import groovy.transform.CompileStatic
+/**
+ * Utility functions for handling duration
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+class DurationUtils {
+
+    static Duration randomDuration(Duration min, Duration max) {
+        if (min > max) {
+            throw new IllegalArgumentException("Min duration must be less than or equal to max duration")
+        }
+
+        long minNanos = min.toNanos()
+        long maxNanos = max.toNanos()
+        long randomNanos = ThreadLocalRandom.current().nextLong(minNanos, maxNanos + 1)
+
+        return Duration.ofNanos(randomNanos)
+    }
+
+    static Duration randomDuration(Duration reference, float intervalPercentage) {
+        if (intervalPercentage < 0 || intervalPercentage > 1) {
+            throw new IllegalArgumentException("Interval percentage must be between 0 and 1")
+        }
+
+        long refNanos = reference.toNanos()
+        long intervalNanos = (long)(refNanos * intervalPercentage)
+
+        long minNanos = Math.max(0, refNanos - intervalNanos)
+        long maxNanos = refNanos + intervalNanos
+
+        long randomNanos = ThreadLocalRandom.current().nextLong(minNanos, maxNanos + 1)
+
+        return Duration.ofNanos(randomNanos)
+    }
+
+}

--- a/src/test/groovy/io/seqera/wave/service/cleanup/CleanupConfigTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/cleanup/CleanupConfigTest.groovy
@@ -1,0 +1,42 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.service.cleanup
+
+import spock.lang.Specification
+
+import java.time.Duration
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class CleanupConfigTest extends Specification {
+
+    def 'should get random delay' () {
+        when:
+        def d = Duration.ofSeconds(10)
+        def config = new CleanupConfig(cleanupStartupDelay: d)
+        then:
+        config.cleanupStartupDelay == d
+        and:
+        config.cleanupStartupDelayRandomized >= d.dividedBy(2)
+        config.cleanupStartupDelayRandomized < (d + d.dividedBy(2))
+    }
+
+}

--- a/src/test/groovy/io/seqera/wave/tower/auth/JwtConfigTest.groovy
+++ b/src/test/groovy/io/seqera/wave/tower/auth/JwtConfigTest.groovy
@@ -1,0 +1,41 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.tower.auth
+
+import spock.lang.Specification
+
+import java.time.Duration
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class JwtConfigTest extends Specification {
+
+    def 'should get random delay' () {
+        when:
+        def d = Duration.ofSeconds(10)
+        def config = new JwtConfig(monitorDelay: d)
+        then:
+        config.monitorDelay == d
+        and:
+        config.monitorDelayRandomized >= d.dividedBy(2)
+        config.monitorDelayRandomized < (d + d.dividedBy(2))
+    }
+
+}

--- a/src/test/groovy/io/seqera/wave/util/DurationUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/DurationUtilsTest.groovy
@@ -1,0 +1,139 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.util
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.Duration
+
+class DurationUtilsTest extends Specification {
+
+    @Unroll
+    def "randomDuration returns a duration between #min and #max"() {
+        given:
+        def minDuration = Duration.ofSeconds(min)
+        def maxDuration = Duration.ofSeconds(max)
+
+        when:
+        def result = DurationUtils.randomDuration(minDuration, maxDuration)
+
+        then:
+        result >= minDuration
+        result <= maxDuration
+
+        where:
+        min | max
+        1   | 10
+        0   | 100
+        60  | 3600
+        3600| 7200
+    }
+
+    def "randomDuration returns min or max when they are equal"() {
+        given:
+        def duration = Duration.ofSeconds(10)
+
+        when:
+        def result = DurationUtils.randomDuration(duration, duration)
+
+        then:
+        result == duration
+    }
+
+
+    def "randomDuration generates different values over multiple calls"() {
+        given:
+        def minDuration = Duration.ofSeconds(1)
+        def maxDuration = Duration.ofSeconds(1000)
+        def iterations = 100
+        def results = []
+
+        when:
+        iterations.times {
+            results << DurationUtils.randomDuration(minDuration, maxDuration)
+        }
+
+        then:
+        results.unique().size() > 1
+    }
+
+    @Unroll
+    def "randomDuration returns a duration within #intervalPercentage of #reference"() {
+        given:
+        def referenceDuration = Duration.ofSeconds(reference)
+
+        when:
+        def result = DurationUtils.randomDuration(referenceDuration, intervalPercentage)
+
+        then:
+        def minAllowed = referenceDuration.multipliedBy((long)((1 - intervalPercentage) * 100)).dividedBy(100)
+        def maxAllowed = referenceDuration.multipliedBy((long)((1 + intervalPercentage) * 100)).dividedBy(100)
+        result >= minAllowed
+        result <= maxAllowed
+
+        where:
+        reference | intervalPercentage
+        100       | 0.2f
+        60        | 0.5f
+        3600      | 0.1f
+        10        | 0.0f
+    }
+
+    def "randomDuration throws IllegalArgumentException for invalid interval percentage"() {
+        given:
+        def referenceDuration = Duration.ofSeconds(100)
+
+        when:
+        DurationUtils.randomDuration(referenceDuration, invalidPercentage)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        invalidPercentage << [-0.1f, 1.1f]
+    }
+
+    def "randomDuration handles zero reference duration"() {
+        given:
+        def referenceDuration = Duration.ZERO
+
+        when:
+        def result = DurationUtils.randomDuration(referenceDuration, 0.2f)
+
+        then:
+        result == Duration.ZERO
+    }
+
+    def "randomDuration generates different values over multiple calls"() {
+        given:
+        def referenceDuration = Duration.ofSeconds(100)
+        def intervalPercentage = 0.2f
+        def iterations = 100
+        def results = []
+
+        when:
+        iterations.times {
+            results << DurationUtils.randomDuration(referenceDuration, intervalPercentage)
+        }
+
+        then:
+        results.unique().size() > 1
+    }
+}


### PR DESCRIPTION
This PR adds some entropy in the startup delay of JwtMonitor and CleanupService to prevent that multiple replicas run them in sync. 