### PR TITLE
Fixed missing IAM permission that broke build flow.

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -323,6 +323,11 @@ Wave requires access to AWS ECR for container image management. Create an IAM ro
 ```json
 "Statement": [
         {
+            "Effect": "Allow",
+            "Action": "ecr:GetAuthorizationToken",
+            "Resource": "*"
+        },
+        {
             "Action": [
                 "ecr:BatchCheckLayerAvailability",
                 "ecr:GetDownloadUrlForLayer",


### PR DESCRIPTION
Missing permission caused build flow to fail (_using token with minimal permissions documented in same page_).

[Internal link](https://github.com/seqeralabs/cx-field-tools-tf-aws-eks/issues/5) with more details.