### PR TITLE
Add lite configuration environment

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@
 #
 
 micronautVersion=4.7.6
-micronautEnvs=dev,h2,mail,aws-ses
+micronautEnvs=dev,h2,mail,aws-ses,lite

--- a/src/main/groovy/io/seqera/wave/auth/RegistryCredentialsProviderImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/auth/RegistryCredentialsProviderImpl.groovy
@@ -50,6 +50,7 @@ class RegistryCredentialsProviderImpl implements RegistryCredentialsProvider {
     private CredentialsService credentialsService
 
     @Inject
+    @Nullable
     private BuildConfig buildConfig
 
     /**
@@ -116,7 +117,7 @@ class RegistryCredentialsProviderImpl implements RegistryCredentialsProvider {
         // NOTE: this requires that 'defaultBuildRepository', 'defaultCacheRepository' and 'defaultPublicRepository' have a unique registry host name
         // that means that for example docker.io/some/repo should not be used otherwise wave credentials could be used in place of user credentials
         // for a repo having the same registry host
-        if( container.sameRegistry(buildConfig.defaultBuildRepository) || container.sameRegistry(buildConfig.defaultCacheRepository) || container.sameRegistry(buildConfig.defaultPublicRepository) )
+        if( container.sameRegistry(buildConfig?.defaultBuildRepository) || container.sameRegistry(buildConfig?.defaultCacheRepository) || container.sameRegistry(buildConfig?.defaultPublicRepository) )
             return getDefaultCredentials(container)
 
         return getUserCredentials0(container.registry, identity)

--- a/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
@@ -32,7 +32,7 @@ import io.micronaut.core.annotation.Nullable
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Slf4j
-@Requires(property = 'wave.blobCache.enabled', value = 'true')
+@Requires(bean = BlobCacheEnabled)
 @ToString(includeNames = true, includePackage = false, excludes = 'storageSecretKey', ignoreNulls = true)
 @CompileStatic
 class BlobCacheConfig {

--- a/src/main/groovy/io/seqera/wave/configuration/BlobCacheEnabled.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BlobCacheEnabled.groovy
@@ -1,0 +1,33 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.configuration
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Singleton
+@CompileStatic
+@Requires(property = 'wave.blobCache.enabled', value = 'true')
+class BlobCacheEnabled {
+}

--- a/src/main/groovy/io/seqera/wave/configuration/BuildEnabled.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BuildEnabled.groovy
@@ -1,0 +1,35 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.configuration
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+@Singleton
+@Slf4j
+@Requires(property = 'wave.build.enabled', value = 'true')
+class BuildEnabled {
+}

--- a/src/main/groovy/io/seqera/wave/configuration/MirrorEnabled.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/MirrorEnabled.groovy
@@ -1,0 +1,33 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.configuration
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Singleton
+@CompileStatic
+@Requires(property = 'wave.mirror.enabled', value = 'true')
+class MirrorEnabled {
+}

--- a/src/main/groovy/io/seqera/wave/configuration/ScanConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/ScanConfig.groovy
@@ -26,7 +26,6 @@ import javax.annotation.PostConstruct
 import groovy.transform.CompileStatic
 import groovy.transform.Memoized
 import groovy.util.logging.Slf4j
-import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Value
 import io.micronaut.core.annotation.Nullable
 import jakarta.inject.Singleton
@@ -38,7 +37,6 @@ import jakarta.inject.Singleton
 @CompileStatic
 @Singleton
 @Slf4j
-@Requires(property = 'wave.scan.enabled', value = 'true')
 class ScanConfig {
 
     /**

--- a/src/main/groovy/io/seqera/wave/configuration/ScanEnabled.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/ScanEnabled.groovy
@@ -1,0 +1,33 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.configuration
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+@Singleton
+@Requires(property = 'wave.scan.enabled', value = 'true')
+class ScanEnabled {
+}

--- a/src/main/groovy/io/seqera/wave/controller/BuildController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/BuildController.groovy
@@ -20,6 +20,7 @@ package io.seqera.wave.controller
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
@@ -30,6 +31,7 @@ import io.micronaut.http.server.types.files.StreamedFile
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
 import io.seqera.wave.api.BuildStatusResponse
+import io.seqera.wave.configuration.BuildEnabled
 import io.seqera.wave.service.builder.ContainerBuildService
 import io.seqera.wave.service.logs.BuildLogService
 import io.seqera.wave.service.persistence.WaveBuildRecord
@@ -41,6 +43,7 @@ import jakarta.inject.Inject
  */
 @Slf4j
 @CompileStatic
+@Requires(bean = BuildEnabled)
 @Controller("/")
 @ExecuteOn(TaskExecutors.BLOCKING)
 class BuildController {

--- a/src/main/groovy/io/seqera/wave/controller/ContainerController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ContainerController.groovy
@@ -49,6 +49,8 @@ import io.seqera.wave.configuration.BuildConfig
 import io.seqera.wave.core.ContainerPlatform
 import io.seqera.wave.core.RegistryProxyService
 import io.seqera.wave.exception.BadRequestException
+import io.seqera.wave.exception.BuildServiceUnavailableException
+import io.seqera.wave.exception.MirrorServiceUnavailableException
 import io.seqera.wave.exception.NotFoundException
 import io.seqera.wave.exchange.DescribeWaveContainerResponse
 import io.seqera.wave.model.ContainerCoordinates
@@ -131,6 +133,7 @@ class ContainerController {
     private BuildConfig buildConfig
 
     @Inject
+    @Nullable
     private ContainerBuildService buildService
 
     @Inject
@@ -162,6 +165,7 @@ class ContainerController {
     private RateLimiterService rateLimiterService
 
     @Inject
+    @Nullable
     private ContainerMirrorService mirrorService
 
     @Inject
@@ -427,6 +431,7 @@ class ContainerController {
         String scanId
         Boolean succeeded
         if( req.containerFile ) {
+            if( !buildService ) throw new BuildServiceUnavailableException()
             final build = makeBuildRequest(req, identity, ip)
             final track = checkBuild(build, req.dryRun)
             targetImage = track.targetImage
@@ -439,6 +444,7 @@ class ContainerController {
             type = ContainerRequest.Type.Build
         }
         else if( req.mirror ) {
+            if( !mirrorService ) throw new MirrorServiceUnavailableException()
             final mirror = makeMirrorRequest(req, identity, digest)
             final track = checkMirror(mirror, identity, req.dryRun)
             targetImage = track.targetImage

--- a/src/main/groovy/io/seqera/wave/controller/MirrorController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/MirrorController.groovy
@@ -20,11 +20,13 @@ package io.seqera.wave.controller
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import io.micronaut.core.annotation.Nullable
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.scheduling.TaskExecutors
 import io.micronaut.scheduling.annotation.ExecuteOn
+import io.seqera.wave.exception.MirrorServiceUnavailableException
 import io.seqera.wave.service.mirror.ContainerMirrorService
 import io.seqera.wave.service.mirror.MirrorResult
 import jakarta.inject.Inject
@@ -40,10 +42,13 @@ import jakarta.inject.Inject
 class MirrorController {
 
     @Inject
+    @Nullable
     private ContainerMirrorService mirrorService
 
     @Get("/v1alpha1/mirrors/{mirrorId}")
     HttpResponse<MirrorResult> getMirrorRecord(String mirrorId) {
+        if( !mirrorService )
+            throw new MirrorServiceUnavailableException()
         final result = mirrorService.getMirrorResult(mirrorId)
         return result
                 ? HttpResponse.ok(result)

--- a/src/main/groovy/io/seqera/wave/controller/RegistryProxyController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/RegistryProxyController.groovy
@@ -82,7 +82,8 @@ class RegistryProxyController {
     private RouteHandler routeHelper
 
     @Inject
-    private ContainerBuildService containerBuildService
+    @Nullable
+    private ContainerBuildService buildService
 
     @Inject
     @Nullable
@@ -135,7 +136,7 @@ class RegistryProxyController {
 
     protected CompletableFuture<MutableHttpResponse<?>> handleFutureBuild0(RoutePath route, HttpRequest httpRequest){
         // check if there's a future build result
-        final future = containerBuildService.buildResult(route)
+        final future = buildService?.buildResult(route)
         if( future ) {
             // wait for the build completion, then apply the usual 'handleGet0' logic
             future

--- a/src/main/groovy/io/seqera/wave/controller/ViewController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ViewController.groovy
@@ -43,8 +43,11 @@ import io.seqera.wave.api.ScanMode
 import io.seqera.wave.api.SubmitContainerTokenRequest
 import io.seqera.wave.api.SubmitContainerTokenResponse
 import io.seqera.wave.exception.BadRequestException
+import io.seqera.wave.exception.BuildServiceUnavailableException
 import io.seqera.wave.exception.HttpResponseException
+import io.seqera.wave.exception.MirrorServiceUnavailableException
 import io.seqera.wave.exception.NotFoundException
+import io.seqera.wave.exception.ScanServiceUnavailableException
 import io.seqera.wave.service.builder.ContainerBuildService
 import io.seqera.wave.service.inspect.ContainerInspectService
 import io.seqera.wave.service.logs.BuildLogService
@@ -83,6 +86,7 @@ class ViewController {
     private PersistenceService persistenceService
 
     @Inject
+    @Nullable
     private ContainerBuildService buildService
 
     @Inject
@@ -97,6 +101,7 @@ class ViewController {
     private ContainerScanService scanService
 
     @Inject
+    @Nullable
     private ContainerMirrorService mirrorService
 
     @Inject
@@ -106,6 +111,8 @@ class ViewController {
     @View("mirror-view")
     @Get('/mirrors/{mirrorId}')
     HttpResponse viewMirror(String mirrorId) {
+        if( !mirrorService )
+            throw new MirrorServiceUnavailableException()
         final result = mirrorService.getMirrorResult(mirrorId)
         if( !result )
             throw new NotFoundException("Unknown container mirror id '$mirrorId'")
@@ -136,6 +143,8 @@ class ViewController {
 
     @Get('/builds/{buildId}')
     HttpResponse viewBuild(String buildId) {
+        if( !buildService )
+            throw new BuildServiceUnavailableException()
         // check redirection for invalid suffix in the form `-nn`
         final r1 = isBuildInvalidSuffix(buildId)
         if( r1 ) {
@@ -357,6 +366,8 @@ class ViewController {
 
     @Get('/scans/{scanId}')
     HttpResponse viewScan(String scanId) {
+        if( !scanService )
+            throw new ScanServiceUnavailableException()
         // check redirection for invalid suffix in the form `-nn`
         final r1 = isScanInvalidSuffix(scanId)
         if( r1 ) {

--- a/src/main/groovy/io/seqera/wave/exception/BuildServiceUnavailableException.groovy
+++ b/src/main/groovy/io/seqera/wave/exception/BuildServiceUnavailableException.groovy
@@ -1,0 +1,33 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.exception
+
+import groovy.transform.CompileStatic
+import io.micronaut.http.HttpStatus
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+class BuildServiceUnavailableException extends HttpResponseException {
+    BuildServiceUnavailableException() {
+        super(HttpStatus.SERVICE_UNAVAILABLE, "Build service is not enabled - Check Wave configuration setting 'wave.build.enabled'")
+    }
+}

--- a/src/main/groovy/io/seqera/wave/exception/MirrorServiceUnavailableException.groovy
+++ b/src/main/groovy/io/seqera/wave/exception/MirrorServiceUnavailableException.groovy
@@ -1,0 +1,33 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.exception
+
+import groovy.transform.CompileStatic
+import io.micronaut.http.HttpStatus
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+class MirrorServiceUnavailableException extends HttpResponseException {
+    MirrorServiceUnavailableException() {
+        super(HttpStatus.SERVICE_UNAVAILABLE, "Mirror service is not enabled - Check Wave configuration setting 'wave.mirror.enabled'")
+    }
+}

--- a/src/main/groovy/io/seqera/wave/exception/ScanServiceUnavailableException.groovy
+++ b/src/main/groovy/io/seqera/wave/exception/ScanServiceUnavailableException.groovy
@@ -1,0 +1,33 @@
+/*
+ *  Wave, containers provisioning service
+ *  Copyright (c) 2023-2024, Seqera Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.seqera.wave.exception
+
+import groovy.transform.CompileStatic
+import io.micronaut.http.HttpStatus
+
+/**
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+class ScanServiceUnavailableException extends HttpResponseException {
+    ScanServiceUnavailableException() {
+        super(HttpStatus.SERVICE_UNAVAILABLE, "Security scan service is not enabled - Check Wave configuration setting 'wave.scan.enabled'")
+    }
+}

--- a/src/main/groovy/io/seqera/wave/service/blob/impl/BlobCacheServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/blob/impl/BlobCacheServiceImpl.groovy
@@ -22,6 +22,7 @@ import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Value
 import io.seqera.wave.configuration.BlobCacheConfig
+import io.seqera.wave.configuration.BlobCacheEnabled
 import io.seqera.wave.configuration.HttpClientConfig
 import io.seqera.wave.core.RegistryProxyService
 import io.seqera.wave.core.RoutePath
@@ -51,7 +52,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception
 @Slf4j
 @Named('Transfer')
 @Singleton
-@Requires(property = 'wave.blobCache.enabled', value = 'true')
+@Requires(bean = BlobCacheEnabled)
 @CompileStatic
 class BlobCacheServiceImpl implements BlobCacheService, JobHandler<BlobEntry> {
 

--- a/src/main/groovy/io/seqera/wave/service/builder/DockerBuildStrategy.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/DockerBuildStrategy.groovy
@@ -23,8 +23,10 @@ import java.nio.file.Path
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import io.micronaut.context.annotation.Requires
 import io.micronaut.context.annotation.Value
 import io.seqera.wave.configuration.BuildConfig
+import io.seqera.wave.configuration.BuildEnabled
 import io.seqera.wave.core.ContainerPlatform
 import io.seqera.wave.core.RegistryProxyService
 import jakarta.inject.Inject
@@ -39,6 +41,7 @@ import static java.nio.file.StandardOpenOption.WRITE
  */
 @Slf4j
 @Singleton
+@Requires(bean = BuildEnabled)
 @CompileStatic
 class DockerBuildStrategy extends BuildStrategy {
 

--- a/src/main/groovy/io/seqera/wave/service/builder/KubeBuildStrategy.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/KubeBuildStrategy.groovy
@@ -29,6 +29,7 @@ import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Nullable
 import io.seqera.wave.configuration.BuildConfig
+import io.seqera.wave.configuration.BuildEnabled
 import io.seqera.wave.core.RegistryProxyService
 import io.seqera.wave.exception.BadRequestException
 import io.seqera.wave.service.k8s.K8sService
@@ -43,6 +44,7 @@ import static io.seqera.wave.util.K8sHelper.getSelectorLabel
 @Slf4j
 @Primary
 @Requires(property = 'wave.build.k8s')
+@Requires(bean = BuildEnabled)
 @Singleton
 @CompileStatic
 class KubeBuildStrategy extends BuildStrategy {

--- a/src/main/groovy/io/seqera/wave/service/builder/impl/ContainerBuildServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/builder/impl/ContainerBuildServiceImpl.groovy
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService
 import groovy.json.JsonOutput
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import io.micronaut.context.annotation.Requires
 import io.micronaut.context.event.ApplicationEventPublisher
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.scheduling.TaskExecutors
@@ -36,6 +37,7 @@ import io.seqera.wave.api.BuildContext
 import io.seqera.wave.auth.RegistryCredentialsProvider
 import io.seqera.wave.auth.RegistryLookupService
 import io.seqera.wave.configuration.BuildConfig
+import io.seqera.wave.configuration.BuildEnabled
 import io.seqera.wave.configuration.HttpClientConfig
 import io.seqera.wave.core.RegistryProxyService
 import io.seqera.wave.exception.HttpServerRetryableErrorException
@@ -79,6 +81,7 @@ import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE
  */
 @Slf4j
 @Singleton
+@Requires(bean = BuildEnabled)
 @Named('Build')
 @CompileStatic
 class ContainerBuildServiceImpl implements ContainerBuildService, JobHandler<BuildEntry> {

--- a/src/main/groovy/io/seqera/wave/service/cleanup/CleanupServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/cleanup/CleanupServiceImpl.groovy
@@ -24,6 +24,7 @@ import java.time.Instant
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Context
+import io.micronaut.context.annotation.Requires
 import io.micronaut.scheduling.TaskScheduler
 import io.seqera.wave.configuration.ScanConfig
 import io.seqera.wave.service.job.JobOperation
@@ -38,6 +39,7 @@ import jakarta.inject.Inject
  */
 @Slf4j
 @Context
+@Requires(notEnv = 'lite')
 @CompileStatic
 class CleanupServiceImpl implements Runnable, CleanupService {
 

--- a/src/main/groovy/io/seqera/wave/service/job/JobManager.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobManager.groovy
@@ -28,6 +28,7 @@ import com.github.benmanes.caffeine.cache.Caffeine
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Context
+import io.micronaut.context.annotation.Requires
 import io.micronaut.scheduling.TaskExecutors
 import io.seqera.wave.configuration.JobManagerConfig
 import jakarta.annotation.PostConstruct
@@ -40,6 +41,7 @@ import jakarta.inject.Named
  */
 @Slf4j
 @Context
+@Requires(notEnv = 'lite')
 @CompileStatic
 class JobManager {
 

--- a/src/main/groovy/io/seqera/wave/service/job/JobServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/job/JobServiceImpl.groovy
@@ -21,6 +21,7 @@ package io.seqera.wave.service.job
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Nullable
 import io.seqera.wave.service.blob.BlobEntry
 import io.seqera.wave.service.blob.TransferStrategy
@@ -37,6 +38,7 @@ import jakarta.inject.Singleton
  */
 @Slf4j
 @Singleton
+@Requires(notEnv = 'lite')
 @CompileStatic
 class JobServiceImpl implements JobService {
 

--- a/src/main/groovy/io/seqera/wave/service/mirror/ContainerMirrorServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/mirror/ContainerMirrorServiceImpl.groovy
@@ -24,8 +24,10 @@ import java.util.concurrent.ExecutorService
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
+import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.scheduling.TaskExecutors
+import io.seqera.wave.configuration.MirrorEnabled
 import io.seqera.wave.service.builder.BuildTrack
 import io.seqera.wave.service.job.JobHandler
 import io.seqera.wave.service.job.JobService
@@ -39,7 +41,6 @@ import jakarta.inject.Inject
 import jakarta.inject.Named
 import jakarta.inject.Singleton
 import static io.seqera.wave.service.job.JobHelper.saveDockerAuth
-
 /**
  * Implement a service to mirror a container image to a repository specified by the user
  *
@@ -48,6 +49,7 @@ import static io.seqera.wave.service.job.JobHelper.saveDockerAuth
 @Slf4j
 @Singleton
 @Named('Mirror')
+@Requires(bean = MirrorEnabled)
 @CompileStatic
 class ContainerMirrorServiceImpl implements ContainerMirrorService, JobHandler<MirrorEntry> {
 

--- a/src/main/groovy/io/seqera/wave/service/mirror/MirrorStateStore.groovy
+++ b/src/main/groovy/io/seqera/wave/service/mirror/MirrorStateStore.groovy
@@ -18,11 +18,13 @@
 
 package io.seqera.wave.service.mirror
 
+import io.micronaut.context.annotation.Requires
 import io.seqera.wave.configuration.MirrorConfig
 
 import java.time.Duration
 
 import groovy.transform.CompileStatic
+import io.seqera.wave.configuration.MirrorEnabled
 import io.seqera.wave.encoder.MoshiEncodeStrategy
 import io.seqera.wave.store.state.AbstractStateStore
 import io.seqera.wave.store.state.impl.StateProvider
@@ -34,6 +36,7 @@ import jakarta.inject.Singleton
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Singleton
+@Requires(bean = MirrorEnabled)
 @CompileStatic
 class MirrorStateStore extends AbstractStateStore<MirrorEntry> {
 

--- a/src/main/groovy/io/seqera/wave/service/request/ContainerStatusServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/request/ContainerStatusServiceImpl.groovy
@@ -18,6 +18,9 @@
 
 package io.seqera.wave.service.request
 
+import io.seqera.wave.exception.BuildServiceUnavailableException
+import io.seqera.wave.exception.MirrorServiceUnavailableException
+import io.seqera.wave.exception.ScanServiceUnavailableException
 import static io.seqera.wave.api.ContainerStatus.*
 
 import java.time.Duration
@@ -56,9 +59,11 @@ class ContainerStatusServiceImpl implements ContainerStatusService {
     }
 
     @Inject
+    @Nullable
     private ContainerBuildService buildService
 
     @Inject
+    @Nullable
     private ContainerMirrorService mirrorService
 
     @Inject
@@ -73,6 +78,8 @@ class ContainerStatusServiceImpl implements ContainerStatusService {
     private String serverUrl
 
     protected ScanEntry getScanState(String scanId) {
+        if( !scanService )
+            throw new ScanServiceUnavailableException()
         final entry = scanService.getScanState(scanId)
         if( entry!=null )
             return entry
@@ -116,12 +123,15 @@ class ContainerStatusServiceImpl implements ContainerStatusService {
 
     protected ContainerState getContainerState(ContainerRequest request) {
         if( request.mirror && request.buildId ) {
+            if( !mirrorService )
+                throw new MirrorServiceUnavailableException()
             final mirror = mirrorService.getMirrorResult(request.buildId)
             if (!mirror)
                 throw new NotFoundException("Missing container mirror record with id: ${request.buildId}")
             return ContainerState.from(mirror)
         }
         if( request.buildId ) {
+            if( !buildService ) throw new BuildServiceUnavailableException()
             final build = buildService.getBuildRecord(request.buildId)
             if (!build)
                 throw new NotFoundException("Missing container build record with id: ${request.buildId}")

--- a/src/main/groovy/io/seqera/wave/service/scan/ContainerScanServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/scan/ContainerScanServiceImpl.groovy
@@ -30,6 +30,7 @@ import io.micronaut.core.annotation.Nullable
 import io.micronaut.scheduling.TaskExecutors
 import io.seqera.wave.api.ScanMode
 import io.seqera.wave.configuration.ScanConfig
+import io.seqera.wave.configuration.ScanEnabled
 import io.seqera.wave.service.builder.BuildEntry
 import io.seqera.wave.service.builder.BuildRequest
 import io.seqera.wave.service.cleanup.CleanupService
@@ -58,7 +59,7 @@ import static io.seqera.wave.service.job.JobHelper.saveDockerAuth
  */
 @Slf4j
 @Named("Scan")
-@Requires(bean = ScanConfig)
+@Requires(bean = ScanEnabled)
 @Singleton
 @CompileStatic
 class ContainerScanServiceImpl implements ContainerScanService, JobHandler<ScanEntry> {

--- a/src/main/groovy/io/seqera/wave/service/scan/DockerScanStrategy.groovy
+++ b/src/main/groovy/io/seqera/wave/service/scan/DockerScanStrategy.groovy
@@ -18,12 +18,12 @@
 
 package io.seqera.wave.service.scan
 
-
 import java.nio.file.Path
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Requires
+import io.seqera.wave.configuration.BuildEnabled
 import io.seqera.wave.configuration.ScanConfig
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
@@ -36,6 +36,7 @@ import jakarta.inject.Singleton
 @Slf4j
 @Singleton
 @Requires(missingProperty = 'wave.build.k8s')
+@Requires(bean = BuildEnabled)
 @CompileStatic
 class DockerScanStrategy extends ScanStrategy {
 

--- a/src/main/groovy/io/seqera/wave/service/scan/KubeScanStrategy.groovy
+++ b/src/main/groovy/io/seqera/wave/service/scan/KubeScanStrategy.groovy
@@ -18,7 +18,6 @@
 
 package io.seqera.wave.service.scan
 
-
 import java.nio.file.Path
 
 import groovy.transform.CompileStatic
@@ -28,6 +27,7 @@ import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.Nullable
+import io.seqera.wave.configuration.BuildEnabled
 import io.seqera.wave.configuration.ScanConfig
 import io.seqera.wave.exception.BadRequestException
 import io.seqera.wave.service.k8s.K8sService
@@ -41,6 +41,7 @@ import jakarta.inject.Singleton
 @Slf4j
 @Primary
 @Requires(property = 'wave.build.k8s')
+@Requires(bean = BuildEnabled)
 @Singleton
 @CompileStatic
 class KubeScanStrategy extends ScanStrategy {

--- a/src/main/groovy/io/seqera/wave/service/scan/ScanStrategy.groovy
+++ b/src/main/groovy/io/seqera/wave/service/scan/ScanStrategy.groovy
@@ -24,6 +24,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Requires
 import io.seqera.wave.configuration.ScanConfig
+import io.seqera.wave.configuration.ScanEnabled
 import io.seqera.wave.core.ContainerPlatform
 
 /**
@@ -34,7 +35,7 @@ import io.seqera.wave.core.ContainerPlatform
  */
 @Slf4j
 @CompileStatic
-@Requires(bean = ScanConfig)
+@Requires(bean = ScanEnabled)
 abstract class ScanStrategy {
 
     abstract void scanContainer(String jobName, ScanEntry entry)

--- a/src/main/resources/application-lite.yml
+++ b/src/main/resources/application-lite.yml
@@ -1,0 +1,9 @@
+wave:
+  build:
+    enabled: false
+  mirror:
+    enabled: false
+  scan:
+    enabled: false
+  blobCache:
+    enabled: false


### PR DESCRIPTION
This PR introduces a configuration profile named `lite`. When applied, it disables the functionalities that relies on the use of Kubernetes cluster and a shared file system for carrying out the execution compute intensive jobs, and streamline the service installation. 

As a side effect, when enabling this option, the following features are not available:  

* Container Freeze 
* Container Build service
* Container Mirror service 
* Container Security scanning  
* Container blobs caching  

