### PR TITLE
Update libseqera dependencies to latest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,11 @@ dependencies {
     compileOnly 'io.micronaut:micronaut-inject-groovy'
     compileOnly 'io.micronaut:micronaut-http-validation'
     implementation 'jakarta.persistence:jakarta.persistence-api:3.0.0'
-    implementation 'io.seqera:lib-cache-tiered-redis:1.0.0'
+    implementation 'io.seqera:lib-cache-tiered-redis:1.1.0'
     implementation 'io.seqera:lib-lang:1.1.0'
-    implementation 'io.seqera:lib-serde:1.1.0'
-    implementation 'io.seqera:lib-serde-moshi:1.0.0'
-    implementation 'io.seqera:lib-mail:1.3.0'
+    implementation 'io.seqera:lib-serde:1.2.0'
+    implementation 'io.seqera:lib-serde-moshi:1.1.0'
+    implementation 'io.seqera:lib-mail:1.3.1'
     implementation 'io.seqera:lib-pool:1.0.0'
     implementation 'io.seqera:lib-retry:2.0.0'
     implementation 'io.seqera:lib-random:1.0.0'
@@ -101,7 +101,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:postgresql'
     testRuntimeOnly 'com.h2database:h2'
-    testImplementation testFixtures('io.seqera:lib-fixtures-redis:1.0.0')
+    testImplementation testFixtures('io.seqera:lib-fixtures-redis:1.1.0')
     
     // rate limit
     implementation 'com.coveo:spillway:3.0.0'

--- a/src/main/groovy/io/seqera/wave/auth/RegistryLookupCache.groovy
+++ b/src/main/groovy/io/seqera/wave/auth/RegistryLookupCache.groovy
@@ -26,8 +26,8 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Value
 import io.micronaut.core.annotation.Nullable
+import io.seqera.serde.Encodable
 import io.seqera.serde.moshi.MoshiEncodeStrategy
-import io.seqera.serde.moshi.MoshiSerializable
 import io.seqera.cache.tiered.AbstractTieredCache
 import io.seqera.cache.tiered.L2TieredCache
 import jakarta.inject.Singleton
@@ -75,7 +75,7 @@ class RegistryLookupCache extends AbstractTieredCache<String, RegistryAuth> {
     }
 
     static JsonAdapter.Factory factory() {
-        PolymorphicJsonAdapterFactory.of(MoshiSerializable.class, "@type")
+        PolymorphicJsonAdapterFactory.of(Encodable.class, "@type")
                 .withSubtype(AbstractTieredCache.Entry.class, AbstractTieredCache.Entry.name)
                 .withSubtype(RegistryAuth.class, RegistryAuth.name)
     }

--- a/src/main/groovy/io/seqera/wave/proxy/ProxyCache.groovy
+++ b/src/main/groovy/io/seqera/wave/proxy/ProxyCache.groovy
@@ -25,8 +25,8 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.core.annotation.Nullable
 import io.seqera.wave.configuration.ProxyCacheConfig
+import io.seqera.serde.Encodable
 import io.seqera.serde.moshi.MoshiEncodeStrategy
-import io.seqera.serde.moshi.MoshiSerializable
 import io.seqera.cache.tiered.AbstractTieredCache
 import io.seqera.cache.tiered.L2TieredCache
 import jakarta.inject.Singleton
@@ -50,7 +50,7 @@ class ProxyCache extends AbstractTieredCache<String, DelegateResponse> {
 
     static MoshiEncodeStrategy encoder() {
         // json adapter factory
-        final factory = PolymorphicJsonAdapterFactory.of(MoshiSerializable.class, "@type")
+        final factory = PolymorphicJsonAdapterFactory.of(Encodable.class, "@type")
                 .withSubtype(Entry.class, Entry.name)
                 .withSubtype(DelegateResponse.class, DelegateResponse.simpleName)
         // the encoding strategy

--- a/src/main/groovy/io/seqera/wave/service/aws/cache/AwsEcrCache.groovy
+++ b/src/main/groovy/io/seqera/wave/service/aws/cache/AwsEcrCache.groovy
@@ -26,8 +26,8 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Value
 import io.micronaut.core.annotation.Nullable
+import io.seqera.serde.Encodable
 import io.seqera.serde.moshi.MoshiEncodeStrategy
-import io.seqera.serde.moshi.MoshiSerializable
 import io.seqera.cache.tiered.AbstractTieredCache
 import io.seqera.cache.tiered.L2TieredCache
 import io.seqera.cache.tiered.TieredKey
@@ -76,7 +76,7 @@ class AwsEcrCache extends AbstractTieredCache<TieredKey, AwsEcrAuthToken> {
     }
 
     static JsonAdapter.Factory factory() {
-        PolymorphicJsonAdapterFactory.of(MoshiSerializable.class, "@type")
+        PolymorphicJsonAdapterFactory.of(Encodable.class, "@type")
                 .withSubtype(AbstractTieredCache.Entry.class, AbstractTieredCache.Entry.name)
                 .withSubtype(AwsEcrAuthToken.class, AwsEcrAuthToken.simpleName)
     }

--- a/src/main/groovy/io/seqera/wave/tower/client/cache/ClientCache.groovy
+++ b/src/main/groovy/io/seqera/wave/tower/client/cache/ClientCache.groovy
@@ -25,8 +25,8 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.context.annotation.Value
 import io.micronaut.core.annotation.Nullable
+import io.seqera.serde.Encodable
 import io.seqera.serde.moshi.MoshiEncodeStrategy
-import io.seqera.serde.moshi.MoshiSerializable
 import io.seqera.cache.tiered.AbstractTieredCache
 import io.seqera.cache.tiered.L2TieredCache
 import io.seqera.wave.tower.User
@@ -75,7 +75,7 @@ class ClientCache extends AbstractTieredCache {
     }
 
     static JsonAdapter.Factory factory() {
-        PolymorphicJsonAdapterFactory.of(MoshiSerializable.class, "@type")
+        PolymorphicJsonAdapterFactory.of(Encodable.class, "@type")
                 .withSubtype(AbstractTieredCache.Entry.class, AbstractTieredCache.Entry.name)
         // add all exchange classes used by the tower client
                 .withSubtype(ComputeEnv.class, ComputeEnv.simpleName)


### PR DESCRIPTION
## Summary
- Update libseqera dependencies to their latest versions:
  - lib-cache-tiered-redis: 1.0.0 → 1.1.0
  - lib-serde: 1.1.0 → 1.2.0
  - lib-serde-moshi: 1.0.0 → 1.1.0
  - lib-mail: 1.3.0 → 1.3.1
  - lib-fixtures-redis: 1.0.0 → 1.1.0
- Update `MoshiSerializable` → `Encodable` in cache implementations to match new lib-serde API

## Test plan
- [ ] Run `./gradlew test` to verify all tests pass
- [ ] Verify application starts correctly with `./run.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)