### PR TITLE
Fix listener thread

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/data/stream/AbstractMessageStream.groovy
+++ b/src/main/groovy/io/seqera/wave/service/data/stream/AbstractMessageStream.groovy
@@ -58,9 +58,13 @@ abstract class AbstractMessageStream<M> implements Closeable {
         this.encoder = new MoshiEncodeStrategy<M>(type) {}
         this.stream = target
         this.name0 = name() + '-thread-' + count.getAndIncrement()
-        this.thread = new Thread(()-> processMessages(), name0)
-        this.thread.setDaemon(true)
-        this.thread.start()
+    }
+
+    protected Thread createListenerThread() {
+        final thread = new Thread(()-> processMessages(), name0)
+        thread.setDaemon(true)
+        thread.start()
+        return thread
     }
 
     /**
@@ -109,6 +113,9 @@ abstract class AbstractMessageStream<M> implements Closeable {
             stream.init(streamId)
             // then add the consumer to the listeners
             listeners.put(streamId, consumer)
+            // finally start the listener thread
+            if( !thread )
+                thread = createListenerThread()
         }
     }
 

--- a/src/main/groovy/io/seqera/wave/service/job/JobPendingQueue.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobPendingQueue.groovy
@@ -51,7 +51,7 @@ class JobPendingQueue extends AbstractMessageStream<JobSpec> {
         super(target)
         this.encoder = new MoshiEncodeStrategy<JobSpec>() {}
         this.config = config
-        log.debug "Created jobs pending queue"
+        log.debug "Created jobs pending queue - config=${config}"
     }
 
     @Override

--- a/src/main/groovy/io/seqera/wave/service/job/JobProcessingQueue.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobProcessingQueue.groovy
@@ -48,7 +48,7 @@ class JobProcessingQueue extends AbstractMessageStream<JobSpec> {
     JobProcessingQueue(MessageStream<String> target, JobManagerConfig config) {
         super(target)
         this.config = config
-        log.debug "Created jobs processing queue"
+        log.debug "Created jobs processing queue - config=${config}"
     }
 
     @Override


### PR DESCRIPTION
This fixed a null pointer exception when accessing the `config.pollInterval` attribute. 

This happens because the `config` attribute is set \*after* the invocation of the super-constructor, that launches a listening process on a separate thread. 

The solution consist postponing the listener creation and launch thread after the class initialisation. 