### PR TITLE
Upgrade Netty to 4.2.5.Final to fix CVE-2025-58057 [COMP-547]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     implementation 'io.micronaut.views:micronaut-views-handlebars'
     // bump version to prevent security issue
     runtimeOnly 'org.apache.commons:commons-lang3:3.18.0'
-    runtimeOnly "io.netty:netty-bom:4.2.4.Final"
+    runtimeOnly "io.netty:netty-bom:4.2.5.Final"
 }
 
 application {


### PR DESCRIPTION
## Summary

This PR upgrades Netty BOM from version 4.2.4.Final to 4.2.5.Final to address CVE-2025-58057, a denial-of-service vulnerability in Netty's BrotliDecoder and other decompressing decoders.

## Details

**Vulnerability:** CVE-2025-58057 - Netty's decoders vulnerable to DoS via zip bomb style attack

**Impact:** With specially crafted input, BrotliDecoder and other decompressing decoders will allocate a large number of reachable byte buffers, which can lead to denial of service (out-of-memory errors).

**Root Cause:** BrotliDecoder.decompress has no limit in how often it calls pull, decompressing data 64K bytes at a time. The buffers are saved in the output list and remain reachable until OOM is hit.

**Fix:** Version 4.2.5.Final introduces limits on decompression buffer allocation to prevent zip bomb style attacks.

## Changes

- Updated `io.netty:netty-bom` from `4.2.4.Final` to `4.2.5.Final` in build.gradle

## References

- JIRA: COMP-547
- GitHub Security Advisory: https://github.com/netty/netty/security/advisories/GHSA-3p8m-j85q-pgmj