### PR TITLE
Build report: make inspect link separate to image name

### DIFF
--- a/src/main/resources/io/seqera/wave/build-view.hbs
+++ b/src/main/resources/io/seqera/wave/build-view.hbs
@@ -126,7 +126,7 @@
             {{#if build_in_progress}}
             <td>{{build_image}}</td>
             {{else}}
-            <td><a href="{{inspect_url}}">{{build_image}}</a></td>
+            <td>{{build_image}} <a href="{{inspect_url}}">[inspect image]</a></td>
             {{/if}}
         </tr>
 


### PR DESCRIPTION
Give the inspect link its own text, rather than linking the container name (which itself is a URL, and behaves as such in emails giving different behaviour in different contexts).

![CleanShot 2024-10-22 at 08 29 29@2x](https://github.com/user-attachments/assets/b1d2cc89-27a5-4e35-a267-9e016531698b)
