### PR TITLE
docs: fix wave build steps

### DIFF
--- a/docs/install/configure-wave-build.md
+++ b/docs/install/configure-wave-build.md
@@ -134,18 +134,30 @@ data:
       # Enable build service
       build:
         enabled: true
-        workspace: '/build/work'
+        workspace: '/build/workspace'
+        # Optional: Retain failed builds to gather logs & inspect
+        cleanup: "OnSuccess"
         # Optional: Configure build timeouts
-        timeout: '1h'
-        # Optional: Configure resource limits for build pods
-        resources:
-          requests:
-            memory: '1Gi'
-            cpu: '500m'
-          limits:
-            memory: '4Gi'
-            cpu: '2000m'
-
+        timeout: '15m'
+        # Example additional kubernetes configuration for wave-build
+        k8s:
+          dns:
+            servers:
+              - "1.1.1.1"
+              - "8.8.8.8"
+          namespace: "wave-build"
+          storage:
+            mountPath: "/build"
+            # Relevant volume claim name should match the 
+            claimName: "wave-build-pvc"
+          serviceAccount: "wave-build-sa"
+          resources:
+            requests:
+              memory: '1800Mi'
+          nodeSelector:
+            # this node selector binds the build pods to a separate cluster node group
+            linux/amd64: 'service=wave-build'
+            linux/arm64: 'service=wave-build-arm64'
       # Enable other build-dependent features
       mirror:
         enabled: true
@@ -167,15 +179,6 @@ data:
         endpoint:
           url: "https://your-platform-instance.com/api"
 
-      # Kubernetes-specific configuration for builds
-      k8s:
-        namespace: wave
-        serviceAccount: wave-sa
-        # Optional: Configure build pod settings
-        buildPod:
-          image: 'quay.io/buildah/stable:latest'
-          nodeSelector:
-            wave-builds: "true"
 ```
 
 ## Update Wave Deployment
@@ -224,7 +227,7 @@ spec:
             - name: wave-cfg
               mountPath: /work/config.yml
               subPath: "config.yml"
-            - name: build-storage  # Add EFS mount
+            - name: build-storage
               mountPath: /build
           readinessProbe:
             httpGet:

--- a/docs/install/configure-wave-build.md
+++ b/docs/install/configure-wave-build.md
@@ -153,7 +153,11 @@ data:
           serviceAccount: "wave-build-sa"
           resources:
             requests:
-              memory: '1800Mi'
+              memory: '1Gi'
+              cpu: '500m'
+            limits:
+              memory: '4Gi'
+              cpu: '2000m'
           nodeSelector:
             # this node selector binds the build pods to a separate cluster node group
             linux/amd64: 'service=wave-build'


### PR DESCRIPTION
The following updates the relevant build documentation guide & steps. 

The k8s config was not nested properly under the build config. 

Key items. 

- Changed `workspace` from `/build/work` -> `/build/workspace` this is more to help align terminology and a not strictly needed but helpful.
- `build.k8s.storage.mountpath` set a mount on `/build` for the pod so the directory is usable for build pods to prevent directory not found errors. 
- Added various config examples which a consumer may want to use such as resource limits / node selectors etc. 