### PR TITLE
 Refine Docker Compose setup for Wave Lite   

### DIFF
--- a/docs/install/docker-compose.md
+++ b/docs/install/docker-compose.md
@@ -66,7 +66,7 @@ Wave will automatically handle schema migrations on startup and create the requi
 
 Create a configuration file that defines Wave's behavior and integrations. Save this as `config/wave-config.yml` in your Docker Compose directory.
 
-Database, Redis, and Platform connection settings are provided via the `wave.env` environment file (see [Deploy Wave](#deploy-wave) below), so they do not need to be duplicated here.
+Database, Redis, and Platform connection settings are provided via the `wave.env` environment file (see [Deploy Wave](#deploy-wave) below).
 
 ```yaml
 wave:
@@ -137,7 +137,7 @@ Add the following to your `docker-compose.yml`:
 services:
   wave:
     # Replace with your Wave image registry path
-    image: cr.seqera.io/public/wave:latest
+    image: <WAVE CONTAINER IMAGE>
     ports:
       - "9090:9090"
     environment:

--- a/docs/install/docker-compose.md
+++ b/docs/install/docker-compose.md
@@ -23,8 +23,8 @@ The minimum system requirements for self-hosted Wave in Docker Compose are:
 
 - Current, supported versions of **Docker Engine** and **Docker Compose**.
 - Compute instance minimum requirements:
-  - **Memory**: 16 GB RAM available to be used by the Wave application on the host system.
-  - **CPU**: 4 CPU cores available on the host system.
+  - **Memory**: 12 GB RAM available on the host system (8 GB for Wave replicas + headroom for OS and Docker).
+  - **CPU**: 4 CPU cores available on the host system (2 for Wave replicas + headroom for OS and Docker).
   - **Storage**: 10 GB in addition to sufficient disk space for your container images and temporary files.
   - For example, in AWS EC2, `m5a.xlarge` or greater
   - **Network**: Connectivity to your PostgreSQL and Redis instances.
@@ -156,7 +156,7 @@ services:
           cpus: '1.0'
         reservations:
           memory: 2G
-          cpus: '0.5'
+          cpus: '0.2'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9090/health"]
       interval: 30s

--- a/docs/install/docker-compose.md
+++ b/docs/install/docker-compose.md
@@ -13,16 +13,20 @@ Before installing Wave, you need the following infrastructure components:
 - **PostgreSQL instance** - Version 12, or higher
 - **Redis instance** - Version 6.2, or higher
 
+:::note
+Use managed services for PostgreSQL and Redis (e.g., Amazon RDS, Amazon ElastiCache, or equivalent) rather than running them in Docker Compose. Managed services provide automated backups, failover, patching, and monitoring that are difficult to replicate with containerized databases. Running PostgreSQL or Redis in Docker Compose is suitable only for local development and testing.
+:::
+
 ## System requirements
 
 The minimum system requirements for self-hosted Wave in Docker Compose are:
 
 - Current, supported versions of **Docker Engine** and **Docker Compose**.
 - Compute instance minimum requirements:
-  - **Memory**: 32 GB RAM available to be used by the Wave application on the host system.
-  - **CPU**: 8 CPU cores available on the host system.
+  - **Memory**: 16 GB RAM available to be used by the Wave application on the host system.
+  - **CPU**: 4 CPU cores available on the host system.
   - **Storage**: 10 GB in addition to sufficient disk space for your container images and temporary files.
-  - For example, in AWS EC2, `m5a.2xlarge` or greater
+  - For example, in AWS EC2, `m5a.xlarge` or greater
   - **Network**: Connectivity to your PostgreSQL and Redis instances.
 
 ## Database configuration
@@ -62,34 +66,24 @@ Wave will automatically handle schema migrations on startup and create the requi
 
 Create a configuration file that defines Wave's behavior and integrations. Save this as `config/wave-config.yml` in your Docker Compose directory.
 
+Database, Redis, and Platform connection settings are provided via the `wave.env` environment file (see [Deploy Wave](#deploy-wave) below), so they do not need to be duplicated here.
+
 ```yaml
 wave:
-  # Build service configuration - disabled for Docker Compose
-  build:
-    enabled: false
-  # Mirror service configuration - disabled for Docker Compose
-  mirror:
-    enabled: false
-  # Security scanning configuration - disabled for Docker Compose
-  scan:
-    enabled: false
-  # Blob caching configuration - disabled for Docker Compose
-  blobCache:
-    enabled: false
-  # Database connection settings
-  db:
-    uri: "jdbc:postgresql://your-postgres-host:5432/wave"
-    user: "wave_user"
-    password: "your_secure_password"
+  debug: false
+  tokens:
+    cache:
+      duration: "36h"
+  metrics:
+    enabled: true
 
-# Redis configuration for caching and session management
-redis:
-  uri: "redis://your-redis-host:6379"
-
-# Platform integration (optional)
-tower:
-  endpoint:
-    url: "https://your-platform-server.com"
+# Rate limiting configuration
+rate-limit:
+  pull:
+    anonymous: 250/1h
+    authenticated: 2000/1m
+  timeout-errors:
+    max-rate: 100/1m
 
 # Micronaut framework configuration
 micronaut:
@@ -98,18 +92,15 @@ micronaut:
     event-loops:
       default:
         num-threads: 64
-      stream-pool:
-        executor: stream-executor
   # HTTP client configuration
   http:
     services:
       stream-client:
-        read-timeout: 30s
-        read-idle-timeout: 5m
-        event-loop-group: stream-pool
+        read-timeout: '30s'
+        read-idle-timeout: '5m'
 
 # Management endpoints configuration
-loggers:
+endpoints:
   env:
     enabled: false
   bean:
@@ -136,8 +127,7 @@ loggers:
 
 Configuration notes:
 
-- Replace `your-postgres-host` and `your-redis-host` with your service endpoints.
-- Adjust `number-of-threads` (16) and `num-threads` (64) based on your CPU cores — Use between 2x and 4x your CPU core count.
+- Adjust `num-threads` (64) based on your CPU cores — use between 2x and 4x your CPU core count.
 
 ## Docker Compose
 
@@ -145,16 +135,18 @@ Add the following to your `docker-compose.yml`:
 
 ```yaml
 services:
-  wave-app:
-    image: your-registry.com/wave:latest
-    container_name: wave-app
+  wave:
+    # Replace with your Wave image registry path
+    image: cr.seqera.io/public/wave:latest
     ports:
-      # Bind to the host on 9100 vs 9090
-      - "9100:9090"
+      - "9090:9090"
     environment:
-      - MICRONAUT_ENVIRONMENTS=lite,redis,postgres
+      - MICRONAUT_ENVIRONMENTS=lite,rate-limit,redis,postgres,prometheus
     volumes:
       - ./config/wave-config.yml:/work/config.yml:ro
+    env_file:
+      - wave.env
+    working_dir: /work
     deploy:
       mode: replicated
       replicas: 2
@@ -163,16 +155,14 @@ services:
           memory: 4G
           cpus: '1.0'
         reservations:
-          memory: 4G
-          cpus: '1'
-    # Health check configuration
+          memory: 2G
+          cpus: '0.5'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9090/health"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 60s
-    # Restart policy
     restart: unless-stopped
 ```
 

--- a/lite/config.yml
+++ b/lite/config.yml
@@ -1,5 +1,13 @@
 wave:
   debug: false
+  build:
+    enabled: false
+  mirror:
+    enabled: false
+  scan:
+    enabled: false
+  blobCache:
+    enabled: false
   tokens:
     cache:
       duration: "36h"

--- a/lite/docker-compose.yml
+++ b/lite/docker-compose.yml
@@ -51,7 +51,7 @@ services:
           cpus: '1.0'
         reservations:
           memory: 2G
-          cpus: '0.5'
+          cpus: '0.2'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9090/health"]
       interval: 30s

--- a/lite/docker-compose.yml
+++ b/lite/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   wave:
     # Replace with your Wave image registry path
-    image: hrma017/wave:1.33.2
+    image: #<WAVE Container Image>
     ports:
       - "9090:9090"
     volumes:

--- a/lite/docker-compose.yml
+++ b/lite/docker-compose.yml
@@ -1,17 +1,64 @@
-version: "3.9"
 services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: wave
+      POSTGRES_USER: wave
+      POSTGRES_PASSWORD: wave
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U wave"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
   wave:
+    # Replace with your Wave image registry path
+    image: hrma017/wave:1.33.2
     ports:
       - "9090:9090"
     volumes:
-      - $PWD:/work
-      - ./config.yml:/work/config.yml
+      - ./config.yml:/work/config.yml:ro
     environment:
       - MICRONAUT_ENVIRONMENTS=lite,rate-limit,redis,postgres,prometheus
-      - WAVE_JVM_OPTS=-XX:+UseG1GC -Xms512m -Xmx850m -XX:MaxDirectMemorySize=100m -Dio.netty.maxDirectMemory=0 -Dio.netty.allocator.type=pooled -Djdk.httpclient.keepalive.timeout=10 -Djdk.tracePinnedThreads=short -Djdk.traceVirtualThreadInThreadDump=full
     env_file:
       - wave.env
     working_dir: /work
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     deploy:
       mode: replicated
-      replicas: 2
+      # Use 2 replicas with `docker stack deploy` (Swarm mode).
+      # For `docker compose up`, use 1 to avoid port conflicts.
+      replicas: 1
+      resources:
+        limits:
+          memory: 4G
+          cpus: '1.0'
+        reservations:
+          memory: 2G
+          cpus: '0.5'
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9090/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+
+volumes:
+  db-data:

--- a/lite/wave.env
+++ b/lite/wave.env
@@ -1,0 +1,40 @@
+#
+# Base URL that will be used to reach the Wave service.
+#
+WAVE_SERVER_URL=http://localhost:9090
+
+#
+# JDBC connection URI to connect the PostgreSQL database
+# required by the Wave service. Note the database name is expected
+# to be provided in place of the "changeme"  suffix.
+#
+WAVE_DB_URI=jdbc:postgresql://db:5432/wave
+
+#
+# User name required to access the PostgreSQL database
+# used by the Wave service.
+#
+WAVE_DB_USER=wave
+
+#
+# Password required to access the PostgreSQL database
+# used by the Wave service.
+#
+WAVE_DB_PASSWORD=wave
+
+#
+# Connection URI to connect Wave with the Redis cache
+#
+REDIS_URI=redis://redis:6379
+
+#
+# Connection URL to connect Wave service with Platform instance.
+# Replace this variable with your own Platform endpoint.
+#
+TOWER_ENDPOINT_URL=http://localhost:8000/api
+
+#
+# Email address that will be used by the Wave service to send notification emails.
+# Replace this variable with your own mail address.
+#
+MAIL_FROM=wave-app+changeme@seqera.io


### PR DESCRIPTION
###   Summary                                                                                                                                                      
                                                                                                                                                               
- Right-sized system requirements from 32 GB / 8 CPU (m5a.2xlarge) down to 12 GB / 4 CPU (m5a.xlarge) — Wave Lite disables build, mirror, scan, and blob cache services, and k8s runs at 1.4 GB / 0.2 CPU per pod, so the previous requirements were massively oversized.                                           
- Right-sized container resource limits — set 4 GB memory / 1 CPU limit and 2 GB memory / 0.2 CPU reservation per replica, aligned with actual k8s production usage rather than the previous 4 GB / 1 CPU reservations.                                                                                                   - Overhauled lite/docker-compose.yml — added bundled PostgreSQL 16 and Redis 7 services with health checks, depends_on conditions, resource limits, and restart policies. Previously the compose file assumed external DB/Redis but provided no guidance, making first-time setup impossible out of the box.         
- Added lite/wave.env template — centralizes connection settings (DB, Redis, Platform endpoint, mail) in one documented env file instead of scattering them across the YAML config.                                                                                                                                      
- Simplified docs/install/docker-compose.md — removed disabled-service blocks and stale settings (removed stream-pool event loop group, duplicate connection strings) from the example config. Moved DB/Redis/Platform settings to the env file to reduce copy-paste errors.                                            
- Updated lite/config.yml to explicitly disable build, mirror, scan, and blobCache —  these were previously only implied by the lite Micronaut profile but not visible in the config, causing confusion about what was running.                                                                                          - Added managed-services note — steers production users toward managed PostgreSQL/Redis (RDS, ElastiCache) while keeping containerized option for development.                                                                                                                                                 
- Switched deployment to Docker Swarm — docs now use docker stack deploy with 2 replicas, since plain docker compose up cannot run replicas with port      
  bindings.     