### PR TITLE
Use addIfLess for JWT refresh timer scheduling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'io.seqera:jedis-lock:1.0.0'
     implementation 'io.seqera:lib-data-queue-redis:1.1.2'
     implementation 'io.seqera:lib-data-stream-redis:1.2.0'
-    implementation 'io.seqera:lib-data-range-redis:1.0.0'
+    implementation 'io.seqera:lib-data-range-redis:1.1.0'
     implementation 'io.seqera:lib-jedis-pool:1.0.0'
     implementation 'io.micronaut:micronaut-http-client'
     implementation 'io.micronaut:micronaut-jackson-databind'

--- a/src/main/groovy/io/seqera/wave/tower/auth/JwtTimeStore.groovy
+++ b/src/main/groovy/io/seqera/wave/tower/auth/JwtTimeStore.groovy
@@ -50,7 +50,7 @@ class JwtTimeStore extends AbstractRangeStore {
     }
 
     void setRefreshTimer(String key) {
-        this.add(key, expireSecs0())
+        this.addIfLess(key, expireSecs0())
     }
 
     private long expireSecs0() {

--- a/src/test/groovy/io/seqera/wave/tower/auth/JwtTimeLocalTest.groovy
+++ b/src/test/groovy/io/seqera/wave/tower/auth/JwtTimeLocalTest.groovy
@@ -61,4 +61,28 @@ class JwtTimeLocalTest extends Specification {
         timer.getRange(0, now+5, 5) == []
     }
 
+    def 'should keep earlier score when using addIfLess' () {
+        given:
+        def now = Instant.now().epochSecond
+
+        when:
+        timer.addIfLess('foo', now+10)
+        then: 'new member is added'
+        timer.getRange(0, now+20, 5) == ['foo']
+
+        when:
+        timer.addIfLess('foo', now+10)
+        timer.addIfLess('foo', now+20)
+        then: 'later score is ignored, earlier score wins'
+        timer.getRange(0, now+15, 5) == ['foo']
+        timer.getRange(0, now+15, 5) == []
+
+        when:
+        timer.addIfLess('foo', now+20)
+        timer.addIfLess('foo', now+5)
+        then: 'earlier score replaces the existing one'
+        timer.getRange(0, now+10, 5) == ['foo']
+        timer.getRange(0, now+10, 5) == []
+    }
+
 }

--- a/src/test/groovy/io/seqera/wave/tower/auth/JwtTimeRedisTest.groovy
+++ b/src/test/groovy/io/seqera/wave/tower/auth/JwtTimeRedisTest.groovy
@@ -75,4 +75,28 @@ class JwtTimeRedisTest extends Specification implements RedisTestContainer{
         timer.getRange(0, now+5, 5) == []
     }
 
+    def 'should keep earlier score when using addIfLess' () {
+        given:
+        def now = Instant.now().epochSecond
+
+        when:
+        timer.addIfLess('foo', now+10)
+        then: 'new member is added'
+        timer.getRange(0, now+20, 5) == ['foo']
+
+        when:
+        timer.addIfLess('foo', now+10)
+        timer.addIfLess('foo', now+20)
+        then: 'later score is ignored, earlier score wins'
+        timer.getRange(0, now+15, 5) == ['foo']
+        timer.getRange(0, now+15, 5) == []
+
+        when:
+        timer.addIfLess('foo', now+20)
+        timer.addIfLess('foo', now+5)
+        then: 'earlier score replaces the existing one'
+        timer.getRange(0, now+10, 5) == ['foo']
+        timer.getRange(0, now+10, 5) == []
+    }
+
 }


### PR DESCRIPTION
## Summary
- Switch `JwtTimeStore.setRefreshTimer` from `add` to `addIfLess` so the JWT refresh deadline can only move earlier. With plain `add`, any duplicate call for the same key (racing replicas, retries from `JwtAuthStore.storeIfAbsent`, etc.) overwrites the existing score and pushes the refresh deadline forward.
- Bump `lib-data-range-redis` from 1.0.0 to 1.1.0 to pick up the new `addIfLess` API.
- Extend `JwtTimeLocalTest` and `JwtTimeRedisTest` with a feature method covering `addIfLess` semantics: new member is added, later score is ignored, earlier score replaces existing.

## Test plan
- [x] `./gradlew :test --tests 'io.seqera.wave.tower.auth.JwtTimeLocalTest' --tests 'io.seqera.wave.tower.auth.JwtTimeRedisTest'` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)