### PR TITLE
Add ARM64 platform support to container build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,7 @@ jib {
         image = 'cr.seqera.io/public/nf-jdk:corretto-25-al2023-mimalloc'
         platforms {
             platform { architecture = 'amd64'; os = 'linux' }
+            platform { architecture = 'arm64'; os = 'linux' }
         }
     }
     to {


### PR DESCRIPTION
## Summary
- Add ARM64 platform support to Jib container build configuration
- Enable multi-architecture builds alongside existing AMD64 support

## Test plan
- [ ] Verify container builds successfully for both amd64 and arm64 platforms
- [ ] Test container functionality on ARM64 architecture

🤖 Generated with [Claude Code](https://claude.ai/code)