### PR TITLE
Implement pending queue as stream

### DIFF
--- a/src/main/groovy/io/seqera/wave/configuration/JobManagerConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/JobManagerConfig.groovy
@@ -39,7 +39,7 @@ class JobManagerConfig {
     @Value('${wave.job-manager.poll-interval:1s}')
     Duration pollInterval
 
-    @Value('${wave.job-manager.scheduler-interval:400ms}')
+    @Value('${wave.job-manager.scheduler-interval:1s}')
     Duration schedulerInterval
 
     @Value('${wave.job-manager.scheduler-max-delay:1m}')

--- a/src/main/groovy/io/seqera/wave/service/job/JobDispatcher.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobDispatcher.groovy
@@ -91,12 +91,6 @@ class JobDispatcher {
     }
 
     JobSpec launchJob(JobSpec job) {
-        try {
-            return apply(job, (handler, entry)-> handler.launchJob(job, entry))
-        }
-        catch (Throwable error) {
-            notifyJobException(job, error)
-            return null
-        }
+        return apply(job, (handler, entry)-> handler.launchJob(job, entry))
     }
 }

--- a/src/main/groovy/io/seqera/wave/service/job/JobManager.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobManager.groovy
@@ -18,12 +18,9 @@
 
 package io.seqera.wave.service.job
 
-import io.seqera.wave.configuration.JobManagerConfig
-
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ExecutorService
-import javax.annotation.PreDestroy
 
 import com.github.benmanes.caffeine.cache.AsyncCache
 import com.github.benmanes.caffeine.cache.Cache
@@ -32,6 +29,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Context
 import io.micronaut.scheduling.TaskExecutors
+import io.seqera.wave.configuration.JobManagerConfig
 import jakarta.annotation.PostConstruct
 import jakarta.inject.Inject
 import jakarta.inject.Named
@@ -67,8 +65,6 @@ class JobManager {
     // FIXME https://github.com/seqeralabs/wave/issues/747
     private AsyncCache<String,Instant> debounceCache
 
-    private Thread scheduleJobThread
-
     @PostConstruct
     void init() {
         log.info "Creating job manager - config=$config"
@@ -77,62 +73,45 @@ class JobManager {
                 .expireAfterWrite(config.graceInterval.multipliedBy(2))
                 .executor(ioExecutor)
                 .buildAsync()
+        pendingQueue.addConsumer((job)-> launchJob(job))
         processingQueue.addConsumer((job)-> processJob(job))
-        // run the scheduler thread
-        scheduleJobThread = Thread.ofPlatform()
-                .name("jobs-scheduler-thread")
-                .daemon(true)
-                .start(()->scheduleJobs())
     }
 
-    protected void scheduleJobs() {
-        try {
-            scheduleJobs0()
-        }
-        catch (InterruptedException e) {
-            log.debug "Got interrupted exception"
-        }
-        finally {
-            log.debug "Exiting job scheduler thread"
-        }
-
-    }
-    protected void scheduleJobs0() {
-        int errors=0
-        while( !Thread.currentThread().isInterrupted() ) {
-            try {
-                schedule0()
-                errors=0
-            }
-            catch (InterruptedException e) {
-                log.debug "Got interrupted exception"
-                break
-            }
-            catch (Throwable e) {
-                final delay = Math.min(Math.pow(2, errors++) * config.schedulerInterval.toMillis() as long, config.schedulerMaxDelay.toMillis())
-                log.debug "Unexpected error while scheduling scheduling job [awaiting ${Duration.ofMillis(delay)}] - cause: ${e.message}", e
-                Thread.sleep(delay)
-            }
-        }
-    }
-
-    protected void schedule0() {
-        if( pendingQueue.length()==0 ) {
-            log.trace "No pending jobs to schedule"
-            // wait for new jobs
-            sleep config.schedulerInterval.toMillis()
-        }
-        else {
-            final processingQueueLen = processingQueue.length()
-            final canLaunchNewJobs = processingQueueLen<config.maxRunningJobs
-            final jobSpec = canLaunchNewJobs ? pendingQueue.poll() : null
-            final submitted = jobSpec ? dispatcher.launchJob(jobSpec) : null
+    protected boolean launchJob0(JobSpec job) {
+        final processingQueueLen = processingQueue.length()
+        final canLaunchNewJobs = processingQueueLen < config.maxRunningJobs
+        if( canLaunchNewJobs ) {
+            final submitted = dispatcher.launchJob(job)
             if( log.isTraceEnabled() )
-                log.trace "Processing queue len=${processingQueueLen}; job=${jobSpec}; submitted=${submitted}"
+                log.trace "Processing queue len=${processingQueueLen}; job=${job}; submitted=${submitted}"
             if( submitted )
                 processingQueue.offer(submitted)
-            if( !canLaunchNewJobs )
-                Thread.sleep(config.schedulerInterval.toMillis())
+        }
+        else {
+            log.debug "Processing queue is full (${processingQueueLen}) - delaying submission of job=$job"
+        }
+        return canLaunchNewJobs
+    }
+
+    /**
+     * Launch a job execution adding it to the {@link JobProcessingQueue} queue
+     *
+     * @param jobSpec
+     *      A {@link JobSpec} object representing the job to be launched
+     * @return
+     *      {@code true} to signal the process has been launched successfully and it should
+     *      be removed from the underlying pending queue, or {@code false} if the job cannot be
+     *      launched because the processing queue is full.
+     */
+    protected boolean launchJob(JobSpec jobSpec) {
+        try {
+            return launchJob0(jobSpec)
+        }
+        catch (Throwable err) {
+            // in the case of an expected exception report the error condition by using `onJobException`
+            dispatcher.notifyJobException(jobSpec, err)
+            // note: return `true` to mark the entry as consumed so that the job is not processed anymore
+            return true
         }
     }
 
@@ -153,7 +132,7 @@ class JobManager {
         catch (Throwable err) {
             // in the case of an expected exception report the error condition by using `onJobException`
             dispatcher.notifyJobException(jobSpec, err)
-            // note: return `true` to signal the job should not be processed anymore
+            // note: return `true` to mark the entry as consumed so that the job is not processed anymore
             return true
         }
     }
@@ -209,14 +188,4 @@ class JobManager {
         }
     }
 
-    @PreDestroy
-    void destroy() {
-        scheduleJobThread.interrupt()
-        try {
-            scheduleJobThread.join(1_000)
-        }
-        catch (Exception e) {
-            log.warn "Unable to join scheduler thread - cause: ${e.message}", e
-        }
-    }
 }

--- a/src/main/groovy/io/seqera/wave/service/job/JobPendingQueue.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobPendingQueue.groovy
@@ -18,12 +18,17 @@
 
 package io.seqera.wave.service.job
 
+import java.time.Duration
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import io.seqera.wave.configuration.JobManagerConfig
 import io.seqera.wave.encoder.EncodingStrategy
 import io.seqera.wave.encoder.MoshiEncodeStrategy
-import io.seqera.wave.service.data.queue.MessageQueue
+import io.seqera.wave.service.data.stream.AbstractMessageStream
+import io.seqera.wave.service.data.stream.MessageConsumer
+import io.seqera.wave.service.data.stream.MessageStream
+import jakarta.annotation.PreDestroy
 import jakarta.inject.Singleton
 /**
  * Model a FIFO queue that accumulates job requests waiting to be submitted
@@ -34,31 +39,46 @@ import jakarta.inject.Singleton
 @Slf4j
 @Singleton
 @CompileStatic
-class JobPendingQueue {
+class JobPendingQueue extends AbstractMessageStream<JobSpec> {
 
-    private final static String QUEUE_NAME = 'jobs-pending/v1'
-
-    private MessageQueue<String> delegate
+    private final static String STREAM_NAME = 'jobs-pending/v2'
 
     private EncodingStrategy<JobSpec> encoder
 
-    JobPendingQueue(MessageQueue<String> queue) {
-        this.delegate = queue
+    private JobManagerConfig config
+
+    JobPendingQueue(MessageStream<String> target, JobManagerConfig config) {
+        super(target)
         this.encoder = new MoshiEncodeStrategy<JobSpec>() {}
-        log.debug "Created jobs processing queue"
+        this.config = config
+        log.debug "Created jobs pending queue"
     }
 
-    void submit(JobSpec request) {
-        delegate.offer(QUEUE_NAME, encoder.encode(request))
+    @Override
+    protected String name() {
+        return "jobs-pending"
     }
 
-    JobSpec poll() {
-        final result = delegate.poll(QUEUE_NAME)
-        return result!=null ? encoder.decode(result) : null
+    @Override
+    protected Duration pollInterval() {
+        return config.schedulerInterval
     }
 
-    int length() {
-        return delegate.length(QUEUE_NAME)
+    final void submit(JobSpec jobSpec) {
+        super.offer(STREAM_NAME, jobSpec)
     }
 
+    final void addConsumer(MessageConsumer<JobSpec> consumer) {
+        super.addConsumer(STREAM_NAME, consumer)
+    }
+
+    final int length() {
+        return super.length(STREAM_NAME)
+    }
+
+    @PreDestroy
+    void destroy() {
+        log.debug "Shutting down jobs pending queue"
+        this.close()
+    }
 }


### PR DESCRIPTION
This PR refactor the jobs pending queue using a Redis stream in place of list relying on the existing `AbstractMessageStream` abstraction 