### PR TITLE
fix(deps): upgrade micronaut to 4.10.22 (COMP-1713)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ dependencies {
     implementation 'io.micronaut.views:micronaut-views-handlebars'
     // bump version to prevent security issue
     runtimeOnly 'org.apache.commons:commons-lang3:3.18.0'
-    runtimeOnly "io.netty:netty-bom:4.2.5.Final"
+    implementation platform("io.netty:netty-bom:4.2.13.Final")
     runtimeOnly 'org.bouncycastle:bcpkix-jdk18on:1.84'
     runtimeOnly 'org.bouncycastle:bcprov-jdk18on:1.84'
     runtimeOnly 'org.bouncycastle:bcutil-jdk18on:1.84'

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,5 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-micronautVersion=4.9.4
+micronautVersion=4.10.22
 micronautEnvs=local,mail,aws-ses


### PR DESCRIPTION
## Summary
- Upgrades `io.micronaut:micronaut-context` (via Micronaut BOM) from `4.9.4` to `4.10.22`
- Resolves CVE-2026-44241 / GHSA-8hjv-92q9-g4xj
- Fixes unbounded `formattersCache` in `TimeConverterRegistrar` that allows memory exhaustion via `Accept-Language` header

## JIRA
COMP-1713: Fix Micronaut has unbounded `formattersCache` in `TimeConverterRegistrar` that Allows Memory Exhaustion via `Accept-Language` Header

## Security Advisory
https://github.com/seqeralabs/wave/security/dependabot/42

🤖 Generated with [Claude Code](https://claude.ai/code)