### PR TITLE
docs: Reduce wave resource requirements in installation manifests

### DIFF
--- a/docs/install/docker-compose.md
+++ b/docs/install/docker-compose.md
@@ -160,11 +160,10 @@ services:
       replicas: 2
       resources:
         limits:
-          memory: 4G
-          cpus: '1.0'
+          memory: 1500M
         reservations:
-          memory: 4G
-          cpus: '1'
+          memory: 1500M
+          cpus: '0.2'
     # Health check configuration
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9090/health"]

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -209,9 +209,9 @@ spec:
               value: "postgres,redis,lite"
           resources:
             requests:
-              memory: "4000Mi"
+              memory: "1500Mi"
             limits:
-              memory: "4000Mi"
+              memory: "1500Mi"
           workingDir: "/work"
           volumeMounts:
             - name: wave-cfg
@@ -338,7 +338,7 @@ Wave requires access to AWS ECR for container image management. Create an IAM ro
           "ecr:GetDownloadUrlForLayer",
           "ecr:InitiateLayerUpload",
           "ecr:PutImage",
-          "ecr:UploadLayerPart"  
+          "ecr:UploadLayerPart"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -355,7 +355,7 @@ Wave requires access to AWS ECR for container image management. Create an IAM ro
           "ecr:GetLifecyclePolicyPreview",
           "ecr:GetRepositoryPolicy",
           "ecr:ListImages",
-          "ecr:ListTagsForResource"  
+          "ecr:ListTagsForResource"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -363,7 +363,7 @@ Wave requires access to AWS ECR for container image management. Create an IAM ro
       ]
     },
   ]
-}    
+}
 ```
 
 ### Advanced configuration

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -346,7 +346,7 @@ Wave requires access to AWS ECR for container image management. Create an IAM ro
       ]
     },
     {
-      "Sid": "ExtraPermissionsForBuild"
+      "Sid": "ExtraPermissionsForBuild",
       "Action": [
           "ecr:DescribeImageScanFindings",
           "ecr:DescribeImages",

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -21,8 +21,8 @@ Wave's full build capabilities require specific integrations with Kubernetes and
 
 The minimum system requirements for a Wave Kubernetes installation are:
 
-- **Memory**: Minimum 4GB RAM per Wave pod
-- **CPU**: Minimum 1 CPU core per pod
+- **Memory**: Minimum 1500 MiB RAM per Wave pod
+- **CPU**: Minimum 0.2 CPU core per pod
 - **Network**: Connectivity to your external PostgreSQL and Redis instances
 - **Storage**: Sufficient storage for your container images and temporary files
 


### PR DESCRIPTION
While developing the wave chart, I noticed that wave recommends quite a large amount of resources.