### PR TITLE
Fix conda builds for packages requiring __cuda virtual package

### DIFF
--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
@@ -1,6 +1,8 @@
 FROM {{mamba_image}} AS build
 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-RUN micromamba install -y -n base -f /tmp/conda.yml \
+RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \
+    || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
+        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \
     {{base_packages}}
     && micromamba env export --name base --explicit > environment.lock \
     && echo ">> CONDA_LOCK_START" \

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
@@ -1,6 +1,7 @@
 FROM {{mamba_image}} AS build
 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
 RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \
+    && cat /tmp/mamba.log \
     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
         && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \
     {{base_packages}}

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
@@ -3,7 +3,7 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
 RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \
     && cat /tmp/mamba.log \
     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
-        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \
+        && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \
     {{base_packages}}
     && micromamba env export --name base --explicit > environment.lock \
     && echo ">> CONDA_LOCK_START" \

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
@@ -3,7 +3,7 @@ RUN \
     (micromamba install -y -n base {{channel_opts}} {{target}} > /tmp/mamba.log 2>&1 \
     && cat /tmp/mamba.log \
     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
-        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base {{channel_opts}} {{target}})) \
+        && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base {{channel_opts}} {{target}})) \
     {{base_packages}}
     && micromamba env export --name base --explicit > environment.lock \
     && echo ">> CONDA_LOCK_START" \

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
@@ -1,6 +1,8 @@
 FROM {{mamba_image}} AS build
 RUN \
-    micromamba install -y -n base {{channel_opts}} {{target}} \
+    (micromamba install -y -n base {{channel_opts}} {{target}} > /tmp/mamba.log 2>&1 \
+    || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
+        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base {{channel_opts}} {{target}})) \
     {{base_packages}}
     && micromamba env export --name base --explicit > environment.lock \
     && echo ">> CONDA_LOCK_START" \

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
@@ -1,6 +1,7 @@
 FROM {{mamba_image}} AS build
 RUN \
     (micromamba install -y -n base {{channel_opts}} {{target}} > /tmp/mamba.log 2>&1 \
+    && cat /tmp/mamba.log \
     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
         && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base {{channel_opts}} {{target}})) \
     {{base_packages}}

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
@@ -4,6 +4,7 @@ From: {{mamba_image}}
     {{wave_context_dir}}/conda.yml /scratch/conda.yml
 %post
     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \
+        && cat /tmp/mamba.log \
         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
             && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /scratch/conda.yml)
     {{base_packages}}

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
@@ -6,7 +6,7 @@ From: {{mamba_image}}
     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \
         && cat /tmp/mamba.log \
         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
-            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /scratch/conda.yml)
+            && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
     {{base_packages}}
     micromamba env export --name base --explicit > environment.lock
     echo ">> CONDA_LOCK_START"

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
@@ -3,7 +3,9 @@ From: {{mamba_image}}
 %files
     {{wave_context_dir}}/conda.yml /scratch/conda.yml
 %post
-    micromamba install -y -n base -f /scratch/conda.yml
+    micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \
+        || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
+            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /scratch/conda.yml)
     {{base_packages}}
     micromamba env export --name base --explicit > environment.lock
     echo ">> CONDA_LOCK_START"

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
@@ -1,7 +1,9 @@
 BootStrap: docker
 From: {{mamba_image}}
 %post
-    micromamba install -y -n base {{channel_opts}} {{target}}
+    micromamba install -y -n base {{channel_opts}} {{target}} > /tmp/mamba.log 2>&1 \
+        || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
+            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base {{channel_opts}} {{target}})
     {{base_packages}}
     micromamba env export --name base --explicit > environment.lock
     echo ">> CONDA_LOCK_START"

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
@@ -4,7 +4,7 @@ From: {{mamba_image}}
     micromamba install -y -n base {{channel_opts}} {{target}} > /tmp/mamba.log 2>&1 \
         && cat /tmp/mamba.log \
         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
-            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base {{channel_opts}} {{target}})
+            && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base {{channel_opts}} {{target}})
     {{base_packages}}
     micromamba env export --name base --explicit > environment.lock
     echo ">> CONDA_LOCK_START"

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
@@ -2,6 +2,7 @@ BootStrap: docker
 From: {{mamba_image}}
 %post
     micromamba install -y -n base {{channel_opts}} {{target}} > /tmp/mamba.log 2>&1 \
+        && cat /tmp/mamba.log \
         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
             && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base {{channel_opts}} {{target}})
     {{base_packages}}

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -731,7 +731,9 @@ class ContainerHelperTest extends Specification {
         result =='''\
                 FROM mambaorg/micromamba:2-amazon2023 AS build
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                RUN micromamba install -y -n base -f /tmp/conda.yml \\
+                RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                    || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
+                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
@@ -770,7 +772,9 @@ class ContainerHelperTest extends Specification {
         result =='''\
                 FROM mambaorg/micromamba:2.0.0 AS build
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                RUN micromamba install -y -n base -f /tmp/conda.yml \\
+                RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                    || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
+                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base foo::one bar::two \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
@@ -803,7 +807,9 @@ class ContainerHelperTest extends Specification {
         result =='''\
                 FROM mambaorg/micromamba:2-amazon2023 AS build
                 RUN \\
-                    micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml \\
+                    (micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml > /tmp/mamba.log 2>&1 \\
+                    || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
+                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -732,6 +732,7 @@ class ContainerHelperTest extends Specification {
                 FROM mambaorg/micromamba:2-amazon2023 AS build
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
                 RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                    && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
@@ -773,6 +774,7 @@ class ContainerHelperTest extends Specification {
                 FROM mambaorg/micromamba:2.0.0 AS build
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
                 RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                    && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base foo::one bar::two \\
@@ -808,6 +810,7 @@ class ContainerHelperTest extends Specification {
                 FROM mambaorg/micromamba:2-amazon2023 AS build
                 RUN \\
                     (micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml > /tmp/mamba.log 2>&1 \\
+                    && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -734,7 +734,7 @@ class ContainerHelperTest extends Specification {
                 RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
-                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
+                        && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
@@ -776,7 +776,7 @@ class ContainerHelperTest extends Specification {
                 RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
-                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
+                        && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base foo::one bar::two \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
@@ -812,7 +812,7 @@ class ContainerHelperTest extends Specification {
                     (micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
-                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml)) \\
+                        && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -483,7 +483,9 @@ class TemplateUtilsTest extends Specification {
         TemplateUtils.condaFileToDockerFileUsingV2(CONDA_OPTS) == '''\
                 FROM mambaorg/micromamba:2.1.1 AS build
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                RUN micromamba install -y -n base -f /tmp/conda.yml \\
+                RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                    || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
+                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
@@ -504,7 +506,9 @@ class TemplateUtilsTest extends Specification {
         TemplateUtils.condaFileToDockerFileUsingV2(new CondaOpts([:])) == '''\
                 FROM mambaorg/micromamba:1.5.10-noble AS build
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                RUN micromamba install -y -n base -f /tmp/conda.yml \\
+                RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                    || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
+                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
@@ -534,7 +538,9 @@ class TemplateUtilsTest extends Specification {
         TemplateUtils.condaPackagesToDockerFileUsingV2(PACKAGES, CHANNELS, CONDA_OPTS) == '''\
                 FROM mambaorg/micromamba:2.1.1 AS build
                 RUN \\
-                    micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 \\
+                    (micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 > /tmp/mamba.log 2>&1 \\
+                    || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
+                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
@@ -564,7 +570,9 @@ class TemplateUtilsTest extends Specification {
         TemplateUtils.condaPackagesToDockerFileUsingV2(PACKAGES, CHANNELS, CONDA_OPTS) == '''\
                 FROM mambaorg/micromamba:2.1.1 AS build
                 RUN \\
-                    micromamba install -y -n base -c conda-forge numpy pandas \\
+                    (micromamba install -y -n base -c conda-forge numpy pandas > /tmp/mamba.log 2>&1 \\
+                    || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
+                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge numpy pandas)) \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -756,7 +764,9 @@ class TemplateUtilsTest extends Specification {
                 %files
                     {{wave_context_dir}}/conda.yml /scratch/conda.yml
                 %post
-                    micromamba install -y -n base -f /scratch/conda.yml
+                    micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \\
+                        || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
+                            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
@@ -777,7 +787,9 @@ class TemplateUtilsTest extends Specification {
                 %files
                     {{wave_context_dir}}/conda.yml /scratch/conda.yml
                 %post
-                    micromamba install -y -n base -f /scratch/conda.yml
+                    micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \\
+                        || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
+                            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
@@ -804,7 +816,9 @@ class TemplateUtilsTest extends Specification {
                 BootStrap: docker
                 From: mambaorg/micromamba:2.1.1
                 %post
-                    micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1
+                    micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 > /tmp/mamba.log 2>&1 \\
+                        || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
+                            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1)
                     micromamba install -y -n base conda-forge::procps-ng
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
@@ -831,7 +845,9 @@ class TemplateUtilsTest extends Specification {
                 BootStrap: docker
                 From: mambaorg/micromamba:2.1.1
                 %post
-                    micromamba install -y -n base -c conda-forge numpy pandas
+                    micromamba install -y -n base -c conda-forge numpy pandas > /tmp/mamba.log 2>&1 \\
+                        || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
+                            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge numpy pandas)
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -486,7 +486,7 @@ class TemplateUtilsTest extends Specification {
                 RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
-                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
+                        && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
@@ -510,7 +510,7 @@ class TemplateUtilsTest extends Specification {
                 RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
-                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
+                        && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
@@ -543,7 +543,7 @@ class TemplateUtilsTest extends Specification {
                     (micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
-                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1)) \\
+                        && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
@@ -576,7 +576,7 @@ class TemplateUtilsTest extends Specification {
                     (micromamba install -y -n base -c conda-forge numpy pandas > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
-                        && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge numpy pandas)) \\
+                        && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge numpy pandas)) \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -771,7 +771,7 @@ class TemplateUtilsTest extends Specification {
                     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
-                            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /scratch/conda.yml)
+                            && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
@@ -795,7 +795,7 @@ class TemplateUtilsTest extends Specification {
                     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
-                            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /scratch/conda.yml)
+                            && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
@@ -825,7 +825,7 @@ class TemplateUtilsTest extends Specification {
                     micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
-                            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1)
+                            && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1)
                     micromamba install -y -n base conda-forge::procps-ng
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
@@ -855,7 +855,7 @@ class TemplateUtilsTest extends Specification {
                     micromamba install -y -n base -c conda-forge numpy pandas > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
-                            && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge numpy pandas)
+                            && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge numpy pandas)
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -484,6 +484,7 @@ class TemplateUtilsTest extends Specification {
                 FROM mambaorg/micromamba:2.1.1 AS build
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
                 RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                    && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
@@ -507,6 +508,7 @@ class TemplateUtilsTest extends Specification {
                 FROM mambaorg/micromamba:1.5.10-noble AS build
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
                 RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                    && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
@@ -539,6 +541,7 @@ class TemplateUtilsTest extends Specification {
                 FROM mambaorg/micromamba:2.1.1 AS build
                 RUN \\
                     (micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 > /tmp/mamba.log 2>&1 \\
+                    && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
@@ -571,6 +574,7 @@ class TemplateUtilsTest extends Specification {
                 FROM mambaorg/micromamba:2.1.1 AS build
                 RUN \\
                     (micromamba install -y -n base -c conda-forge numpy pandas > /tmp/mamba.log 2>&1 \\
+                    && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge numpy pandas)) \\
                     && micromamba env export --name base --explicit > environment.lock \\
@@ -765,6 +769,7 @@ class TemplateUtilsTest extends Specification {
                     {{wave_context_dir}}/conda.yml /scratch/conda.yml
                 %post
                     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \\
+                        && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                             && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
@@ -788,6 +793,7 @@ class TemplateUtilsTest extends Specification {
                     {{wave_context_dir}}/conda.yml /scratch/conda.yml
                 %post
                     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \\
+                        && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                             && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
@@ -817,6 +823,7 @@ class TemplateUtilsTest extends Specification {
                 From: mambaorg/micromamba:2.1.1
                 %post
                     micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 > /tmp/mamba.log 2>&1 \\
+                        && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                             && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1)
                     micromamba install -y -n base conda-forge::procps-ng
@@ -846,6 +853,7 @@ class TemplateUtilsTest extends Specification {
                 From: mambaorg/micromamba:2.1.1
                 %post
                     micromamba install -y -n base -c conda-forge numpy pandas > /tmp/mamba.log 2>&1 \\
+                        && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                             && CONDA_OVERRIDE_CUDA="12" micromamba install -y -n base -c conda-forge numpy pandas)
                     micromamba env export --name base --explicit > environment.lock


### PR DESCRIPTION
## Summary

- Fixes conda-file and conda-packages builds that fail when a dependency requires the `__cuda` virtual package (e.g., `pytorch-gpu >= 1.12.1`, JAX, TensorFlow)
- Adds retry-on-failure logic to all 4 micromamba v2 templates (Docker/Singularity x file/packages): the first install attempt output is captured, and if it fails with `__cuda` in the error, retries with `CONDA_OVERRIDE_CUDA="12"` set
- Zero overhead for non-GPU builds; GPU builds incur only a fast solver failure (~4s) before the successful retry

Closes #1026

## Test plan

- [x] All 34 TemplateUtilsTest tests pass
- [ ] Verify with a real conda-file build containing pytorch-gpu>=2.0
- [ ] Verify non-GPU builds (e.g., bwa salmon) are unaffected