### PR TITLE
Use uniform notation for resources requests & limits

### DIFF
--- a/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BlobCacheConfig.groovy
@@ -86,18 +86,18 @@ class BlobCacheConfig {
     String s5Image
 
     @Nullable
-    @Value('${wave.blobCache.requestsCpu}')
+    @Value('${wave.blobCache.k8s.resources.requests.cpu}')
     String requestsCpu
 
     @Nullable
-    @Value('${wave.blobCache.requestsMemory}')
+    @Value('${wave.blobCache.k8s.resources.requests.memory}')
     String requestsMemory
 
-    @Value('${wave.blobCache.limitsCpu}')
+    @Value('${wave.blobCache.k8s.resources.limits.cpu}')
     @Nullable
     String limitsCpu
 
-    @Value('${wave.blobCache.limitsMemory}')
+    @Value('${wave.blobCache.k8s.resources.limits.memory}')
     @Nullable
     String limitsMemory
 

--- a/src/main/groovy/io/seqera/wave/configuration/MirrorConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/MirrorConfig.groovy
@@ -52,18 +52,18 @@ class MirrorConfig {
     Integer retryAttempts
 
     @Nullable
-    @Value('${wave.mirror.requestsCpu}')
+    @Value('${wave.mirror.k8s.resources.requests.cpu}')
     String requestsCpu
 
     @Nullable
-    @Value('${wave.mirror.requestsMemory}')
+    @Value('${wave.mirror.k8s.resources.requests.memory}')
     String requestsMemory
 
-    @Value('${wave.mirror.limitsCpu}')
+    @Value('${wave.mirror.k8s.resources.limits.cpu}')
     @Nullable
     String limitsCpu
 
-    @Value('${wave.mirror.limitsMemory}')
+    @Value('${wave.mirror.k8s.resources.limits.memory}')
     @Nullable
     String limitsMemory
 


### PR DESCRIPTION
This PR modifies the notation used for resources requests and limits made by mirror and blobCache service to make consistent with build and scan services 
