### PR TITLE
Add mandatory migration notes section

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,6 +158,7 @@ Scan process configuration lets the user provide a [Trivy docker image](https://
 
 - **`wave.scan.image.name`**: the [Trivy docker image](https://hub.docker.com/r/aquasec/trivy) used for container security scanning. The default value is `aquasec/trivy:0.47.0`. This the image that Wave will use to perform vulnerability scanning on containers. *Optional*.
 
+- **`wave.scan.reports.path`**: the path inside the S3 bucket where Wave will store SBOM reports. For example, `s3://wave-store/scan-reports`. *Mandatory*.
 
 ### Kubernetes configuration for Wave scan process
 

--- a/docs/db-migration.md
+++ b/docs/db-migration.md
@@ -1,5 +1,5 @@
 ---
-title: Wave Database Migration from SurrealDB to PostgreSQL
+title: Wave database migration from SurrealDB to PostgreSQL
 ---
 
 ## Pre-requisites

--- a/docs/migrations/1-21-0.md
+++ b/docs/migrations/1-21-0.md
@@ -1,0 +1,18 @@
+---
+title: Migrating to 1.21.0
+tags: [migration notes, wave]
+---
+
+Wave 1.21.0 was released on May 29, 2025.
+
+## Mandatory steps
+
+Wave 1.21.0 introduces support for PostgreSQL as the primary database backend, replacing SurrealDB.
+
+To upgrade your existing data from SurrealDB to PostgreSQL:
+
+1. Follow the steps in the [Wave database migration from SurrealDB to PostgreSQL](../db-migration.md) guide.
+2. Add the following properties to your Wave configuration file:
+
+    - `wave.build.logs.path`: Sets the path inside  `wave.build.logs.bucket`, where build logs will be stored.
+    - `wave.build.locks.path`: Sets the path inside `wave.build.logs.bucket`, where conda lock files will be stored.

--- a/docs/migrations/1-24-0.md
+++ b/docs/migrations/1-24-0.md
@@ -1,0 +1,14 @@
+---
+title: Migrating to 1.24.0
+tags: [migration notes, wave]
+---
+
+Wave 1.24.0 was released on August 12, 2025.
+
+## Mandatory steps
+
+Wave 1.24.0 adds support for SBOM (Software Bill of Materials) generation using Syft.
+
+To use SBOM generation, add the following property to your Wave configuration:
+
+- `wave.scan.reports.path`: Sets the path inside the S3 bucket where Wave will store SBOM reports. For example, `s3://wave-store/scan-reports`.

--- a/docs/migrations/1-25-0.md
+++ b/docs/migrations/1-25-0.md
@@ -1,0 +1,20 @@
+---
+title: Migrating to 1.25.0
+tags: [migration notes, wave]
+---
+
+Wave 1.25.0 was released on September 2, 2025.
+
+## Mandatory steps
+
+Wave 1.25.0 upgrades Micronaut to 4.9.2 and Netty to 4.2.0. This changes the default Netty ByteBuf allocator from `PooledByteBufAllocator` to `AdaptiveRecvByteBufAllocator`, which may impact your memory usage patterns.
+
+The Netty ByteBuf allocator must be explicitly set back to `PooledByteBufAllocator` to maintain stable memory usage patterns.
+
+If you are passing custom `WAVE_JVM_OPTS`, add the following option to your Wave configuration:
+
+```
+-Dio.netty.allocator.type=pooled
+```
+
+See [Micronaut 4.9.2 Netty Memory Issue Analysis](https://github.com/seqeralabs/wave/blob/master/adr/mv-4.9-netty-memory.md) for more information.

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -1,0 +1,10 @@
+---
+title: Migration notes
+tags: [migration notes, wave]
+---
+
+This section covers mandatory steps for migrating to new versions of Wave.
+
+- [Migrating to 1.25](./1-25-0.md)
+- [Migrating to 1.24](./1-24-0.md)
+- [Migrating to 1.21](./1-21-0.md)


### PR DESCRIPTION
For consideration, instead of #890 

**Summary**
- Add new Updates section to Wave docs for mandatory migration notes.
    - New section leaves space for an Updating Wave guide later
    - Can also be adapted to add other release notes in the future
    
   The eventual goal will be something closer to the [Nextflow docs](https://nextflow.io/docs/latest/updating-nextflow.html).
   
   Preview is here: https://deploy-preview-813--seqera-docs.netlify.app/wave/migrations
   
   PR to update the sidebar is here: https://github.com/seqeralabs/docs/pull/813