### PR TITLE
feat(ci): use OIDC role for maven publish DEVOPS-1455

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,16 +121,20 @@ jobs:
         if: "steps.detect-release.outputs.is_release == 'true'"
         uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # ratchet:aws-actions/amazon-ecr-login@v2.1.5
 
+      - name: Configure AWS credentials for maven publish
+        if: "steps.detect-release.outputs.is_release == 'true'"
+        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # ratchet:aws-actions/configure-aws-credentials@v6.1.2
+        with:
+          aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::195996028523:role/WaveMavenPublisherRole
+          role-session-name: GitHubActions-${{ github.run_id }}-maven-publish
+
       - name: Release
         id: release
         if: "steps.detect-release.outputs.is_release == 'true'"
         run: |
           set -e
           set -x
-          # Drop the session token injected by configure-aws-credentials so publish.sh / gradle
-          # sign maven S3 uploads with the static TOWER_CI keys only (mixing static keys with a
-          # session token from a different role produces SignatureDoesNotMatch).
-          unset AWS_SESSION_TOKEN
           bash publish.sh wave-api
           bash publish.sh wave-utils
 
@@ -161,8 +165,6 @@ jobs:
           echo "version=$TAG" >> $GITHUB_OUTPUT
         env:
           GRADLE_OPTS: '-Dorg.gradle.daemon=false'
-          AWS_ACCESS_KEY_ID: ${{secrets.TOWER_CI_AWS_ACCESS}}
-          AWS_SECRET_ACCESS_KEY: ${{secrets.TOWER_CI_AWS_SECRET}}
           AWS_JAVA_V1_DISABLE_DEPRECATION_ANNOUNCEMENT: true
           AWS_DEFAULT_REGION: 'eu-west-1'
           PUBLISH_REPO_URL: "s3://maven.seqera.io/releases"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # ratchet:aws-actions/configure-aws-credentials@v6.1.2
         with:
           aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::195996028523:role/WaveMavenPublisherRole
+          role-to-assume: arn:aws:iam::195996028523:role/MavenPublisherRole
           role-session-name: GitHubActions-${{ github.run_id }}-maven-publish
 
       - name: Release


### PR DESCRIPTION
## Summary
- Swaps the maven publish in `build.yml`'s Release step from static `TOWER_CI_AWS_*` keys to OIDC role assumption.
- Assumes `arn:aws:iam::195996028523:role/WaveMavenPublisherRole` (created in seqeralabs/infrastructure#1549, already applied). Role is scoped tightly to `s3://maven.seqera.io/releases/*` and trusts only `seqeralabs/wave:ref:refs/heads/master`.
- Drops the `unset AWS_SESSION_TOKEN` hack (no longer needed — session token is now intentional and matches the role's region).
- Removes `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars from the Release step.

The `TOWER_CI_AWS_*` GHA secrets stay in place for now — they're still used by the Tests step (`make check`) and the legacy ECR docker login. Those are separate consumers and out of scope.

DEVOPS-1455