### PR TITLE
Map conda channels to prefix.dev mirrors for pixi builds

### DIFF
--- a/src/main/groovy/io/seqera/wave/util/PixiHelper.groovy
+++ b/src/main/groovy/io/seqera/wave/util/PixiHelper.groovy
@@ -35,6 +35,30 @@ import static TemplateUtils.condaFileToSingularityFileUsingPixi
 class PixiHelper {
 
     /**
+     * Map of well-known conda channels to their prefix.dev mirrors.
+     * Using prefix.dev mirrors enables sharded repodata which provides
+     * 50-100x faster package resolution.
+     * See: https://prefix.dev/blog/sharded_repodata
+     */
+    static final Map<String, String> CHANNEL_TO_PREFIX_DEV = Map.of(
+            'conda-forge', 'https://prefix.dev/conda-forge',
+            'bioconda', 'https://prefix.dev/bioconda'
+    )
+
+    /**
+     * Maps conda channels to their prefix.dev mirrors for faster package resolution.
+     * Channels that don't have a known prefix.dev mirror are left unchanged.
+     *
+     * @param channels List of conda channel names
+     * @return List of channels with known channels mapped to prefix.dev mirrors
+     */
+    static List<String> mapChannelsToPixiServers(List<String> channels) {
+        if( !channels )
+            return channels
+        return channels.collect { ch -> CHANNEL_TO_PREFIX_DEV.getOrDefault(ch, ch) }
+    }
+
+    /**
      * Generate a container file (Dockerfile or Singularity) using the Pixi template.
      * Only supports CONDA package type. Lock files are not supported.
      *

--- a/src/test/groovy/io/seqera/wave/util/PixiHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/PixiHelperTest.groovy
@@ -133,4 +133,62 @@ class PixiHelperTest extends Specification {
         def ex = thrown(BadRequestException)
         ex.message.contains("Conda lock file is not supported by 'conda/pixi:v1' template")
     }
+
+    // ---- Tests for channel mapping to prefix.dev mirrors ----
+
+    def 'should map conda-forge channel to prefix.dev mirror'() {
+        when:
+        def result = PixiHelper.mapChannelsToPixiServers(['conda-forge'])
+
+        then:
+        result == ['https://prefix.dev/conda-forge']
+    }
+
+    def 'should map bioconda channel to prefix.dev mirror'() {
+        when:
+        def result = PixiHelper.mapChannelsToPixiServers(['bioconda'])
+
+        then:
+        result == ['https://prefix.dev/bioconda']
+    }
+
+    def 'should map multiple known channels to prefix.dev mirrors'() {
+        when:
+        def result = PixiHelper.mapChannelsToPixiServers(['conda-forge', 'bioconda'])
+
+        then:
+        result == ['https://prefix.dev/conda-forge', 'https://prefix.dev/bioconda']
+    }
+
+    def 'should leave unknown channels unchanged'() {
+        when:
+        def result = PixiHelper.mapChannelsToPixiServers(['defaults', 'my-custom-channel'])
+
+        then:
+        result == ['defaults', 'my-custom-channel']
+    }
+
+    def 'should handle mixed known and unknown channels'() {
+        when:
+        def result = PixiHelper.mapChannelsToPixiServers(['conda-forge', 'defaults', 'bioconda', 'my-channel'])
+
+        then:
+        result == ['https://prefix.dev/conda-forge', 'defaults', 'https://prefix.dev/bioconda', 'my-channel']
+    }
+
+    def 'should handle null channel list'() {
+        when:
+        def result = PixiHelper.mapChannelsToPixiServers(null)
+
+        then:
+        result == null
+    }
+
+    def 'should handle empty channel list'() {
+        when:
+        def result = PixiHelper.mapChannelsToPixiServers([])
+
+        then:
+        result == []
+    }
 }


### PR DESCRIPTION
## Summary

Enable sharded repodata for pixi-based container builds by automatically mapping well-known conda channels to their prefix.dev mirrors:

- `conda-forge` → `https://prefix.dev/conda-forge`
- `bioconda` → `https://prefix.dev/bioconda`

## Rationale

According to the [prefix.dev blog post on sharded repodata](https://prefix.dev/blog/sharded_repodata), using prefix.dev mirrors provides significant performance improvements for package resolution:

- **50x faster** package resolution on fresh downloads
- **Up to 100x faster** with cached operations  
- Reduces conda-forge index size from 243 MB to 0.421 MB

The sharded repodata architecture splits package metadata into content-addressed shards (one per package name), enabling aggressive caching and faster downloads compared to monolithic `repodata.json` files.

## Implementation

- Added `mapChannelsToPixiServers()` method in `PixiHelper` to map known channels to prefix.dev mirrors
- Modified `condaFileFromRequest()` in `ContainerHelper` to apply channel mapping only when `buildTemplate == CONDA_PIXI_V1`
- Other build templates (micromamba v1/v2) remain unchanged

## Test plan

- [x] Unit tests for channel mapping logic in `PixiHelperTest`
- [x] Integration tests in `ContainerHelperTest` verifying mapping is applied only for pixi builds
- [ ] Manual verification of pixi build performance improvement

🤖 Generated with [Claude Code](https://claude.ai/code)