### PR TITLE
docs: buildkit on bottlerocket support

### DIFF
--- a/docs/install/configure-wave-build.md
+++ b/docs/install/configure-wave-build.md
@@ -347,7 +347,7 @@ Set up monitoring for build operations:
 - **Storage access issues** - Ensure EFS access points are configured correctly
 - **Build timeouts** - Adjust build timeout settings based on workload requirements
 
-For additional configuration options and advanced features, see [Configuring Wave](./configure-wave.md).
+For additional configuration options and advanced features, see [Configuring Wave](../configure-wave.md).
 
 ## Bottlerocket support
 


### PR DESCRIPTION
The following is documenting our supported method for bottle rocket after customer feedback that they ran into issues making this work until they found the upstream buildkit documentation.

https://github.com/moby/buildkit/blob/master/docs/rootless.md#bottlerocket-os

 

