### PR TITLE
Increase timeout in test `should build & push container to quay.io`

### DIFF
--- a/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceLiveTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/builder/ContainerBuildServiceLiveTest.groovy
@@ -159,7 +159,7 @@ class ContainerBuildServiceLiveTest extends Specification {
         given:
         def folder = Files.createTempDirectory('test')
         def cacheRepo = buildConfig.defaultCacheRepository
-        def duration = Duration.ofMinutes(1)
+        def duration = Duration.ofSeconds(90)
         and:
         def dockerFile = '''
         FROM busybox


### PR DESCRIPTION
`should build & push container to quay.io` is failing regulary incearing timeout to fix it