### PR TITLE
docs: Fix links broken by renaming page

### DIFF
--- a/docs/tutorials/nextflow-seqera-containers.mdx
+++ b/docs/tutorials/nextflow-seqera-containers.mdx
@@ -96,6 +96,6 @@ Visit [Seqera Containers][sc] to learn more about Seqera's container solutions.
 [Podman]: https://podman.io/docs/installation
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
 
-[wave-build]: /wave_docs/wave_repo/docs/cli/reference.md#build-a-container
+[wave-build]: /wave_docs/wave_repo/docs/cli/use-cases.md#build-a-container
 [nf-config]: /wave_docs/wave_repo/docs/nextflow.md#configuration-options
 [wave-cli]: /wave_docs/wave_repo/docs/cli/index.md

--- a/docs/tutorials/nextflow-wave.mdx
+++ b/docs/tutorials/nextflow-wave.mdx
@@ -178,6 +178,6 @@ Learn more about [Nextflow's integration][nextflow-int] with Wave.
 [nextflow-int]: /wave_docs/wave_repo/docs/nextflow.md
 [Podman]: https://podman.io/docs/installation
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
-[wave-build]: /wave_docs/wave_repo/docs/cli/reference.md#build-a-container
+[wave-build]: /wave_docs/wave_repo/docs/cli/use-cases.md#build-a-container
 [nf-config]: /wave_docs/wave_repo/docs/nextflow.md#configuration-options
 [wave-cli]: /wave_docs/wave_repo/docs/cli/index.md

--- a/docs/tutorials/wave-cli.mdx
+++ b/docs/tutorials/wave-cli.mdx
@@ -160,6 +160,6 @@ Learn more about Wave CLI and how to use it to build containers in the [Wave CLI
 [Podman]: https://podman.io/docs/installation
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
 
-[wave-build]: /wave_docs/wave_repo/docs/cli/reference.md#build-a-container
+[wave-build]: /wave_docs/wave_repo/docs/cli/use-cases.md#build-a-container
 [nf-config]: /wave_docs/wave_repo/docs/nextflow.md#configuration-options
 [wave-cli]: /wave_docs/wave_repo/docs/cli/index.md


### PR DESCRIPTION
- Fix links broken by renaming `reference.md` to `use-cases.md`