### PR TITLE
Fix SCAN_REPORTS enabled in wave lite

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/aws/ObjectStorageOperationsFactory.groovy
+++ b/src/main/groovy/io/seqera/wave/service/aws/ObjectStorageOperationsFactory.groovy
@@ -35,6 +35,7 @@ import io.micronaut.objectstorage.local.LocalStorageOperations
 import io.seqera.wave.configuration.BuildConfig
 import io.seqera.wave.configuration.ScanConfig
 import io.seqera.wave.configuration.BuildEnabled
+import io.seqera.wave.configuration.ScanEnabled
 import io.seqera.wave.util.BucketTokenizer
 import jakarta.annotation.Nullable
 import jakarta.inject.Inject
@@ -90,6 +91,7 @@ class ObjectStorageOperationsFactory {
 
     @Singleton
     @Named(SCAN_REPORTS)
+    @Requires(bean = ScanEnabled)
     ObjectStorageOperations<?, ?, ?> createScanStorageOpts() {
         if( !scanConfig )
             throw new IllegalStateException("Scan configuration is not defined")


### PR DESCRIPTION
This PR will fix a bug where SCAN_REPORTS are enabled even when using lite.
**Solution:** Added @Requires(bean = ScanEnabled) on SCAN_REPORTS
**Error:** 
```
17:54:19.022 [main] ERROR io.micronaut.runtime.Micronaut - Error starting Micronaut server: Bean definition [io.micronaut.objectstorage.ObjectStorageOperations] could not be loaded: Error instantiating bean of type  [io.micronaut.objectstorage.ObjectStorageOperations]

Message: Scan configuration is not defined
Path Taken:
@j.i.Named("scan-reports") @j.i.Singleton i.m.o.ObjectStorageOperations<j.l.Object, j.l.Object, j.l.Object> i.s.w.s.a.ObjectStorageOperationsFactory.createScanStorageOpts#createScanStorageOpts() >> wt=
io.micronaut.context.exceptions.BeanInstantiationException: Bean definition [io.micronaut.objectstorage.ObjectStorageOperations] could not be loaded: Error instantiating bean of type  [io.micronaut.objectstorage.ObjectStorageOperations]

Message: Scan configuration is not defined
Path Taken:
@j.i.Named("scan-reports") @j.i.Singleton i.m.o.ObjectStorageOperations<j.l.Object, j.l.Object, j.l.Object> i.s.w.s.a.ObjectStorageOperationsFactory.createScanStorageOpts#createScanStorageOpts()
	at io.micronaut.context.DefaultBeanContext.initializeContext(DefaultBeanContext.java:2040)
	at io.micronaut.context.DefaultApplicationContext.initializeContext(DefaultApplicationContext.java:323)
	at io.micronaut.context.DefaultBeanContext.configureAndStartContext(DefaultBeanContext.java:3350)
	at io.micronaut.context.DefaultBeanContext.start(DefaultBeanContext.java:353)
	at io.micronaut.context.DefaultApplicationContext.start(DefaultApplicationContext.java:225)
	at io.micronaut.runtime.Micronaut.start(Micronaut.java:75)
	at io.seqera.wave.Application.main(Application.groovy:41)
Caused by: io.micronaut.context.exceptions.BeanInstantiationException: Error instantiating bean of type  [io.micronaut.objectstorage.ObjectStorageOperations]

Message: Scan configuration is not defined
Path Taken:
@j.i.Named("scan-reports") @j.i.Singleton i.m.o.ObjectStorageOperations<j.l.Object, j.l.Object, j.l.Object> i.s.w.s.a.ObjectStorageOperationsFactory.createScanStorageOpts#createScanStorageOpts()
	at io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2352)
	at io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:3150)
	at io.micronaut.context.SingletonScope.getOrCreate(SingletonScope.java:80)
	at io.micronaut.context.DefaultBeanContext.intializeEagerBean(DefaultBeanContext.java:3039)
	at io.micronaut.context.DefaultBeanContext.initializeEagerBean(DefaultBeanContext.java:2708)
	at io.micronaut.context.DefaultBeanContext.initializeContext(DefaultBeanContext.java:2034)
	... 6 common frames omitted
Caused by: java.lang.IllegalStateException: Scan configuration is not defined
	at io.seqera.wave.service.aws.ObjectStorageOperationsFactory.createScanStorageOpts(ObjectStorageOperationsFactory.groovy:96)
	at io.seqera.wave.service.aws.$ObjectStorageOperationsFactory$CreateScanStorageOpts2$Definition.instantiate(Unknown Source)
	at io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2337)
	... 11 common frames omitted

```