### PR TITLE
fix(deps): upgrade io.netty:netty-bom to 4.2.13.Final (COMP-1677)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ dependencies {
     implementation 'io.micronaut.views:micronaut-views-handlebars'
     // bump version to prevent security issue
     runtimeOnly 'org.apache.commons:commons-lang3:3.18.0'
-    runtimeOnly "io.netty:netty-bom:4.2.5.Final"
+    implementation platform("io.netty:netty-bom:4.2.13.Final")
     runtimeOnly 'org.bouncycastle:bcpkix-jdk18on:1.84'
     runtimeOnly 'org.bouncycastle:bcprov-jdk18on:1.84'
     runtimeOnly 'org.bouncycastle:bcutil-jdk18on:1.84'


### PR DESCRIPTION
## Summary
- Upgrades `io.netty:netty-bom` from `4.2.5.Final` to `4.2.13.Final`
- Corrects BOM declaration from `runtimeOnly` to `implementation platform()` so Gradle properly enforces version constraints across all Netty transitive dependencies
- Resolves CVE-2026-33871 / GHSA-w9fj-cfpg-grvv (`io.netty:netty-codec-http2` HTTP/2 CONTINUATION Frame Flood DoS)

## JIRA
COMP-1677: Fix Netty HTTP/2 CONTINUATION Frame Flood DoS via Zero-Byte Frame Bypass

## Security Advisory
https://github.com/seqeralabs/wave/security/dependabot/38

🤖 Generated with [Claude Code](https://claude.ai/code)