### PR TITLE
Truncate verbose DEBUG log payloads to reduce heap pressure

### DIFF
--- a/src/main/groovy/io/seqera/wave/core/ContainerAugmenter.groovy
+++ b/src/main/groovy/io/seqera/wave/core/ContainerAugmenter.groovy
@@ -475,7 +475,7 @@ class ContainerAugmenter {
     }
 
     protected Map layerBlob(String image, ContainerLayer layer) {
-        log.debug "Adding layer: $layer to image: $client.registry.name/$image"
+        log.debug "Adding layer: gzipDigest=$layer.gzipDigest; size=$layer.gzipSize to image: $client.registry.name/$image"
         // store the layer blob in the cache
         final String path = "$client.registry.name/v2/$image/blobs/$layer.gzipDigest"
         final store = storage.saveBlob(path, layer)

--- a/src/main/groovy/io/seqera/wave/service/request/ContainerRequest.groovy
+++ b/src/main/groovy/io/seqera/wave/service/request/ContainerRequest.groovy
@@ -84,7 +84,7 @@ class ContainerRequest {
                 "containerImage=$containerImage; " +
                 "containerFile=${trunc(containerFile)}; " +
                 "condaFile=${trunc(condaFile)}; " +
-                "containerConfig=${containerConfig}; " +
+                "containerConfig=${trunc(containerConfig?.toString(), 500)}; " +
                 "platform=${platform}; " +
                 "buildId=${buildId}; " +
                 "buildNew=${buildNew}; " +

--- a/src/main/groovy/io/seqera/wave/tower/client/connector/TowerConnector.groovy
+++ b/src/main/groovy/io/seqera/wave/tower/client/connector/TowerConnector.groovy
@@ -52,6 +52,7 @@ import jakarta.annotation.PostConstruct
 import jakarta.inject.Inject
 import jakarta.inject.Named
 import static io.seqera.random.LongRndKey.rndHex
+import static io.seqera.wave.util.StringUtils.trunc
 /**
  * Implements an abstract client that allows to connect Tower service either
  * via HTTP client or a WebSocket-based client
@@ -229,7 +230,7 @@ abstract class TowerConnector {
                     if( resp.status==200 )
                         log.trace "Tower response: GET '${uri}' => ${resp}"
                     else
-                        log.debug "Tower response: GET '${uri}' => ${resp}"
+                        log.debug "Tower response: GET '${uri}' => msgId=${resp?.msgId}; status=${resp?.status}; body=${trunc(resp?.body, 500)}"
                     return CompletableFuture.completedFuture(resp)
                 }, ioExecutor)
         // when accessing unauthorised resources, token refresh is not needed
@@ -277,7 +278,10 @@ abstract class TowerConnector {
                 .thenApplyAsync({ resp ->
                     if( resp==null )
                         throw new HttpResponseException(500, "Missing Tower response refreshing JWT token: ${request.uri}")
-                    log.debug "Tower Refresh '$uri' response; msgId=${msgId}\n- status : ${resp.status}\n- headers: ${RegHelper.dumpHeaders(resp.headers)}\n- content: ${resp.body}"
+                    if( log.isTraceEnabled() )
+                        log.trace "Tower Refresh '$uri' response; msgId=${msgId}\n- status : ${resp.status}\n- headers: ${RegHelper.dumpHeaders(resp.headers)}\n- content: ${resp.body}"
+                    else
+                        log.debug "Tower Refresh '$uri' response; msgId=${msgId}; status=${resp.status}; body=${trunc(resp.body, 500)}"
                     if ( resp.status >= 400 ) {
                         final msg = "Unexpected Tower response refreshing JWT token: ${request.uri}"
                         throw new HttpResponseException(resp.status, msg, resp.body)


### PR DESCRIPTION
## Summary

- Inline `data:` URI container layers and full Tower response headers/bodies were being interpolated into DEBUG log lines, producing log strings hundreds of KB long. Under registry-proxy traffic bursts these allocate humongous G1 regions and amplify GC pressure (observed alongside the recent OOMKill events on `wave-prod`).
- `ContainerRequest.toString()` now truncates `containerConfig` to 500 chars — fixes all 9 call sites that interpolate `$request` in one place.
- `ContainerAugmenter.layerBlob` logs `gzipDigest`+`gzipSize` instead of the full `ContainerLayer` (which can carry a `data:` URI body).
- `TowerConnector` DEBUG paths now log only `msgId`/`status` plus a 500-char truncated body. Full headers and full body are kept available at `TRACE` (single emit, no consecutive log lines).

## Test plan

- [ ] `./gradlew test` passes locally
- [ ] Spot-check DEBUG output in a stage env: confirm `containerConfig` log entries are short and `data:` URI bodies no longer appear
- [ ] Spot-check Tower DEBUG entries show `msgId; status; body=…` and not full CSP/Set-Cookie header dumps
- [ ] Bumping logger to TRACE still produces the full headers/body dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)