### PR TITLE
Increase cache-tower-client to 1min

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ micronaut:
     # Using `expire-after-read` can cause an entry to be retained in the cache more than expected if it is hit continuously
     # with a frequency shorter than the declared cache period.
     cache-tower-client:
-      expire-after-write: 20s
+      expire-after-write: 60s
       record-stats: true
     cache-registry-proxy:
       expire-after-write: 20s


### PR DESCRIPTION
This PR increase the [TowerClient](https://github.com/seqeralabs/wave/blob/94c8fd5414c25bec45e7e3320c547c9a6d9ff2cc/src/main/groovy/io/seqera/wave/tower/client/TowerClient.groovy#L41-L41) cache to 1 minute to reduce the pressure on Platform API invocation 