### PR TITLE
Wv 217 remove app encoded values for seqera environment

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,15 +92,15 @@ These configurations are important for the Wave authentication to the repositori
 
 - **`wave.build.singularity-image-arm64`**: the ARM64 version of the Singularity image for the build process. The default is `quay.io/singularity/singularity:v3.11.4-slim-arm64`. *Optional*.
 
-- **`wave.build.repo`**: specifies the Docker container repository for the Docker images built by Wave. This setting is required to define where the images will be stored. *Mandatory*.
+- **`wave.build.repo`**: specifies the Container repository for the Docker images built by Wave. This setting is required to define where the images will be stored. *Mandatory*.
 
-- **`wave.build.cache`**: determines the Docker container repository used to cache layers of images built by Wave.  *Mandatory*.
+- **`wave.build.cache`**: determines the Container repository used to cache layers of images built by Wave.  *Mandatory*.
+
+- **`wave.build.public-repo`**: specifies a public Container repository for the container images built by Wave. This will be used when user uses freeze but not provide build-repository.  *Mandatory*.
 
 - **`wave.build.status.delay`**: sets the delay between build status checks. Its default value is `5s`, providing a reasonable interval for status checks.  *Optional*.
 
 - **`wave.build.status.duration`**: defines the duration for build status checks. Its default value is `1d` (1 day), indicating how long the system should check the build status.  *Optional*.
-
-- **`wave.build.public`**: indicates whether the Docker container repository is public. If set to true, Wave freeze will prefer this public repository over `wave.build.repo`. *Optional*.
 
 - **`wave.build.oci-mediatypes`**: defines whether to use OCI media types in exported manifests. Its default value is `true`. *Optional*.
 

--- a/src/main/resources/application-default.yml
+++ b/src/main/resources/application-default.yml
@@ -1,0 +1,5 @@
+wave:
+  build:
+    repo : "195996028523.dkr.ecr.eu-west-1.amazonaws.com/wave/build/dev"
+    cache : "195996028523.dkr.ecr.eu-west-1.amazonaws.com/wave/build/cache"
+    public-repo : "community.wave.seqera.io"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,9 +53,6 @@ wave:
   build:
     buildkit-image: "moby/buildkit:v0.21.1-rootless"
     singularity-image: "public.cr.seqera.io/wave/singularity:v4.2.1-r4"
-    repo: "195996028523.dkr.ecr.eu-west-1.amazonaws.com/wave/build/dev"
-    cache: "195996028523.dkr.ecr.eu-west-1.amazonaws.com/wave/build/cache"
-    public-repo: "community.wave.seqera.io"
     # note changing this should be matching the micronaut.server.idle-timeout (see above)
     timeout: 900s
     status:


### PR DESCRIPTION
This pr will add the following:

1. default profile for config used in Seqera Seqera-hosted wave
2. Add `wave.build.public-repo` in docs