### PR TITLE
Add DockerHelper to wave-utils for Nextflow integration

### DIFF
--- a/src/main/groovy/io/seqera/wave/util/CondaHelper.groovy
+++ b/src/main/groovy/io/seqera/wave/util/CondaHelper.groovy
@@ -23,14 +23,14 @@ import io.seqera.wave.api.PackagesSpec
 import io.seqera.wave.config.CondaOpts
 import io.seqera.wave.exception.BadRequestException
 
-import static io.seqera.wave.util.DockerHelper.condaFileToDockerFile
-import static io.seqera.wave.util.DockerHelper.condaFileToDockerFileUsingV2
-import static io.seqera.wave.util.DockerHelper.condaFileToSingularityFile
-import static io.seqera.wave.util.DockerHelper.condaFileToSingularityFileV2
-import static io.seqera.wave.util.DockerHelper.condaPackagesToDockerFile
-import static io.seqera.wave.util.DockerHelper.condaPackagesToDockerFileUsingV2
-import static io.seqera.wave.util.DockerHelper.condaPackagesToSingularityFile
-import static io.seqera.wave.util.DockerHelper.condaPackagesToSingularityFileV2
+import static TemplateUtils.condaFileToDockerFile
+import static TemplateUtils.condaFileToDockerFileUsingV2
+import static TemplateUtils.condaFileToSingularityFile
+import static TemplateUtils.condaFileToSingularityFileV2
+import static TemplateUtils.condaPackagesToDockerFile
+import static TemplateUtils.condaPackagesToDockerFileUsingV2
+import static TemplateUtils.condaPackagesToSingularityFile
+import static TemplateUtils.condaPackagesToSingularityFileV2
 
 /**
  * Helper class for Conda/Micromamba container builds.

--- a/src/main/groovy/io/seqera/wave/util/ContainerHelper.groovy
+++ b/src/main/groovy/io/seqera/wave/util/ContainerHelper.groovy
@@ -38,8 +38,8 @@ import static io.seqera.wave.api.BuildTemplate.CONDA_MICROMAMBA_V2
 import static io.seqera.wave.api.BuildTemplate.CONDA_PIXI_V1
 import static io.seqera.wave.api.BuildTemplate.CRAN_INSTALLR_V1
 import static io.seqera.wave.service.builder.BuildFormat.SINGULARITY
-import static io.seqera.wave.util.DockerHelper.condaEnvironmentToCondaYaml
-import static io.seqera.wave.util.DockerHelper.condaPackagesToCondaYaml
+import static DockerHelper.condaEnvironmentToCondaYaml
+import static DockerHelper.condaPackagesToCondaYaml
 /**
  * Container helper methods
  *

--- a/src/main/groovy/io/seqera/wave/util/PixiHelper.groovy
+++ b/src/main/groovy/io/seqera/wave/util/PixiHelper.groovy
@@ -23,8 +23,8 @@ import io.seqera.wave.api.PackagesSpec
 import io.seqera.wave.config.PixiOpts
 import io.seqera.wave.exception.BadRequestException
 
-import static io.seqera.wave.util.DockerHelper.condaFileToDockerFileUsingPixi
-import static io.seqera.wave.util.DockerHelper.condaFileToSingularityFileUsingPixi
+import static TemplateUtils.condaFileToDockerFileUsingPixi
+import static TemplateUtils.condaFileToSingularityFileUsingPixi
 
 /**
  * Helper class for Pixi-based container builds (PIXI_V1 template).

--- a/src/main/java/io/seqera/wave/util/TemplateUtils.java
+++ b/src/main/java/io/seqera/wave/util/TemplateUtils.java
@@ -20,10 +20,7 @@ package io.seqera.wave.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -31,101 +28,13 @@ import java.util.stream.Collectors;
 import io.seqera.wave.config.CondaOpts;
 import io.seqera.wave.config.PixiOpts;
 import org.apache.commons.lang3.StringUtils;
-import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.representer.Representer;
 
 /**
  * Helper class to create Dockerfile for Conda package manager
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
-public class DockerHelper {
-
-    static public List<String> condaPackagesToList(String packages) {
-        if (packages == null || packages.isEmpty())
-            return null;
-        return Arrays
-                .stream(packages.split(" "))
-                .filter(it -> !StringUtils.isEmpty(it))
-                .map(it -> trim0(it)).collect(Collectors.toList());
-    }
-
-    protected static String trim0(String value) {
-        if( value==null )
-            return null;
-        value = value.trim();
-        while( value.startsWith("'") && value.endsWith("'") )
-            value = value.substring(1,value.length()-1);
-        while( value.startsWith("\"") && value.endsWith("\"") )
-            value = value.substring(1,value.length()-1);
-        return value;
-    }
-
-    public static String condaPackagesToCondaYaml(String packages, List<String> channels) {
-        if( packages==null || packages.isBlank() )
-            return null;
-
-        final List<Object> deps = new ArrayList<>(20);
-        final List<Object> condaPackages = new ArrayList<>(10);
-        final List<Object> pipPackages = new ArrayList<>(10);
-        // split conda package by pip prefixed packages
-        for( String it : condaPackagesToList(packages) ) {
-            if( it.startsWith("pip::") )
-                throw new IllegalArgumentException(String.format("Invalid pip prefix - Likely you want to use '%s' instead of '%s'", it.replaceAll(":+",":"), it));
-            else if( it.startsWith("pip:") )
-                pipPackages.add(it.substring(4));
-            else
-                condaPackages.add(it);
-        }
-
-        // add all conda packages
-        if( !condaPackages.isEmpty() )
-            deps.addAll(condaPackages);
-
-        // add all pip packages
-        if( !pipPackages.isEmpty() ) {
-            deps.add("pip");
-            deps.add(Map.of("pip", pipPackages));
-        }
-
-        // add the channels
-        final Map<String, Object> conda = new LinkedHashMap<>();
-        if (channels != null && !channels.isEmpty() ) {
-            conda.put("channels", channels);
-        }
-
-        // assemble the final yaml
-        conda.put("dependencies", deps);
-        return dumpCondaYaml(conda);
-    }
-
-    static private String dumpCondaYaml(Map<String, Object> conda) {
-        DumperOptions dumperOpts = new DumperOptions();
-        dumperOpts.setPrettyFlow(false); // Disable pretty formatting
-        dumperOpts.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK); // Use block style
-        return new Yaml(new Representer(dumperOpts), dumperOpts).dump(conda);
-    }
-
-    public static String condaEnvironmentToCondaYaml(String env, List<String> channels) {
-        final Yaml yaml = new Yaml();
-        // 1. parse the file
-        Map<String,Object> root = yaml.load(env);
-        // 2. append channels
-        if( channels!=null ) {
-            List<String> channels0 = (List<String>)root.get("channels");
-            if( channels0==null ) {
-                channels0 = new ArrayList<>();
-                root.put("channels", channels0);
-            }
-            for( String it : channels ) {
-                if( !channels0.contains(it) )
-                    channels0.add(it);
-            }
-        }
-        // 3. return it
-        return dumpCondaYaml(root);
-    }
+public class TemplateUtils {
 
     static public String condaPackagesToDockerFile(String packages, List<String> condaChannels, CondaOpts opts) {
         return condaPackagesTemplate0(
@@ -260,7 +169,7 @@ public class DockerHelper {
     }
 
     static private String renderTemplate0(String templatePath, Map<String,String> binding, List<String> ignore) {
-        final URL template = DockerHelper.class.getResource(templatePath);
+        final URL template = TemplateUtils.class.getResource(templatePath);
         if( template==null )
             throw new IllegalStateException(String.format("Unable to load template '%s' from classpath", templatePath));
         try {

--- a/wave-utils/src/main/java/io/seqera/wave/util/DockerHelper.java
+++ b/wave-utils/src/main/java/io/seqera/wave/util/DockerHelper.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.wave.util;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.representer.Representer;
+
+/**
+ * Helper class to create Dockerfile for Conda package manager.
+ * This class provides file-based utility methods for Nextflow CLI integration.
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+public class DockerHelper {
+
+    /**
+     * Create a Conda environment file starting from one or more Conda package names
+     *
+     * @param packages
+     *      A string listing one or more Conda package names separated with a blank character
+     *      e.g. {@code samtools=1.0 bedtools=2.0}
+     * @param condaChannels
+     *      A list of Conda channels
+     * @return
+     *      A path to the Conda environment YAML file. The file is automatically deleted when the JVM exits.
+     */
+    static public Path condaFileFromPackages(String packages, List<String> condaChannels) {
+        final String yaml = condaPackagesToCondaYaml(packages, condaChannels);
+        if (yaml == null || yaml.isEmpty())
+            return null;
+        return toYamlTempFile(yaml);
+    }
+
+    static public List<String> condaPackagesToList(String packages) {
+        if (packages == null || packages.isEmpty())
+            return null;
+        return Arrays
+                .stream(packages.split(" "))
+                .filter(it -> !StringUtils.isEmpty(it))
+                .map(it -> trim0(it)).collect(Collectors.toList());
+    }
+
+    static List<String> pipPackagesToList(String packages) {
+        return condaPackagesToList(packages);
+    }
+
+    protected static String trim0(String value) {
+        if( value==null )
+            return null;
+        value = value.trim();
+        while( value.startsWith("'") && value.endsWith("'") )
+            value = value.substring(1,value.length()-1);
+        while( value.startsWith("\"") && value.endsWith("\"") )
+            value = value.substring(1,value.length()-1);
+        return value;
+    }
+
+    public static String condaPackagesToCondaYaml(String packages, List<String> channels) {
+        if( packages==null || packages.isBlank() )
+            return null;
+
+        final List<Object> deps = new ArrayList<>(20);
+        final List<Object> condaPackages = new ArrayList<>(10);
+        final List<Object> pipPackages = new ArrayList<>(10);
+        // split conda package by pip prefixed packages
+        for( String it : condaPackagesToList(packages) ) {
+            if( it.startsWith("pip::") )
+                throw new IllegalArgumentException(String.format("Invalid pip prefix - Likely you want to use '%s' instead of '%s'", it.replaceAll(":+",":"), it));
+            else if( it.startsWith("pip:") )
+                pipPackages.add(it.substring(4));
+            else
+                condaPackages.add(it);
+        }
+
+        // add all conda packages
+        if( !condaPackages.isEmpty() )
+            deps.addAll(condaPackages);
+
+        // add all pip packages
+        if( !pipPackages.isEmpty() ) {
+            deps.add("pip");
+            deps.add(Map.of("pip", pipPackages));
+        }
+
+        // add the channels
+        final Map<String, Object> conda = new LinkedHashMap<>();
+        if (channels != null && !channels.isEmpty() ) {
+            conda.put("channels", channels);
+        }
+
+        // assemble the final yaml
+        conda.put("dependencies", deps);
+        return dumpCondaYaml(conda);
+    }
+
+    static private String dumpCondaYaml(Map<String, Object> conda) {
+        DumperOptions dumperOpts = new DumperOptions();
+        dumperOpts.setPrettyFlow(false); // Disable pretty formatting
+        dumperOpts.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK); // Use block style
+        return new Yaml(new Representer(dumperOpts), dumperOpts).dump(conda);
+    }
+
+    /**
+     * Get a Conda environment file from a string path.
+     *
+     * @param condaFile
+     *      A file system path where the Conda environment file is located.
+     * @param channels
+     *      A list of Conda channels. If provided the channels are added to the ones
+     *      specified in the Conda environment files.
+     * @return
+     *      A {@link Path} to the Conda environment file. It can be the same file as specified
+     *      via the condaFile argument or a temporary file if the environment was modified due to
+     *      the channels or options specified.
+     */
+    public static Path condaFileFromPath(String condaFile, List<String> channels) {
+        if( StringUtils.isEmpty(condaFile) )
+            throw new IllegalArgumentException("Argument 'condaFile' cannot be empty");
+
+        final Path condaEnvPath = Path.of(condaFile);
+
+        // make sure the file exists
+        if( !Files.exists(condaEnvPath) ) {
+            throw new IllegalArgumentException("The specified Conda environment file cannot be found: " + condaFile);
+        }
+
+        // if there's nothing to be merged just return the conda file path
+        if( channels==null ) {
+            return condaEnvPath;
+        }
+
+        // => parse the conda file yaml, add the base packages to it
+        try {
+            final String result = condaEnvironmentToCondaYaml(Files.readString(condaEnvPath), channels);
+            return toYamlTempFile(result);
+        }
+        catch (FileNotFoundException e) {
+            throw new IllegalArgumentException("The specified Conda environment file cannot be found: " + condaFile, e);
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException("Unable to parse conda file: " + condaFile, e);
+        }
+    }
+
+    public static String condaEnvironmentToCondaYaml(String env, List<String> channels) {
+        final Yaml yaml = new Yaml();
+        // 1. parse the file
+        Map<String,Object> root = yaml.load(env);
+        // 2. append channels
+        if( channels!=null ) {
+            List<String> channels0 = (List<String>)root.get("channels");
+            if( channels0==null ) {
+                channels0 = new ArrayList<>();
+                root.put("channels", channels0);
+            }
+            for( String it : channels ) {
+                if( !channels0.contains(it) )
+                    channels0.add(it);
+            }
+        }
+        // 3. return it
+        return dumpCondaYaml(root);
+    }
+
+    static private Path toYamlTempFile(String yaml) {
+        try {
+            final File tempFile = File.createTempFile("nf-temp", ".yaml");
+            tempFile.deleteOnExit();
+            final Path result = tempFile.toPath();
+            Files.write(result, yaml.getBytes());
+            return result;
+        }
+        catch (IOException e) {
+            throw new IllegalStateException("Unable to write temporary file - Reason: " + e.getMessage(), e);
+        }
+    }
+
+}

--- a/wave-utils/src/test/groovy/io/seqera/wave/util/DockerHelperTest.groovy
+++ b/wave-utils/src/test/groovy/io/seqera/wave/util/DockerHelperTest.groovy
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.wave.util
+
+import java.nio.file.Files
+
+import spock.lang.Specification
+
+/**
+ * Tests for DockerHelper file-based utility methods
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+class DockerHelperTest extends Specification {
+
+    def 'should trim a string' () {
+        expect:
+        DockerHelper.trim0(STR) == EXPECTED
+
+        where:
+        STR         | EXPECTED
+        null        | null
+        "foo"       | "foo"
+        " foo  "    | "foo"
+        "'foo"      | "'foo"
+        '"foo'      | '"foo'
+        and:
+        "'foo'"     | "foo"
+        "''foo''"   | "foo"
+        " 'foo' "   | "foo"
+        " ' foo ' " | " foo "
+        and:
+        '"foo"'     | 'foo'
+        '""foo""'   | 'foo'
+        ' "foo" '   | 'foo'
+    }
+
+    def 'should convert conda packages to list' () {
+        expect:
+        DockerHelper.condaPackagesToList(STR) == EXPECTED
+
+        where:
+        STR                 | EXPECTED
+        "foo"               | ["foo"]
+        "foo bar"           | ["foo", "bar"]
+        "foo 'bar'"         | ["foo", "bar"]
+        "foo    'bar'  "    | ["foo", "bar"]
+    }
+
+    def 'should convert pip packages to list' () {
+        expect:
+        DockerHelper.pipPackagesToList(STR) == EXPECTED
+
+        where:
+        STR                 | EXPECTED
+        "foo"               | ["foo"]
+        "foo bar"           | ["foo", "bar"]
+        "foo 'bar'"         | ["foo", "bar"]
+        "foo    'bar'  "    | ["foo", "bar"]
+    }
+
+    def 'should create conda yaml file' () {
+        expect:
+        DockerHelper.condaPackagesToCondaYaml("foo=1.0 'bar>=2.0'", null)
+            ==  '''\
+                dependencies:
+                - foo=1.0
+                - bar>=2.0
+                '''.stripIndent(true)
+
+
+        DockerHelper.condaPackagesToCondaYaml('foo=1.0 bar=2.0', ['channel_a','channel_b'] )
+                ==  '''\
+                channels:
+                - channel_a
+                - channel_b
+                dependencies:
+                - foo=1.0
+                - bar=2.0
+                '''.stripIndent(true)
+
+        DockerHelper.condaPackagesToCondaYaml('foo=1.0 bar=2.0 pip:numpy pip:pandas', ['channel_a','channel_b'] )
+                ==  '''\
+                channels:
+                - channel_a
+                - channel_b
+                dependencies:
+                - foo=1.0
+                - bar=2.0
+                - pip
+                - pip:
+                  - numpy
+                  - pandas
+                '''.stripIndent(true)
+    }
+
+    def 'should return an error when using invalid pip prefix' () {
+        when:
+        DockerHelper.condaPackagesToCondaYaml('pip::numpy', [] )
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Invalid pip prefix - Likely you want to use 'pip:numpy' instead of 'pip::numpy'"
+    }
+
+    def 'should map pip packages to conda yaml' () {
+        expect:
+        DockerHelper.condaPackagesToCondaYaml('pip:numpy pip:panda pip:matplotlib', ['defaults']) ==
+                '''\
+                channels:
+                - defaults
+                dependencies:
+                - pip
+                - pip:
+                  - numpy
+                  - panda
+                  - matplotlib
+                '''.stripIndent()
+
+        and:
+        DockerHelper.condaPackagesToCondaYaml(null, ['foo']) == null
+        DockerHelper.condaPackagesToCondaYaml('  ', ['foo']) == null
+    }
+
+    def 'should add conda packages to conda yaml /1' () {
+        given:
+        def text = '''\
+         dependencies:
+         - foo=1.0
+         - bar=2.0
+        '''.stripIndent(true)
+
+        when:
+        def result = DockerHelper.condaEnvironmentToCondaYaml(text, null)
+        then:
+        result == '''\
+         dependencies:
+         - foo=1.0
+         - bar=2.0
+        '''.stripIndent(true)
+
+        when:
+        result = DockerHelper.condaEnvironmentToCondaYaml(text, ['ch1', 'ch2'])
+        then:
+        result == '''\
+             dependencies:
+             - foo=1.0
+             - bar=2.0
+             channels:
+             - ch1
+             - ch2
+            '''.stripIndent(true)
+    }
+
+    def 'should add conda packages to conda yaml /2' () {
+        given:
+        def text = '''\
+         dependencies:
+         - foo=1.0
+         - bar=2.0
+         channels:
+         - hola
+         - ciao
+        '''.stripIndent(true)
+
+        when:
+        def result = DockerHelper.condaEnvironmentToCondaYaml(text, null)
+        then:
+        result == '''\
+         dependencies:
+         - foo=1.0
+         - bar=2.0
+         channels:
+         - hola
+         - ciao
+        '''.stripIndent(true)
+
+        when:
+        result = DockerHelper.condaEnvironmentToCondaYaml(text, ['ch1', 'ch2'])
+        then:
+        result == '''\
+             dependencies:
+             - foo=1.0
+             - bar=2.0
+             channels:
+             - hola
+             - ciao
+             - ch1
+             - ch2
+            '''.stripIndent(true)
+    }
+
+    def 'should add conda packages to conda yaml /3' () {
+        given:
+        def text = '''\
+         channels:
+         - hola
+         - ciao
+        '''.stripIndent(true)
+
+        when:
+        def result = DockerHelper.condaEnvironmentToCondaYaml(text, null)
+        then:
+        result == '''\
+         channels:
+         - hola
+         - ciao
+        '''.stripIndent(true)
+
+        when:
+        result = DockerHelper.condaEnvironmentToCondaYaml(text, ['ch1', 'ch2'])
+        then:
+        result == '''\
+             channels:
+             - hola
+             - ciao
+             - ch1
+             - ch2
+            '''.stripIndent(true)
+
+        when:
+        result = DockerHelper.condaEnvironmentToCondaYaml(text, ['bioconda'])
+        then:
+        result == '''\
+             channels:
+             - hola
+             - ciao
+             - bioconda
+            '''.stripIndent(true)
+    }
+
+
+    def 'should add conda packages to conda file /1' () {
+        given:
+        def condaFile = Files.createTempFile('conda','yaml')
+        condaFile.text = '''\
+         dependencies:
+         - foo=1.0
+         - bar=2.0
+        '''.stripIndent(true)
+
+        when:
+        def result = DockerHelper.condaFileFromPath(condaFile.toString(), null)
+        then:
+        result.text == '''\
+         dependencies:
+         - foo=1.0
+         - bar=2.0
+        '''.stripIndent(true)
+
+        when:
+        result = DockerHelper.condaFileFromPath(condaFile.toString(), ['ch1', 'ch2'])
+        then:
+        result.text == '''\
+             dependencies:
+             - foo=1.0
+             - bar=2.0
+             channels:
+             - ch1
+             - ch2
+            '''.stripIndent(true)
+
+        cleanup:
+        if( condaFile ) Files.delete(condaFile)
+    }
+
+    def 'should add conda packages to conda file /2' () {
+        given:
+        def condaFile = Files.createTempFile('conda', 'yaml')
+        condaFile.text = '''\
+         dependencies:
+         - foo=1.0
+         - bar=2.0
+         channels:
+         - hola
+         - ciao
+        '''.stripIndent(true)
+
+        when:
+        def result = DockerHelper.condaFileFromPath(condaFile.toString(), null)
+        then:
+        result.text == '''\
+         dependencies:
+         - foo=1.0
+         - bar=2.0
+         channels:
+         - hola
+         - ciao
+        '''.stripIndent(true)
+
+        when:
+        result = DockerHelper.condaFileFromPath(condaFile.toString(), ['ch1', 'ch2'])
+        then:
+        result.text == '''\
+             dependencies:
+             - foo=1.0
+             - bar=2.0
+             channels:
+             - hola
+             - ciao
+             - ch1
+             - ch2
+            '''.stripIndent(true)
+
+        cleanup:
+        if (condaFile) Files.delete(condaFile)
+    }
+
+    def 'should add conda packages to conda file /3' () {
+        given:
+        def condaFile = Files.createTempFile('conda', 'yaml')
+        condaFile.text = '''\
+         channels:
+         - hola
+         - ciao
+        '''.stripIndent(true)
+
+        when:
+        def result = DockerHelper.condaFileFromPath(condaFile.toString(), null)
+        then:
+        result.text == '''\
+         channels:
+         - hola
+         - ciao
+        '''.stripIndent(true)
+
+        when:
+        result = DockerHelper.condaFileFromPath(condaFile.toString(), ['ch1', 'ch2'])
+        then:
+        result.text == '''\
+             channels:
+             - hola
+             - ciao
+             - ch1
+             - ch2
+            '''.stripIndent(true)
+
+        when:
+        result = DockerHelper.condaFileFromPath(condaFile.toString(), ['bioconda'])
+        then:
+        result.text == '''\
+             channels:
+             - hola
+             - ciao
+             - bioconda
+            '''.stripIndent(true)
+
+        cleanup:
+        if (condaFile) Files.delete(condaFile)
+    }
+
+    def 'should create conda file from packages' () {
+        when:
+        def result = DockerHelper.condaFileFromPackages('foo=1.0 bar=2.0', ['conda-forge'])
+        then:
+        result.text == '''\
+            channels:
+            - conda-forge
+            dependencies:
+            - foo=1.0
+            - bar=2.0
+            '''.stripIndent(true)
+
+        cleanup:
+        if (result) Files.deleteIfExists(result)
+    }
+
+    def 'should return null for empty packages' () {
+        expect:
+        DockerHelper.condaFileFromPackages(null, ['conda-forge']) == null
+        DockerHelper.condaFileFromPackages('', ['conda-forge']) == null
+        DockerHelper.condaFileFromPackages('  ', ['conda-forge']) == null
+    }
+
+}


### PR DESCRIPTION
## Summary
- Create DockerHelper in wave-utils subproject with file-based utility methods needed by Nextflow nf-wave plugin
- Rename DockerHelper to TemplateUtils in main src (contains template-based methods)
- Remove duplicated methods from TemplateUtils in favor of DockerHelper
- Update ContainerHelper to import from DockerHelper

## Changes

### New DockerHelper (wave-utils)
File-based utility methods for Nextflow CLI integration:
- condaFileFromPath - reads conda file from filesystem
- condaFileFromPackages - creates temp YAML file from packages
- condaPackagesToList - parses space-separated packages into List
- condaPackagesToCondaYaml - converts packages to YAML
- condaEnvironmentToCondaYaml - merges channels into YAML

### Renamed TemplateUtils (wave main)
Template-based Dockerfile/Singularity generation methods (no changes to functionality).

## Rationale
This separates concerns:
- **DockerHelper** (wave-utils): Portable file-based utilities for CLI use (no template dependencies)
- **TemplateUtils** (wave main): Template-based container file generation for Wave server

## Test plan
- [x] All wave-utils tests pass
- [x] All main Wave tests pass
- [x] Nextflow nf-wave plugin compiles and tests pass with local wave-utils via includeBuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)