### PR TITLE
fix(docs): Include sidebars & fix relative link

### DIFF
--- a/docs/install/configuring-wave-build.md
+++ b/docs/install/configuring-wave-build.md
@@ -340,4 +340,4 @@ Set up monitoring for build operations:
 - **Storage access issues** - Ensure EFS access points are configured correctly
 - **Build timeouts** - Adjust build timeout settings based on workload requirements
 
-For additional configuration options and advanced features, see [Configuring Wave](../configuring-wave.md).
+For additional configuration options and advanced features, see [Configuring Wave](./configuring-wave.md).

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -32,6 +32,11 @@
         "api"
       ]
     },
-    "faq"
+    "faq",
+    {
+      "type": "link",
+      "label": "Changelog",
+      "href": "/changelog/tags/wave"
+    }
   ]
 }


### PR DESCRIPTION
The following fixes a broken link discovered when raising a docs-pr the change is from `../` to `./` along with including the delta for the sidebars from the docs config. 

Relevant docs PR https://github.com/seqeralabs/docs/pull/668 