### PR TITLE
Add ability to configure Trivy scan environment

### DIFF
--- a/src/main/groovy/io/seqera/wave/configuration/ScanConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/ScanConfig.groovy
@@ -21,16 +21,14 @@ package io.seqera.wave.configuration
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
-
-import io.micronaut.context.annotation.Requires
-import io.micronaut.core.annotation.Nullable
 import javax.annotation.PostConstruct
 
 import groovy.transform.CompileStatic
 import groovy.transform.Memoized
 import groovy.util.logging.Slf4j
+import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Value
-import io.seqera.wave.util.StringUtils
+import io.micronaut.core.annotation.Nullable
 import jakarta.inject.Singleton
 /**
  * Container Scan service settings
@@ -83,8 +81,8 @@ class ScanConfig {
     Duration scanIdDuration
 
     @Nullable
-    @Value('${wave.scan.github-token}')
-    String githubToken
+    @Value('${wave.scan.environment}')
+    List<String> environment
 
     String getScanImage() {
         return scanImage
@@ -118,8 +116,23 @@ class ScanConfig {
         return severity
     }
 
+    List<Tuple2<String,String>> getEnvironmentAsTuples() {
+        if( !environment )
+            return List.of()
+        final result = new ArrayList<Tuple2<String,String>>()
+        for( String entry : environment ) {
+            final p=entry.indexOf('=')
+            final name = p!=-1 ? entry.substring(0,p) : entry
+            final value = p!=-1 ? entry.substring(p+1) : ''
+            if( !value )
+                log.warn "Invalid 'wave.scan.environment value' -- offending entry: '$entry'"
+            result.add(new Tuple2(name,value))
+        }
+        return result
+    }
+
     @PostConstruct
     private void init() {
-        log.info("Scanner config: docker image name: ${scanImage}; cache directory: ${cacheDirectory}; timeout=${timeout}; cpus: ${requestsCpu}; mem: ${requestsMemory}; severity: $severity; retry-attempts: $retryAttempts; github-token=${StringUtils.redact(githubToken)}")
+        log.info("Scan config: docker image name: ${scanImage}; cache directory: ${cacheDirectory}; timeout=${timeout}; cpus: ${requestsCpu}; mem: ${requestsMemory}; severity: $severity; retry-attempts: $retryAttempts; env=${environment}")
     }
 }

--- a/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
@@ -784,8 +784,11 @@ class K8sServiceImpl implements K8sService {
                 .withVolumeMounts(mounts)
                 .withResources(requests)
 
-        if( scanConfig.githubToken ) {
-            container.withEnv(new V1EnvVar().name('GITHUB_TOKEN').value(scanConfig.githubToken))
+        final env = scanConfig.environmentAsTuples
+        for( Tuple2 entry : env ) {
+            final String k = entry.v1
+            final String v = entry.v2
+            container.withEnv(new V1EnvVar().name(k).value(v))
         }
 
         // spec section

--- a/src/main/groovy/io/seqera/wave/service/scan/DockerScanStrategy.groovy
+++ b/src/main/groovy/io/seqera/wave/service/scan/DockerScanStrategy.groovy
@@ -73,7 +73,7 @@ class DockerScanStrategy extends ScanStrategy {
         // outfile file name
         final reportFile = req.workDir.resolve(Trivy.OUTPUT_FILE_NAME)
         // create the launch command
-        final dockerCommand = dockerWrapper(jobName, req.workDir, configFile, scanConfig.githubToken)
+        final dockerCommand = dockerWrapper(jobName, req.workDir, configFile, scanConfig.environment)
         final trivyCommand = List.of(scanConfig.scanImage) + scanCommand(req.targetImage, reportFile, req.platform, scanConfig)
         final command = dockerCommand + trivyCommand
 
@@ -89,7 +89,7 @@ class DockerScanStrategy extends ScanStrategy {
         }
     }
 
-    protected List<String> dockerWrapper(String jobName, Path scanDir, Path credsFile, String githubToken) {
+    protected List<String> dockerWrapper(String jobName, Path scanDir, Path credsFile, List<String> env) {
 
         final wrapper = ['docker','run']
         wrapper.add('--detach')
@@ -112,9 +112,11 @@ class DockerScanStrategy extends ScanStrategy {
             wrapper.add("${credsFile}:${Trivy.CONFIG_MOUNT_PATH}:ro".toString())
         }
 
-        if( githubToken ) {
-            wrapper.add('-e')
-            wrapper.add("GITHUB_TOKEN="+githubToken)
+        if( env ) {
+            for( String it : env ) {
+                wrapper.add('-e')
+                wrapper.add(it)
+            }
         }
 
         return wrapper

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,7 +4,6 @@ wave:
     enabled: true
     failure:
       duration: '30s'
-    github-token: "${GITHUB_TOKEN:}"
   build:
     workspace: 'build-workspace'
   metrics:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,7 +84,11 @@ wave:
       multiplier: '1.75'
   scan:
     image:
-      name: aquasec/trivy:0.55.0
+      name: aquasec/trivy:0.56.2
+    environment:
+      # see https://github.com/aquasecurity/trivy/discussions/7668#discussioncomment-11028887
+      - "TRIVY_DB_REPOSITORY=public.ecr.aws/aquasecurity/trivy-db"
+      - "TRIVY_JAVA_DB_REPOSITORY=public.ecr.aws/aquasecurity/trivy-java-db"
   blobCache:
     s5cmdImage: public.cr.seqera.io/wave/s5cmd:v2.2.2
 ---

--- a/src/test/groovy/io/seqera/wave/configuration/ScanConfigTest.groovy
+++ b/src/test/groovy/io/seqera/wave/configuration/ScanConfigTest.groovy
@@ -1,0 +1,8 @@
+package io.seqera.wave.configuration
+
+/**
+ *
+ *  @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class ScanConfigTest {
+}

--- a/src/test/groovy/io/seqera/wave/service/k8s/K8sServiceImplTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/k8s/K8sServiceImplTest.groovy
@@ -748,7 +748,7 @@ class K8sServiceImplTest extends Specification {
             getCacheDirectory() >> Path.of('/build/cache/dir')
             getRequestsCpu() >> '2'
             getRequestsMemory() >> '4Gi'
-            getGithubToken() >> '123abc'
+            getEnvironmentAsTuples() >> [new Tuple2<String, String>('GITHUB_TOKEN', '123abc')]
         }
 
         when:

--- a/src/test/groovy/io/seqera/wave/service/scan/DockerScanStrategyTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/scan/DockerScanStrategyTest.groovy
@@ -42,7 +42,7 @@ class DockerScanStrategyTest extends Specification {
         when:
         def scanDir = Path.of('/some/scan/dir')
         def config = Path.of("/user/test/build-workspace/config.json")
-        def command = dockerContainerStrategy.dockerWrapper('foo-123', scanDir, config, 'xyz')
+        def command = dockerContainerStrategy.dockerWrapper('foo-123', scanDir, config, ['FOO=1', 'BAR=2'])
 
         then:
         command == [
@@ -60,7 +60,9 @@ class DockerScanStrategyTest extends Specification {
                 '-v',
                 '/user/test/build-workspace/config.json:/root/.docker/config.json:ro',
                 '-e',
-                'GITHUB_TOKEN=xyz'
+                'FOO=1',
+                '-e',
+                'BAR=2'
         ]
 
         cleanup:


### PR DESCRIPTION
This adds the ability to provide a custom environment for Trivy scan jobs. 

This allows also the use of custom Trivy DBs. See also https://github.com/aquasecurity/trivy/discussions/7668#discussioncomment-11028887