### PR TITLE
Remove unneeded user async api

### DIFF
--- a/src/main/groovy/io/seqera/wave/controller/ContainerController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ContainerController.groovy
@@ -20,7 +20,6 @@ package io.seqera.wave.controller
 
 import java.nio.file.Path
 import java.time.Instant
-import java.util.concurrent.CompletableFuture
 import javax.annotation.PostConstruct
 
 import groovy.transform.CompileStatic
@@ -76,7 +75,6 @@ import io.seqera.wave.service.scan.ContainerScanService
 import io.seqera.wave.service.validation.ValidationService
 import io.seqera.wave.service.validation.ValidationServiceImpl
 import io.seqera.wave.tower.PlatformId
-import io.seqera.wave.tower.User
 import io.seqera.wave.tower.auth.JwtAuth
 import io.seqera.wave.tower.auth.JwtAuthStore
 import io.seqera.wave.util.DataTimeUtils
@@ -94,7 +92,6 @@ import static io.seqera.wave.util.ContainerHelper.makeResponseV1
 import static io.seqera.wave.util.ContainerHelper.makeResponseV2
 import static io.seqera.wave.util.ContainerHelper.makeTargetImage
 import static io.seqera.wave.util.ContainerHelper.patchPlatformEndpoint
-import static java.util.concurrent.CompletableFuture.completedFuture
 /**
  * Implement a controller to receive container token requests
  * 
@@ -182,17 +179,17 @@ class ContainerController {
     @Deprecated
     @Post('/container-token')
     @ExecuteOn(TaskExecutors.BLOCKING)
-    CompletableFuture<HttpResponse<SubmitContainerTokenResponse>> getToken(HttpRequest httpRequest, @Body SubmitContainerTokenRequest req) {
+    HttpResponse<SubmitContainerTokenResponse> getToken(HttpRequest httpRequest, @Body SubmitContainerTokenRequest req) {
         return getContainerImpl(httpRequest, req, false)
     }
 
     @Post('/v1alpha2/container')
     @ExecuteOn(TaskExecutors.BLOCKING)
-    CompletableFuture<HttpResponse<SubmitContainerTokenResponse>> getTokenV2(HttpRequest httpRequest, @Body SubmitContainerTokenRequest req) {
+    HttpResponse<SubmitContainerTokenResponse> getTokenV2(HttpRequest httpRequest, @Body SubmitContainerTokenRequest req) {
         return getContainerImpl(httpRequest, req, true)
     }
 
-    protected CompletableFuture<HttpResponse<SubmitContainerTokenResponse>> getContainerImpl(HttpRequest httpRequest, SubmitContainerTokenRequest req, boolean v2) {
+    protected HttpResponse<SubmitContainerTokenResponse> getContainerImpl(HttpRequest httpRequest, SubmitContainerTokenRequest req, boolean v2) {
         // patch platform endpoint
         req.towerEndpoint = patchPlatformEndpoint(req.towerEndpoint)
 
@@ -207,7 +204,7 @@ class ContainerController {
 
         // anonymous access
         if( !req.towerAccessToken ) {
-            return completedFuture(handleRequest(httpRequest, req, PlatformId.NULL, v2))
+            return handleRequest(httpRequest, req, PlatformId.NULL, v2)
         }
 
         // first check if the service is registered
@@ -222,9 +219,8 @@ class ContainerController {
             jwtAuthStore.storeIfAbsent(auth)
 
         // find out the user associated with the specified tower access token
-        return userService
-                .getUserByAccessTokenAsync(registration.endpoint, auth)
-                .thenApply((User user) -> handleRequest(httpRequest, req, PlatformId.of(user,req), v2))
+        final user = userService.getUserByAccessToken(registration.endpoint, auth)
+        return handleRequest(httpRequest, req, PlatformId.of(user,req), v2)
     }
 
     protected HttpResponse<SubmitContainerTokenResponse> handleRequest(HttpRequest httpRequest, SubmitContainerTokenRequest req, PlatformId identity, boolean v2) {

--- a/src/main/groovy/io/seqera/wave/controller/InspectController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/InspectController.groovy
@@ -18,7 +18,6 @@
 
 package io.seqera.wave.controller
 
-import java.util.concurrent.CompletableFuture
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -38,7 +37,6 @@ import io.seqera.wave.service.UserService
 import io.seqera.wave.service.inspect.ContainerInspectService
 import io.seqera.wave.service.pairing.PairingService
 import io.seqera.wave.tower.PlatformId
-import io.seqera.wave.tower.User
 import io.seqera.wave.tower.auth.JwtAuth
 import jakarta.inject.Inject
 import static io.seqera.wave.util.ContainerHelper.patchPlatformEndpoint
@@ -71,7 +69,7 @@ class InspectController {
     private String serverUrl
 
     @Post("/v1alpha1/inspect")
-    CompletableFuture<HttpResponse<ContainerInspectResponse>> inspect(@Body ContainerInspectRequest req, @Nullable @QueryValue String platform) {
+    HttpResponse<ContainerInspectResponse> inspect(@Body ContainerInspectRequest req, @Nullable @QueryValue String platform) {
 
         if( !req.containerImage )
             throw new BadRequestException("Missing 'containerImage' attribute")
@@ -86,7 +84,7 @@ class InspectController {
 
         // anonymous access
         if( !req.towerAccessToken ) {
-            return CompletableFuture.completedFuture(makeResponse(req, platform, PlatformId.NULL))
+            return makeResponse(req, platform, PlatformId.NULL)
         }
 
         // We first check if the service is registered
@@ -95,10 +93,8 @@ class InspectController {
             throw new BadRequestException("Tower instance '${req.towerEndpoint}' has not enabled to connect Wave service '$serverUrl'")
 
         // find out the user associated with the specified tower access token
-        return userService
-                .getUserByAccessTokenAsync(registration.endpoint, JwtAuth.of(req))
-                .thenApply((User user) -> makeResponse(req, platform, PlatformId.of(user,req)) )
-
+        final user = userService .getUserByAccessToken(registration.endpoint, JwtAuth.of(req))
+        return makeResponse(req, platform, PlatformId.of(user,req))
     }
 
     protected HttpResponse<ContainerInspectResponse> makeResponse(ContainerInspectRequest req, String platform, PlatformId identity) {

--- a/src/main/groovy/io/seqera/wave/controller/RegistryProxyController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/RegistryProxyController.groovy
@@ -215,7 +215,7 @@ class RegistryProxyController {
         }
         else if( resp.body!=null ) {
             log.debug "Returning ${route.type} from repository: '${route.getTargetContainer()}'"
-            return fromContentResponse(resp, route)
+            return fromContentResponse(resp)
         }
         else if( blobCacheService ) {
             log.debug "Forwarding ${route.type} cache request '${route.getTargetContainer()}'"
@@ -346,7 +346,7 @@ class RegistryProxyController {
                 .headers(toMutableHeaders(response.headers))
     }
 
-    MutableHttpResponse<?> fromContentResponse(DelegateResponse resp, RoutePath route) {
+    MutableHttpResponse<?> fromContentResponse(DelegateResponse resp) {
         HttpResponse
                 .status(HttpStatus.valueOf(resp.statusCode))
                 .body(resp.body)

--- a/src/main/groovy/io/seqera/wave/service/UserService.groovy
+++ b/src/main/groovy/io/seqera/wave/service/UserService.groovy
@@ -18,11 +18,9 @@
 
 package io.seqera.wave.service
 
-import java.util.concurrent.CompletableFuture
 
 import io.seqera.wave.tower.User
 import io.seqera.wave.tower.auth.JwtAuth
-
 /**
  * Declare a service to access a Tower user
  *
@@ -31,7 +29,5 @@ import io.seqera.wave.tower.auth.JwtAuth
 interface UserService {
 
     User getUserByAccessToken(String endpoint, JwtAuth auth)
-
-    CompletableFuture<User> getUserByAccessTokenAsync(String endpoint, JwtAuth auth)
 
 }

--- a/src/main/groovy/io/seqera/wave/service/UserServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/UserServiceImpl.groovy
@@ -18,19 +18,15 @@
 
 package io.seqera.wave.service
 
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutorService
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.core.annotation.Nullable
-import io.micronaut.scheduling.TaskExecutors
 import io.seqera.wave.exception.UnauthorizedException
 import io.seqera.wave.tower.User
 import io.seqera.wave.tower.auth.JwtAuth
 import io.seqera.wave.tower.client.TowerClient
 import jakarta.inject.Inject
-import jakarta.inject.Named
 import jakarta.inject.Singleton
 /**
  * Define a service to access a Tower user
@@ -45,18 +41,6 @@ class UserServiceImpl implements UserService {
     @Inject
     @Nullable
     private TowerClient towerClient
-
-    @Inject
-    @Named(TaskExecutors.BLOCKING)
-    private ExecutorService ioExecutor
-
-    @Override
-    CompletableFuture<User> getUserByAccessTokenAsync(String endpoint, JwtAuth auth) {
-        if( !towerClient )
-            throw new IllegalStateException("Missing Tower client - make sure the 'tower' micronaut environment has been provided")
-
-        return CompletableFuture.supplyAsync(()-> getUserByAccessToken(endpoint,auth), ioExecutor)
-    }
 
     @Override
     User getUserByAccessToken(String endpoint, JwtAuth auth) {


### PR DESCRIPTION
This PR removes the use of async API for `getUserByAccessToken` method since the use of virtual threads make it useless.