### PR TITLE
Migration to virtual threads - phase 4

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/data/future/AbstractFutureStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/data/future/AbstractFutureStore.groovy
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeoutException
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Value
+import io.micronaut.scheduling.TaskExecutors
 import io.seqera.wave.encoder.EncodingStrategy
 import jakarta.inject.Inject
 import jakarta.inject.Named
@@ -55,7 +56,7 @@ abstract class AbstractFutureStore<V> implements FutureStore<String,V> {
     private volatile Duration pollInterval
 
     @Inject
-    @Named('future-store-executor')
+    @Named(TaskExecutors.BLOCKING)
     private ExecutorService executor
 
     AbstractFutureStore(FutureHash<String> store, EncodingStrategy<V> encodingStrategy) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,9 +41,6 @@ micronaut:
     stream-executor:
       type: FIXED
       number-of-threads: 16
-    future-store-executor:
-      type : FIXED
-      number-of-threads : 32
   netty:
     event-loops:
       stream-pool:


### PR DESCRIPTION
This PR introduces the use of virtual threads for `AbstractFutureStore` class 