### PR TITLE
Check block existence with object operation

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/blob/impl/BlobCacheServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/blob/impl/BlobCacheServiceImpl.groovy
@@ -17,7 +17,6 @@
  */
 package io.seqera.wave.service.blob.impl
 
-import java.net.http.HttpClient
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -27,7 +26,6 @@ import io.seqera.wave.configuration.BlobCacheConfig
 import io.seqera.wave.configuration.HttpClientConfig
 import io.seqera.wave.core.RegistryProxyService
 import io.seqera.wave.core.RoutePath
-import io.seqera.wave.http.HttpClientFactory
 import io.seqera.wave.service.blob.BlobCacheService
 import io.seqera.wave.service.blob.BlobEntry
 import io.seqera.wave.service.blob.BlobSigningService
@@ -46,7 +44,6 @@ import jakarta.inject.Singleton
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.S3Exception
-
 /**
  * Implements cache for container image layer blobs
  *
@@ -81,13 +78,11 @@ class BlobCacheServiceImpl implements BlobCacheService, JobHandler<BlobEntry> {
     private HttpClientConfig httpConfig
 
     @Inject
+    @Named('BlobS3Client')
     private S3Client s3Client
-
-    private HttpClient httpClient
 
     @PostConstruct
     private void init() {
-        httpClient = HttpClientFactory.followRedirectsHttpClient()
         log.info "Creating Blob cache service - $blobConfig"
     }
 

--- a/src/test/groovy/io/seqera/wave/service/blob/BlobStateStoreImplTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/blob/BlobStateStoreImplTest.groovy
@@ -23,10 +23,14 @@ import spock.lang.Specification
 import java.time.Duration
 
 import io.micronaut.context.annotation.Property
+import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.seqera.wave.configuration.BlobCacheConfig
 import io.seqera.wave.store.state.impl.StateProvider
 import jakarta.inject.Inject
+import jakarta.inject.Named
+import software.amazon.awssdk.services.s3.S3Client
+
 /**
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
@@ -36,6 +40,10 @@ import jakarta.inject.Inject
 @Property(name = 'wave.blobCache.storage.region', value='eu-west-1')
 @MicronautTest
 class BlobStateStoreImplTest extends Specification {
+
+    @MockBean(S3Client)
+    @Named('BlobS3Client')
+    S3Client mockS3Client() { Mock(S3Client) }
 
     @Inject
     BlobStoreImpl store


### PR DESCRIPTION
This PR change the logic for checking the existence of blob cache by using S3 operation instead of HTTP head method. 

This is needed to prevent that the result of the HTTP HEAD check for a non-existing object retuning 404 (not found) is cached by the underlying caching rule as documented [here](https://developers.cloudflare.com/r2/reference/consistency/#caching). 

The of S3 API should bypass the caching layer and therefore preventing this issue. 