### PR TITLE
Fix creds validation endpoint

### DIFF
--- a/src/main/groovy/io/seqera/wave/controller/ValidateController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ValidateController.groovy
@@ -18,7 +18,6 @@
 
 package io.seqera.wave.controller
 
-import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Post
 import io.micronaut.scheduling.TaskExecutors
@@ -26,7 +25,6 @@ import io.micronaut.scheduling.annotation.ExecuteOn
 import io.seqera.wave.auth.RegistryAuthService
 import jakarta.inject.Inject
 import jakarta.validation.Valid
-import reactor.core.publisher.Mono
 
 @ExecuteOn(TaskExecutors.IO)
 @Controller("/validate-creds")
@@ -35,10 +33,8 @@ class ValidateController {
     @Inject RegistryAuthService loginService
 
     @Post
-    Mono<Boolean> validateCreds(@Valid @Body ValidateRegistryCredsRequest request){
-        Mono.just(
-            loginService.validateUser(request.registry, request.userName, request.password)
-        )
+    Boolean validateCreds(@Valid ValidateRegistryCredsRequest request){
+        loginService.validateUser(request.registry, request.userName, request.password)
     }
 
 }

--- a/src/test/groovy/io/seqera/wave/controller/ValidateCredsControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ValidateCredsControllerTest.groovy
@@ -103,11 +103,11 @@ class ValidateCredsControllerTest extends Specification implements SecureDockerR
 
     void 'test validateController valid login'() {
         given:
-        def req = [
+        def req = [request: [
                 userName: USER,
                 password: PWD,
                 registry: getTestRegistryUrl(REGISTRY_URL)
-        ]
+        ]]
         HttpRequest request = HttpRequest.POST("/validate-creds", req)
         when:
         HttpResponse<Boolean> response = client.toBlocking().exchange(request, Boolean)

--- a/src/test/groovy/io/seqera/wave/controller/ValidateCredsControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ValidateCredsControllerTest.groovy
@@ -67,9 +67,9 @@ class ValidateCredsControllerTest extends Specification implements SecureDockerR
 
     void 'should validate username required'() {
         when:
-        HttpRequest request = HttpRequest.POST("/validate-creds", [
+        HttpRequest request = HttpRequest.POST("/validate-creds", [request: [
                 password: 'test',
-        ])
+        ]])
         client.toBlocking().exchange(request, Boolean)
         then:
         def e = thrown(HttpClientResponseException)
@@ -77,9 +77,9 @@ class ValidateCredsControllerTest extends Specification implements SecureDockerR
 
     void 'should validate pwd required'() {
         when:
-        HttpRequest request = HttpRequest.POST("/validate-creds", [
+        HttpRequest request = HttpRequest.POST("/validate-creds", [request:[
                 userName: 'test',
-        ])
+        ]])
         client.toBlocking().exchange(request, Boolean)
         then:
         def e = thrown(HttpClientResponseException)
@@ -87,10 +87,10 @@ class ValidateCredsControllerTest extends Specification implements SecureDockerR
 
     void 'should validate the test user'() {
         given:
-        def req = [
+        def req = [request: [
                 userName:'test',
                 password:'test',
-                registry: getTestRegistryUrl('test') ]
+                registry: getTestRegistryUrl('test') ]]
         and:
         HttpRequest request = HttpRequest.POST("/validate-creds", req)
         when:


### PR DESCRIPTION
This PR reverts the use of `@Body` annotation in the `/validate-creds` endpoint because it represents a braking change 

https://github.com/seqeralabs/wave/blob/059602cb4ba0a5cd174c84a04ad476c88cc6d7ed/src/main/groovy/io/seqera/wave/controller/ValidateController.groovy#L36-L36


when using `@Body` the post payload should be provided as 

```
{"userName":"value","password":"value","registry":"value"} 
``` 

Instead without `@Body` the payload should be 

```
{"request": {"userName":"value","password":"value","registry":"value"} }
```