### PR TITLE
Bump Spock to 2.4-groovy-4.0

### DIFF
--- a/buildSrc/src/main/groovy/io.seqera.wave.java-library-conventions.gradle
+++ b/buildSrc/src/main/groovy/io.seqera.wave.java-library-conventions.gradle
@@ -44,8 +44,8 @@ dependencies {
     testImplementation 'org.apache.groovy:groovy-test:4.0.15'
     testImplementation 'org.objenesis:objenesis:3.4'
     testImplementation 'net.bytebuddy:byte-buddy:1.14.17'
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
-    testImplementation 'org.spockframework:spock-junit4:2.3-groovy-4.0'
+    testImplementation 'org.spockframework:spock-core:2.4-groovy-4.0'
+    testImplementation 'org.spockframework:spock-junit4:2.4-groovy-4.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ resilience4j = "0.17.0"
 slf4j = "2.0.16"
 snakeyaml = "2.2"
 spillway = "3.0.0"
-spock = "2.3-groovy-4.0"
+spock = "2.4-groovy-4.0"
 
 [libraries]
 # Jakarta


### PR DESCRIPTION
## Summary
- Update Spock testing framework from 2.3 to 2.4 (groovy-4.0)

## Test plan
- [ ] CI tests pass with the new Spock version

🤖 Generated with [Claude Code](https://claude.com/claude-code)