### PR TITLE
Revert use of async Caffeine cache

### DIFF
--- a/src/main/groovy/io/seqera/wave/auth/RegistryAuthServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/auth/RegistryAuthServiceImpl.groovy
@@ -25,9 +25,9 @@ import java.util.concurrent.CompletionException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 
-import com.github.benmanes.caffeine.cache.AsyncLoadingCache
 import com.github.benmanes.caffeine.cache.CacheLoader
 import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.LoadingCache
 import groovy.json.JsonSlurper
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
@@ -108,8 +108,7 @@ class RegistryAuthServiceImpl implements RegistryAuthService {
         return result
     }
 
-    // FIXME https://github.com/seqeralabs/wave/issues/747
-    private AsyncLoadingCache<CacheKey, String> cacheTokens
+    private LoadingCache<CacheKey, String> cacheTokens
 
     @Inject
     private RegistryLookupService lookupService
@@ -124,7 +123,7 @@ class RegistryAuthServiceImpl implements RegistryAuthService {
                 .maximumSize(10_000)
                 .expireAfterAccess(_1_HOUR.toMillis(), TimeUnit.MILLISECONDS)
                 .executor(ioExecutor)
-                .buildAsync(loader)
+                .build(loader)
     }
 
     /**
@@ -284,8 +283,7 @@ class RegistryAuthServiceImpl implements RegistryAuthService {
     protected String getAuthToken(String image, RegistryAuth auth, RegistryCredentials creds) {
         final key = new CacheKey(image, auth, creds)
         try {
-            // FIXME https://github.com/seqeralabs/wave/issues/747
-            return cacheTokens.synchronous().get(key)
+            return cacheTokens.get(key)
         }
         catch (CompletionException e) {
             // this catches the exception thrown in the cache loader lookup
@@ -303,8 +301,7 @@ class RegistryAuthServiceImpl implements RegistryAuthService {
      */
     void invalidateAuthorization(String image, RegistryAuth auth, RegistryCredentials creds) {
         final key = new CacheKey(image, auth, creds)
-        // FIXME https://github.com/seqeralabs/wave/issues/747
-        cacheTokens.synchronous().invalidate(key)
+        cacheTokens.invalidate(key)
         tokenStore.remove(getStableKey(key))
     }
 

--- a/src/main/groovy/io/seqera/wave/service/data/queue/AbstractMessageQueue.groovy
+++ b/src/main/groovy/io/seqera/wave/service/data/queue/AbstractMessageQueue.groovy
@@ -24,7 +24,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.github.benmanes.caffeine.cache.AsyncCache
+import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -35,7 +35,6 @@ import io.seqera.wave.service.pairing.socket.MessageSender
 import io.seqera.wave.util.ExponentialAttempt
 import io.seqera.wave.util.TypeHelper
 import jakarta.annotation.PostConstruct
-
 /**
  * Implements a distributed message queue in which many listeners can register
  * to consume a message. A message instance can be consumed by one and only listener.
@@ -63,8 +62,7 @@ abstract class AbstractMessageQueue<M> implements Runnable {
 
     final private String name0
 
-    // FIXME https://github.com/seqeralabs/wave/issues/747
-    final private AsyncCache<String,Boolean> closedClients
+    final private Cache<String,Boolean> closedClients
 
     AbstractMessageQueue(MessageQueue<String> broker, ExecutorService ioExecutor) {
         final type = TypeHelper.getGenericType(this, 0)
@@ -76,12 +74,12 @@ abstract class AbstractMessageQueue<M> implements Runnable {
         this.thread.setDaemon(true)
     }
 
-    private AsyncCache<String,Boolean> createCache(ExecutorService ioExecutor) {
+    private Cache<String,Boolean> createCache(ExecutorService ioExecutor) {
         Caffeine
                 .newBuilder()
                 .executor(ioExecutor)
                 .expireAfterWrite(10, TimeUnit.MINUTES)
-                .buildAsync()
+                .build()
     }
 
     /**
@@ -172,8 +170,7 @@ abstract class AbstractMessageQueue<M> implements Runnable {
 
     @Override
     void run() {
-        // FIXME https://github.com/seqeralabs/wave/issues/747
-        final clientsCache = closedClients.synchronous()
+        final clientsCache = closedClients
         while( !thread.isInterrupted() ) {
             try {
                 int sent=0

--- a/src/main/groovy/io/seqera/wave/service/job/JobManager.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobManager.groovy
@@ -22,7 +22,6 @@ import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ExecutorService
 
-import com.github.benmanes.caffeine.cache.AsyncCache
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import groovy.transform.CompileStatic
@@ -62,8 +61,7 @@ class JobManager {
     @Named(TaskExecutors.BLOCKING)
     private ExecutorService ioExecutor
 
-    // FIXME https://github.com/seqeralabs/wave/issues/747
-    private AsyncCache<String,Instant> debounceCache
+    private Cache<String,Instant> debounceCache
 
     @PostConstruct
     void init() {
@@ -72,7 +70,7 @@ class JobManager {
                 .newBuilder()
                 .expireAfterWrite(config.graceInterval.multipliedBy(2))
                 .executor(ioExecutor)
-                .buildAsync()
+                .build()
         pendingQueue.addConsumer((job)-> launchJob(job))
         processingQueue.addConsumer((job)-> processJob(job))
     }
@@ -138,8 +136,7 @@ class JobManager {
     }
 
     protected JobState state(JobSpec job) {
-        // FIXME https://github.com/seqeralabs/wave/issues/747
-        return state0(job, config.graceInterval, debounceCache.synchronous())
+        return state0(job, config.graceInterval, debounceCache)
     }
 
     protected JobState state0(final JobSpec job, final Duration graceInterval, final Cache<String,Instant> cache) {


### PR DESCRIPTION
This PR reverts the use of Caffeine async cache. The use of async is not needed anymore sync starting of Java 24 virtual thread works properly with `synchronised` blocks 

Close https://github.com/seqeralabs/wave/issues/747

