### PR TITLE
added ttlSecondsAfterFinished for k8s jobs

### DIFF
--- a/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
@@ -106,6 +106,9 @@ class BlobCacheConfig {
     @Value('${wave.blobCache.transfer.executor-shutdown-timeout:20s}')
     Duration transferExecutorShutdownTimeout
 
+    @Value('${wave.blob.k8s.job.retention.duration:30d}')
+    Duration jobRetentionDuration
+
     Map<String,String> getEnvironment() {
         final result = new HashMap<String,String>(10)
         if( storageRegion ) {

--- a/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
@@ -112,6 +112,9 @@ class BuildConfig {
     @Value('${wave.build.max-container-file-size:10000}')
     int maxContainerFileSize
 
+    @Value('${wave.build.k8s.job.retention.duration:30d}')
+    Duration jobRetentionDuration
+
     @PostConstruct
     private void init() {
         log.info("Builder config: " +

--- a/src/main/groovy/io/seqera/wave/configuration/MirrorConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/MirrorConfig.groovy
@@ -59,4 +59,7 @@ class MirrorConfig {
     @Value('${wave.mirror.requestsMemory}')
     String requestsMemory
 
+    @Value('${wave.mirror.k8s.job.retention.duration:30d}')
+    Duration jobRetentionDuration
+
 }

--- a/src/main/groovy/io/seqera/wave/configuration/ScanConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/ScanConfig.groovy
@@ -88,6 +88,9 @@ class ScanConfig {
     @Value('${wave.scan.vulnerability.limit:100}')
     Integer vulnerabilityLimit
 
+    @Value('${wave.scan.k8s.job.retention.duration:30d}')
+    Duration jobRetentionDuration
+
     String getScanImage() {
         return scanImage
     }

--- a/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
@@ -454,6 +454,7 @@ class K8sServiceImpl implements K8sService {
 
         //spec section
         def spec = builder.withNewSpec()
+                .withTtlSecondsAfterFinished(blobConfig.jobRetentionDuration.toSeconds() as Integer)
                 .withBackoffLimit(blobConfig.retryAttempts)
                 .withNewTemplate()
                     .editOrNewSpec()
@@ -534,6 +535,7 @@ class K8sServiceImpl implements K8sService {
         //spec section
         def spec = builder
                 .withNewSpec()
+                .withTtlSecondsAfterFinished(buildConfig.jobRetentionDuration.toSeconds() as Integer)
                 .withBackoffLimit(buildConfig.retryAttempts)
                 .withNewTemplate()
                 .withNewMetadata()
@@ -614,6 +616,7 @@ class K8sServiceImpl implements K8sService {
         //spec section
         def spec = builder
                 .withNewSpec()
+                .withTtlSecondsAfterFinished(scanConfig.jobRetentionDuration.toSeconds() as Integer)
                 .withBackoffLimit(scanConfig.retryAttempts)
                 .withNewTemplate()
                 .editOrNewSpec()
@@ -682,6 +685,7 @@ class K8sServiceImpl implements K8sService {
         //spec section
         def spec = builder
                 .withNewSpec()
+                .withTtlSecondsAfterFinished(config.jobRetentionDuration.toSeconds() as Integer)
                 .withBackoffLimit(config.retryAttempts)
                 .withNewTemplate()
                 .editOrNewSpec()

--- a/src/test/groovy/io/seqera/wave/service/k8s/K8sServiceImplTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/k8s/K8sServiceImplTest.groovy
@@ -446,6 +446,7 @@ class K8sServiceImplTest extends Specification {
         def config = Mock(BlobCacheConfig) {
             getEnvironment() >> [:]
             getRetryAttempts() >> 5
+            getJobRetentionDuration() >> Duration.ofDays(1)
         }
 
         when:
@@ -455,6 +456,7 @@ class K8sServiceImplTest extends Specification {
         result.metadata.name == 'foo'
         result.metadata.namespace == 'my-ns'
         and:
+        result.spec.ttlSecondsAfterFinished == Duration.ofDays(1).toSeconds() as Integer
         result.spec.backoffLimit == 5
         and:
         verifyAll(result.spec.template.spec) {
@@ -484,6 +486,7 @@ class K8sServiceImplTest extends Specification {
             getRequestsCpu() >> '2'
             getRequestsMemory() >> '8Gi'
             getRetryAttempts() >> 3
+            getJobRetentionDuration() >> Duration.ofDays(1)
         }
 
         when:
@@ -492,6 +495,7 @@ class K8sServiceImplTest extends Specification {
         result.metadata.name == 'foo'
         result.metadata.namespace == 'my-ns'
         and:
+        result.spec.ttlSecondsAfterFinished == Duration.ofDays(1).toSeconds() as Integer
         result.spec.backoffLimit == 3
         and:
         verifyAll(result.spec.template.spec) {
@@ -579,7 +583,8 @@ class K8sServiceImplTest extends Specification {
                 'wave.build.k8s.configPath': '/home/kube.config',
                 'wave.build.k8s.storage.claimName': 'build-claim',
                 'wave.build.k8s.storage.mountPath': '/build',
-                'wave.build.retry-attempts': 3
+                'wave.build.retry-attempts': 3,
+                'wave.build.k8s.job.retention.duration': Duration.ofDays(1)
         ]
         and:
         def ctx = ApplicationContext.run(PROPS)
@@ -596,6 +601,7 @@ class K8sServiceImplTest extends Specification {
         def job = k8sService.buildJobSpec(name, containerImage, args, workDir, credsFile, timeout, nodeSelector)
 
         then:
+        job.spec.ttlSecondsAfterFinished == Duration.ofDays(1).toSeconds() as Integer
         job.spec.backoffLimit == 3
         job.spec.template.spec.containers[0].image == containerImage
         job.spec.template.spec.containers[0].command == args
@@ -695,6 +701,7 @@ class K8sServiceImplTest extends Specification {
             getRequestsCpu() >> '2'
             getRequestsMemory() >> '4Gi'
             getEnvironmentAsTuples() >> [new Tuple2<String, String>('FOO', 'abc'), new Tuple2<String, String>('BAR', 'xyz')]
+            getJobRetentionDuration() >> Duration.ofDays(1)
         }
 
         when:
@@ -738,6 +745,7 @@ class K8sServiceImplTest extends Specification {
             getCacheDirectory() >> Path.of('/build/cache/dir')
             getRequestsCpu() >> '2'
             getRequestsMemory() >> '4Gi'
+            getJobRetentionDuration() >> Duration.ofDays(1)
         }
 
         when:
@@ -781,6 +789,7 @@ class K8sServiceImplTest extends Specification {
             getRequestsCpu() >> '2'
             getRequestsMemory() >> '4Gi'
             getRetryAttempts() >> 3
+            getJobRetentionDuration() >> Duration.ofDays(1)
         }
 
         when:
@@ -825,6 +834,7 @@ class K8sServiceImplTest extends Specification {
             getRequestsCpu() >> null
             getRequestsMemory() >> null
             getRetryAttempts() >> 3
+            getJobRetentionDuration() >> Duration.ofDays(1)
         }
 
         when:
@@ -833,6 +843,7 @@ class K8sServiceImplTest extends Specification {
         then:
         job.metadata.name == name
         job.metadata.namespace == 'foo'
+        job.spec.ttlSecondsAfterFinished == Duration.ofDays(1).toSeconds() as Integer
         job.spec.backoffLimit == 3
         job.spec.template.spec.containers[0].image == containerImage
         job.spec.template.spec.containers[0].args == args
@@ -885,6 +896,7 @@ class K8sServiceImplTest extends Specification {
             getRequestsCpu() >> null
             getRequestsMemory() >> null
             getRetryAttempts() >> 3
+            getJobRetentionDuration() >> Duration.ofDays(1)
         }
 
         when:
@@ -893,6 +905,7 @@ class K8sServiceImplTest extends Specification {
         then:
         job.metadata.name == name
         job.metadata.namespace == 'foo'
+        job.spec.ttlSecondsAfterFinished == Duration.ofDays(1).toSeconds() as Integer
         job.spec.backoffLimit == 3
         job.spec.template.spec.containers[0].image == containerImage
         job.spec.template.spec.containers[0].args == args


### PR DESCRIPTION
There are lot of failed jobs retained which are not getting deleted by our cleanup process.
So this PR will add ttlSecondsAfterFinished which will defaults to 30 days, if not configured in config.