### PR TITLE
Wave inspect: CSS edits

### DIFF
--- a/src/main/resources/io/seqera/wave/assets/expand-collapse.svg
+++ b/src/main/resources/io/seqera/wave/assets/expand-collapse.svg
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="12" viewBox="0 0 40 20">
-  <g fill="#fff">
-    <path d="m5 9h4v-4h2v4h4v2h-4v4h-2v-4h-4z"/>
-    <path d="m25 9h10v2h-10z"/>
-  </g>
-</svg>

--- a/src/main/resources/io/seqera/wave/inspect-view.hbs
+++ b/src/main/resources/io/seqera/wave/inspect-view.hbs
@@ -4,8 +4,24 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="Wave container inspect">
-    <title>Wave container inspect</title>
+    <title>Wave inspect: {{imageName}}</title>
     <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+        body {
+            font-family: "Inter", sans-serif;
+            font-optical-sizing: auto;
+            font-weight: 200;
+            font-style: normal;
+        }
+        .monospace {
+            font-family: monospace;
+            font-size: 0.9em;
+        }
+        .container {
+            padding: 30px;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
         table {
             width: 100%;
             margin: 20px 0;
@@ -18,9 +34,14 @@
             border: 1px solid #ddd;
             vertical-align: top;
         }
+        td:first-child {
+            max-width: 200px;
+            font-weight: 500;
+        }
         .tree {
             --spacing: 1.5rem;
             --radius: 6px;
+            padding: 10px 0 0;
         }
 
         .tree li {
@@ -87,7 +108,7 @@
 
         .tree summary::before {
             z-index: 1;
-            background: #3D95FD url('/assets/expand-collapse.svg') 0 0;
+            background: #3D95FD url("data:image/svg+xml,%3C%3Fxml version='1.0'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='20' viewBox='0 0 40 20'%3E%3Cg fill='%23fff'%3E%3Cpath d='m5 9h4v-4h2v4h4v2h-4v4h-2v-4h-4z'/%3E%3Cpath d='m25 9h10v2h-10z'/%3E%3C/g%3E%3C/svg%3E%0A") 0 0;
         }
 
         .tree details[open] > summary::before {
@@ -96,7 +117,7 @@
     </style>
 </head>
 <body>
-<div style="font-family:'-apple-system', BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; padding: 30px; max-width: 1200px; margin: 0 auto;">
+<div class="container">
 
     <div>
         <img style="float:left; margin-top: 5px; margin-right: 10px; width: 30px;" src="/assets/wave-logo.png">
@@ -115,19 +136,19 @@
         <table>
             <tr>
                 <td>Image Name</td>
-                <td>{{imageName}}</td>
+                <td class="monospace">{{imageName}}</td>
             </tr>
             <tr>
                 <td>Reference (tag)</td>
-                <td>{{reference}}</td>
+                <td class="monospace">{{reference}}</td>
             </tr>
             <tr>
                 <td>Digest</td>
-                <td>{{digest}}</td>
+                <td class="monospace">{{digest}}</td>
             </tr>
             <tr>
                 <td>Registry</td>
-                <td>{{registry}}</td>
+                <td class="monospace">{{registry}}</td>
             </tr>
             <tr>
                 <td>Host Name</td>

--- a/src/main/resources/io/seqera/wave/inspect-view.hbs
+++ b/src/main/resources/io/seqera/wave/inspect-view.hbs
@@ -6,7 +6,7 @@
     <meta name="description" content="Wave container inspect">
     <title>Wave inspect: {{imageName}}</title>
     <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+        @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Roboto+Mono:ital,wght@0,100..700;1,100..700&display=swap');
         body {
             font-family: "Inter", sans-serif;
             font-optical-sizing: auto;
@@ -14,7 +14,10 @@
             font-style: normal;
         }
         .monospace {
-            font-family: monospace;
+            font-family: "Roboto Mono", monospace;
+            font-optical-sizing: auto;
+            font-weight: 400;
+            font-style: normal;
             font-size: 0.9em;
         }
         .container {

--- a/src/main/resources/io/seqera/wave/inspect-view.hbs
+++ b/src/main/resources/io/seqera/wave/inspect-view.hbs
@@ -111,7 +111,7 @@
 
         .tree summary::before {
             z-index: 1;
-            background: #3D95FD url("data:image/svg+xml,%3C%3Fxml version='1.0'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='20' viewBox='0 0 40 20'%3E%3Cg fill='%23fff'%3E%3Cpath d='m5 9h4v-4h2v4h4v2h-4v4h-2v-4h-4z'/%3E%3Cpath d='m25 9h10v2h-10z'/%3E%3C/g%3E%3C/svg%3E%0A") 0 0;
+            background: #3D95FD url("data:image/svg+xml,%3C%3Fxml version='1.0'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='12' viewBox='0 0 40 20'%3E%3Cg fill='%23fff'%3E%3Cpath d='m5 9h4v-4h2v4h4v2h-4v4h-2v-4h-4z'/%3E%3Cpath d='m25 9h10v2h-10z'/%3E%3C/g%3E%3C/svg%3E%0A") 0 0;
         }
 
         .tree details[open] > summary::before {


### PR DESCRIPTION
Minor improvements in CSS and styling for PR #619

* Encode SVG into the file, rather than including a new external asset
* Use [Inter](https://fonts.google.com/specimen/Inter) for our main font
* Use monospace fonts for technical details like name, tag, digest etc.
* Use [Roboto Mono](https://fonts.google.com/specimen/Roboto+Mono) for monospace font
* Avoid using inline CSS styling
* Set maximum width for first table column to avoid bounce when expanding tree nodes
* Minor tidying of padding and spacing

Future stuff we should do across all reports, for future PR(s):

- [ ] Do all of the above tweaks in all reports
- [ ] base64 encode the PNG images and include inline too, rather than using external image files
- [ ] Update table styling
- [ ] Include link to Seqera Wave webpage, in addition to the hostname of where it was generated
- [ ] General design updates to match other design assets (heading styles etc etc)

Wanted to get this in first though for PR #619, before tackling that larger effort across all reports.

Currently looks almost identical, which was the intention. Just minor tidying here:

![CleanShot 2024-09-18 at 09 15 14@2x](https://github.com/user-attachments/assets/4301b1f9-4de3-46c6-8f4b-a8d8096dec91)
