### PR TITLE
fix: add micromamba clean to v2 templates to reduce image size

### DIFF
--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
@@ -5,6 +5,7 @@ RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \
     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \
     {{base_packages}}
+    && micromamba clean -a -y \
     && micromamba env export --name base --explicit > environment.lock \
     && echo ">> CONDA_LOCK_START" \
     && cat environment.lock \

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
@@ -5,6 +5,7 @@ RUN \
     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base {{channel_opts}} {{target}})) \
     {{base_packages}}
+    && micromamba clean -a -y \
     && micromamba env export --name base --explicit > environment.lock \
     && echo ">> CONDA_LOCK_START" \
     && cat environment.lock \

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
@@ -8,6 +8,7 @@ From: {{mamba_image}}
         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
     {{base_packages}}
+    micromamba clean -a -y
     micromamba env export --name base --explicit > environment.lock
     echo ">> CONDA_LOCK_START"
     cat environment.lock

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
@@ -6,6 +6,7 @@ From: {{mamba_image}}
         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base {{channel_opts}} {{target}})
     {{base_packages}}
+    micromamba clean -a -y
     micromamba env export --name base --explicit > environment.lock
     echo ">> CONDA_LOCK_START"
     cat environment.lock

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -736,6 +736,7 @@ class ContainerHelperTest extends Specification {
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
+                    && micromamba clean -a -y \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -778,6 +779,7 @@ class ContainerHelperTest extends Specification {
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base foo::one bar::two \\
+                    && micromamba clean -a -y \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -814,6 +816,7 @@ class ContainerHelperTest extends Specification {
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
+                    && micromamba clean -a -y \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -488,6 +488,7 @@ class TemplateUtilsTest extends Specification {
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
+                    && micromamba clean -a -y \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -512,6 +513,7 @@ class TemplateUtilsTest extends Specification {
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
+                    && micromamba clean -a -y \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -545,6 +547,7 @@ class TemplateUtilsTest extends Specification {
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
+                    && micromamba clean -a -y \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -577,6 +580,7 @@ class TemplateUtilsTest extends Specification {
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge numpy pandas)) \\
+                    && micromamba clean -a -y \\
                     && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -770,6 +774,7 @@ class TemplateUtilsTest extends Specification {
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
+                    micromamba clean -a -y
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
@@ -794,6 +799,7 @@ class TemplateUtilsTest extends Specification {
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
+                    micromamba clean -a -y
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
@@ -824,6 +830,7 @@ class TemplateUtilsTest extends Specification {
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1)
                     micromamba install -y -n base conda-forge::procps-ng
+                    micromamba clean -a -y
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
@@ -853,6 +860,7 @@ class TemplateUtilsTest extends Specification {
                         && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge numpy pandas)
+                    micromamba clean -a -y
                     micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock


### PR DESCRIPTION
The conda/micromamba:v2 templates were missing `micromamba clean -a -y` which is present in v1. This caused cached package tarballs in /opt/conda/pkgs/ to be included in the final image, roughly doubling the image size compared to v1 and pixi templates.