### PR TITLE
Replace volatile with final

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/data/future/AbstractFutureStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/data/future/AbstractFutureStore.groovy
@@ -25,12 +25,10 @@ import java.util.concurrent.TimeoutException
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import io.micronaut.context.annotation.Value
 import io.micronaut.scheduling.TaskExecutors
 import io.seqera.wave.encoder.EncodingStrategy
 import jakarta.inject.Inject
 import jakarta.inject.Named
-
 /**
  * Implements a {@link FutureStore} that allow handling {@link CompletableFuture} objects
  * in a distributed environment.
@@ -52,9 +50,6 @@ abstract class AbstractFutureStore<V> implements FutureStore<String,V> {
 
     private FutureHash<String> store
 
-    @Value('${wave.pairing.channel.awaitTimeout:100ms}')
-    private volatile Duration pollInterval
-
     @Inject
     @Named(TaskExecutors.BLOCKING)
     private ExecutorService executor
@@ -67,6 +62,8 @@ abstract class AbstractFutureStore<V> implements FutureStore<String,V> {
     abstract String prefix()
 
     abstract Duration getTimeout()
+
+    abstract Duration getPollInterval()
 
     /**
      * Create a new {@link CompletableFuture} instance. The future can be "completed" by this or any other instance
@@ -92,7 +89,7 @@ abstract class AbstractFutureStore<V> implements FutureStore<String,V> {
                 if( System.currentTimeMillis()-start > max )
                     throw new TimeoutException("Unable to retrieve a value for key: $target")
                 // sleep for a while
-                sleep(pollInterval.toMillis())
+                sleep(getPollInterval().toMillis())
             }
         }, executor)
     }

--- a/src/main/groovy/io/seqera/wave/service/job/JobQueue.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobQueue.groovy
@@ -37,9 +37,9 @@ import jakarta.inject.Singleton
 @CompileStatic
 class JobQueue extends AbstractMessageStream<JobSpec> {
 
-    final private static String STREAM_NAME = 'jobs-queue/v1'
+    private final static String STREAM_NAME = 'jobs-queue/v1'
 
-    private volatile JobConfig config
+    private final JobConfig config
 
     JobQueue(MessageStream<String> target, JobConfig config) {
         super(target)

--- a/src/main/groovy/io/seqera/wave/service/pairing/socket/PairingInboundStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/pairing/socket/PairingInboundStore.groovy
@@ -27,7 +27,6 @@ import io.seqera.wave.service.data.future.AbstractFutureStore
 import io.seqera.wave.service.data.future.FutureHash
 import io.seqera.wave.service.pairing.socket.msg.PairingMessage
 import jakarta.inject.Singleton
-
 /**
  * Model an distribute store for completable future that
  * used to collect inbound messages
@@ -38,11 +37,17 @@ import jakarta.inject.Singleton
 @CompileStatic
 class PairingInboundStore extends AbstractFutureStore<PairingMessage> {
 
-    @Value('${wave.pairing.channel.timeout:5s}')
-    private volatile Duration timeout
+    private final Duration timeout
 
-    PairingInboundStore(FutureHash<String> publisher) {
+    private final Duration pollInterval
+
+    PairingInboundStore(FutureHash<String> publisher,
+                        @Value('${wave.pairing.channel.timeout:5s}') Duration timeout,
+                        @Value('${wave.pairing.channel.awaitTimeout:100ms}') Duration pollInterval )
+    {
         super(publisher, new MoshiEncodeStrategy<PairingMessage>() {})
+        this.timeout = timeout
+        this.pollInterval = pollInterval
     }
 
     @Override
@@ -55,5 +60,10 @@ class PairingInboundStore extends AbstractFutureStore<PairingMessage> {
     @Override
     Duration getTimeout() {
         return timeout
+    }
+
+    @Override
+    Duration getPollInterval() {
+        return pollInterval
     }
 }

--- a/src/main/groovy/io/seqera/wave/tower/client/connector/TowerConnector.groovy
+++ b/src/main/groovy/io/seqera/wave/tower/client/connector/TowerConnector.groovy
@@ -84,7 +84,7 @@ abstract class TowerConnector {
 
     @Inject
     @Named(TaskExecutors.BLOCKING)
-    private volatile ExecutorService ioExecutor
+    private ExecutorService ioExecutor
 
     private CacheLoader<JwtRefreshParams, CompletableFuture<JwtAuth>> loader = new CacheLoader<JwtRefreshParams, CompletableFuture<JwtAuth>>() {
         @Override

--- a/src/test/groovy/io/seqera/wave/service/data/future/AbstractFutureStoreTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/data/future/AbstractFutureStoreTest.groovy
@@ -39,11 +39,16 @@ class AbstractFutureStoreTest extends Specification{
     @Singleton
     static class TestFutureStore extends AbstractFutureStore<String> {
 
-        @Value('${wave.pairing.channel.timeout:1s}')
         Duration timeout
+        Duration pollInterval
 
-        TestFutureStore(FutureHash queue) {
+        TestFutureStore(FutureHash queue,
+            @Value('${wave.pairing.channel.timeout:1s}') Duration timeout,
+            @Value('${wave.pairing.channel.awaitTimeout:100ms}') Duration pollInterval )
+        {
             super(queue, new MoshiEncodeStrategy<String>() {})
+            this.timeout = timeout
+            this.pollInterval = pollInterval
         }
 
         @Override

--- a/src/test/groovy/io/seqera/wave/service/data/queue/AbstractMessageQueueLocalTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/data/queue/AbstractMessageQueueLocalTest.groovy
@@ -63,7 +63,7 @@ class AbstractMessageQueueLocalTest extends Specification {
         queue.close()
     }
 
-    def 'should validate '() {
+    def 'should validate keys prefixes'() {
         given:
         def queue = new PairingOutboundQueue(broker, Duration.ofMillis(100), ioExecutor)
 


### PR DESCRIPTION
This PR replaces the unneeded use of `volatile` with `final` declaration for class attribute definitions. 

When the object is fully constructed, all threads will see the initialized value of final fields, even without synchronization.