### PR TITLE
Changelog PR: Add link to release

### DIFF
--- a/.github/workflows/seqera_docs_changelog.yml
+++ b/.github/workflows/seqera_docs_changelog.yml
@@ -55,6 +55,8 @@ jobs:
           body: |
             This PR adds the changelog for Wave ${{ github.event.release.name || inputs.release_name }} to the Seqera documentation.
 
+            https://github.com/seqeralabs/wave/releases/tag/${{ github.event.release.name || inputs.release_name }}
+
             This is an automated PR created from the Wave repository.
           branch: changelog-wave-${{ github.event.release.name || inputs.release_name }}
           base: master


### PR DESCRIPTION
When creating a PR to the Seqera docs for a changelog entry, include a link in the comment to the release in question.