### PR TITLE
Add configurable singularity init container image

### DIFF
--- a/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
+++ b/src/main/groovy/io/seqera/wave/configuration/BuildConfig.groovy
@@ -46,6 +46,9 @@ class BuildConfig {
     @Value('${wave.build.singularity-image}')
     String singularityImage
 
+    @Value('${wave.build.singularity-image-init:`public.cr.seqera.io/wave/busybox:latest`}')
+    String singularityImageInit
+
     @Value('${wave.build.repo}')
      String defaultBuildRepository
 

--- a/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/k8s/K8sServiceImpl.groovy
@@ -600,7 +600,7 @@ class K8sServiceImpl implements K8sService {
                 // init container to copy change owner of docker config and remote.yaml
                 spec.withInitContainers(new V1ContainerBuilder()
                         .withName("permissions-fix")
-                        .withImage("busybox")
+                        .withImage(buildConfig.singularityImageInit)
                         .withCommand("sh", "-c", "cp -r /tmp/singularity/* /singularity && chown -R 1000:1000 /singularity")
                         .withVolumeMounts(initMounts)
                         .build()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,7 @@ wave:
   build:
     buildkit-image: "moby/buildkit:v0.25.2-rootless"
     singularity-image: "public.cr.seqera.io/wave/singularity:v4.2.1-r4"
+    singularity-image-init: "public.cr.seqera.io/wave/busybox:latest"
     # note changing this should be matching the micronaut.server.idle-timeout (see above)
     timeout: 900s
     status:

--- a/src/test/groovy/io/seqera/wave/service/k8s/K8sServiceImplTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/k8s/K8sServiceImplTest.groovy
@@ -580,6 +580,10 @@ class K8sServiceImplTest extends Specification {
         and:
         job.spec.template.spec.dnsPolicy == null
         job.spec.template.spec.dnsConfig == null
+        and: 'init container should use configured singularity-image-init'
+        job.spec.template.spec.initContainers.size() == 1
+        job.spec.template.spec.initContainers[0].name == 'permissions-fix'
+        job.spec.template.spec.initContainers[0].image == 'public.cr.seqera.io/wave/busybox:latest'
 
         cleanup:
         ctx.close()


### PR DESCRIPTION
## Summary
- Add `wave.build.singularity-image-init` configuration setting to customize the init container image used for singularity builds
- Replace hardcoded `busybox` reference with configurable value
- Default to `public.cr.seqera.io/wave/busybox:latest`

## Test plan
- [x] Existing `K8sServiceImplTest` tests pass
- [x] Added validation for init container image in singularity build job spec test

🤖 Generated with [Claude Code](https://claude.com/claude-code)