### PR TITLE
Workflow to sync changelog with Seqera docs

### DIFF
--- a/.github/workflows/seqera_docs_changelog.yml
+++ b/.github/workflows/seqera_docs_changelog.yml
@@ -1,0 +1,61 @@
+name: Push changelog to Seqera Docs
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: 'Release version (e.g. 1.0.0)'
+        required: true
+      release_body:
+        description: 'Release changelog content'
+        required: true
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+          
+      - name: Clone seqeralabs/docs
+        run: |
+          git clone https://github.com/seqeralabs/docs.git seqeralabs-docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create changelog file
+        run: |
+          mkdir -p seqeralabs-docs/changelog/wave
+          cat << EOF > seqeralabs-docs/changelog/wave/${{ github.event.release.name || inputs.release_name }}.mdx
+          ---
+          title: Wave ${{ github.event.release.name || inputs.release_name }}
+          date: $(date +%Y-%m-%d)
+          tags: [wave]
+          ---
+
+          ${{ github.event.release.body || inputs.release_body }}
+          EOF
+
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCS_BOT_APP_PRIVATE_KEY }}
+          owner: seqeralabs
+          repositories: docs
+        
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          branch-token: ${{ steps.generate-token.outputs.token }}
+          path: seqeralabs-docs
+          commit-message: "Changelog: Wave ${{ github.event.release.name }}"
+          title: "Changelog: Wave ${{ github.event.release.name }}"
+          body: |
+            This PR adds the changelog for Wave ${{ github.event.release.name }} to the Seqera documentation.
+
+            This is an automated PR created from the Wave repository.
+          branch: changelog-wave-${{ github.event.release.name }}
+          base: master
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ deployment-url.txt
 tsp-output/
 node_modules/
 package-lock.json
+
+# Seqera Docs clone
+seqeralabs-docs


### PR DESCRIPTION
Automation to push a changelog entry into [seqeralbas](https://github.com/seqeralabs/docs)

That requires settings a PAT:

* Log into the GitHub account you want to push PRs from (with admin rights for both repos)
* Go to Settings > Developer Settings > Personal Access Tokens > Tokens (classic)
* Click Generate new token
* Select scope to push to seqeralabs/docs
* Store the PAT as `SEQERALABS_DOCS_PAT` secret in wave repo