### PR TITLE
chore: port wave CI to push to internal ECR SEC-1395

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
         if: "contains(github.event.head_commit.message, '[release]')"
         shell: bash
         run: |
-          LOCAL=platform/wave:${{ steps.release.outputs.version }}
+          LOCAL=wave/server:${{ steps.release.outputs.version }}
           REMOTE="${{ steps.login-ecr-platform.outputs.registry }}/${LOCAL}"
           docker tag "$LOCAL" "$REMOTE"
           docker push "$REMOTE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,18 +117,61 @@ jobs:
           docker push 195996028523.dkr.ecr.eu-west-1.amazonaws.com/wave/app:$TAG
           docker push 195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/wave:$TAG
 
+      # Internal ECR push - inlined from seqeralabs/actions/push@a78e62713a7895bef99f404d736b72451dbdb917
+      # because seqeralabs/actions is private and Wave is a public repo. See SEC-1409.
+      - name: Configure AWS credentials for action role
+        if: "contains(github.event.head_commit.message, '[release]')"
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # ratchet:aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::232933512461:role/gha-seqeralabs-action-role
+          role-session-name: GitHubActions-${{ github.run_id }}
+
+      - name: Configure AWS credentials for internal pusher
+        if: "contains(github.event.head_commit.message, '[release]')"
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # ratchet:aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::232933512461:role/gha-generic-internal-pusher
+          role-session-name: ${{ github.event.repository.name }}
+          role-chaining: true
+
+      - name: Login to internal Amazon ECR
+        if: "contains(github.event.head_commit.message, '[release]')"
+        id: login-ecr-internal
+        uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # ratchet:aws-actions/amazon-ecr-login@v2.1.4
+
       - name: Push image to internal registry
         if: "contains(github.event.head_commit.message, '[release]')"
-        uses: seqeralabs/actions/push@a78e62713a7895bef99f404d736b72451dbdb917 # ratchet:exclude
+        shell: bash
+        run: |
+          LOCAL=app:${{ steps.release.outputs.version }}
+          REMOTE="${{ steps.login-ecr-internal.outputs.registry }}/internal/${{ github.repository }}/${LOCAL}"
+          docker tag "$LOCAL" "$REMOTE"
+          docker push "$REMOTE"
+
+      # Enterprise ECR push - inlined from seqeralabs/actions/push@a78e62713a7895bef99f404d736b72451dbdb917 with custom-role-arn
+      - name: Configure AWS credentials for platform pusher
+        if: "contains(github.event.head_commit.message, '[release]')"
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # ratchet:aws-actions/configure-aws-credentials@v6.1.0
         with:
-          image-tag: app:${{ steps.release.outputs.version }}
+          aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::232933512461:role/platform-ecr-pusher
+          role-session-name: GitHubActions-${{ github.run_id }}
+
+      - name: Login to enterprise Amazon ECR
+        if: "contains(github.event.head_commit.message, '[release]')"
+        id: login-ecr-platform
+        uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # ratchet:aws-actions/amazon-ecr-login@v2.1.4
 
       - name: Push image to enterprise registry
         if: "contains(github.event.head_commit.message, '[release]')"
-        uses: seqeralabs/actions/push@a78e62713a7895bef99f404d736b72451dbdb917 # ratchet:exclude
-        with:
-          image-tag: platform/wave:${{ steps.release.outputs.version }}
-          custom-role-arn: arn:aws:iam::232933512461:role/platform-ecr-pusher
+        shell: bash
+        run: |
+          LOCAL=platform/wave:${{ steps.release.outputs.version }}
+          REMOTE="${{ steps.login-ecr-platform.outputs.registry }}/${LOCAL}"
+          docker tag "$LOCAL" "$REMOTE"
+          docker push "$REMOTE"
 
       - name: Publish tests report
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
         if: "contains(github.event.head_commit.message, '[release]')"
         shell: bash
         run: |
-          LOCAL=app:${{ steps.release.outputs.version }}
+          LOCAL=server:${{ steps.release.outputs.version }}
           REMOTE="${{ steps.login-ecr-internal.outputs.registry }}/internal/${{ github.repository }}/${LOCAL}"
           docker tag "$LOCAL" "$REMOTE"
           docker push "$REMOTE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         java_version: [21]
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - name: Environment
@@ -80,11 +81,13 @@ jobs:
           sudo rm -rf /home/runner/work/wave/wave/build-workspace
 
       - name: Release
+        id: release
         if: "contains(github.event.head_commit.message, '[release]')"
         run: |
           bash publish.sh wave-api
           bash publish.sh wave-utils
           bash tag-and-push.sh
+          echo "version=v$(cat VERSION)" >> $GITHUB_OUTPUT
         env:
           GRADLE_OPTS: '-Dorg.gradle.daemon=false'
           AWS_ACCESS_KEY_ID: ${{secrets.TOWER_CI_AWS_ACCESS}}
@@ -96,6 +99,36 @@ jobs:
           DOCKER_PAT: ${{ secrets.DOCKER_PAT }}
           QUAY_PAT: ${{ secrets.QUAY_PAT }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to legacy ECR
+        if: "contains(github.event.head_commit.message, '[release]')"
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4.1.0
+        with:
+          registry: 195996028523.dkr.ecr.eu-west-1.amazonaws.com
+          username: ${{ secrets.TOWER_CI_AWS_ACCESS }}
+          password: ${{ secrets.TOWER_CI_AWS_SECRET }}
+        env:
+          AWS_REGION: eu-west-1
+
+      - name: Push images to legacy ECR
+        if: "contains(github.event.head_commit.message, '[release]')"
+        run: |
+          TAG="${{ steps.release.outputs.version }}"
+          docker push 195996028523.dkr.ecr.eu-west-1.amazonaws.com/wave/app:$TAG
+          docker push 195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/wave:$TAG
+
+      - name: Push image to internal registry
+        if: "contains(github.event.head_commit.message, '[release]')"
+        uses: seqeralabs/actions/push@a78e62713a7895bef99f404d736b72451dbdb917 # ratchet:exclude
+        with:
+          image-tag: app:${{ steps.release.outputs.version }}
+
+      - name: Push image to enterprise registry
+        if: "contains(github.event.head_commit.message, '[release]')"
+        uses: seqeralabs/actions/push@a78e62713a7895bef99f404d736b72451dbdb917 # ratchet:exclude
+        with:
+          image-tag: platform/wave:${{ steps.release.outputs.version }}
+          custom-role-arn: arn:aws:iam::232933512461:role/platform-ecr-pusher
 
       - name: Publish tests report
         if: failure()

--- a/tag-and-push.sh
+++ b/tag-and-push.sh
@@ -47,11 +47,11 @@ if [[ $RELEASE ]]; then
   # Push happens from the workflow so we can also push to the new internal/enterprise ECR repos.
   echo "Building non-enterprise image $TAG"
   ./gradlew jibDockerBuild
-  docker tag 195996028523.dkr.ecr.eu-west-1.amazonaws.com/wave/app:$TAG app:$TAG
+  docker tag 195996028523.dkr.ecr.eu-west-1.amazonaws.com/wave/app:$TAG server:$TAG
 
   echo "Building enterprise image $TAG"
   ./gradlew -PjibRepo=195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/wave:$TAG jibDockerBuild
-  docker tag 195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/wave:$TAG platform/wave:$TAG
+  docker tag 195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/wave:$TAG wave/server:$TAG
 
   # check for "draft" release
   grep -Ei '.*-(A[0-9]+|B[0-9]+|RC[0-9]+)$' VERSION  &>/dev/null && DRAFT='--draft' || DRAFT=''

--- a/tag-and-push.sh
+++ b/tag-and-push.sh
@@ -42,10 +42,17 @@ if [[ $RELEASE ]]; then
   # tag repo
   git tag $TAG $FORCE
   git push $REMOTE $TAG $FORCE
-  # build and push the container
-  ./gradlew jib
-  # build and push enterprise
-  ./gradlew -PjibRepo=195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/wave:$TAG jib
+
+  # Build images locally (jibDockerBuild loads to the local docker daemon).
+  # Push happens from the workflow so we can also push to the new internal/enterprise ECR repos.
+  echo "Building non-enterprise image $TAG"
+  ./gradlew jibDockerBuild
+  docker tag 195996028523.dkr.ecr.eu-west-1.amazonaws.com/wave/app:$TAG app:$TAG
+
+  echo "Building enterprise image $TAG"
+  ./gradlew -PjibRepo=195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/wave:$TAG jibDockerBuild
+  docker tag 195996028523.dkr.ecr.eu-west-1.amazonaws.com/nf-tower-enterprise/wave:$TAG platform/wave:$TAG
+
   # check for "draft" release
   grep -Ei '.*-(A[0-9]+|B[0-9]+|RC[0-9]+)$' VERSION  &>/dev/null && DRAFT='--draft' || DRAFT=''
   # publish release notes


### PR DESCRIPTION
## Summary
- ported wave CI to push to the new internal ECR alongside the legacy one
- tag-and-push.sh switched from jib (push) to jibDockerBuild (local) so the workflow handles all pushes
- legacy pushes (wave/app and nf-tower-enterprise/wave) preserved on [release] commits; new internal pushes go to internal/seqeralabs/wave/app and platform/wave