### PR TITLE
Use conda-lock to generate environment.lock (closes #975)

### DIFF
--- a/src/main/resources/templates/conda-micromamba-v1/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v1/dockerfile-conda-file.txt
@@ -3,7 +3,7 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
 RUN micromamba install -y -n base -f /tmp/conda.yml \
     {{base_packages}}
     && micromamba install -y -n base conda-forge::conda-lock \
-    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \
+    && micromamba run -n base conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \
     && echo ">> CONDA_LOCK_START" \
     && cat environment.lock \
     && echo "<< CONDA_LOCK_END" \

--- a/src/main/resources/templates/conda-micromamba-v1/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v1/dockerfile-conda-file.txt
@@ -2,7 +2,8 @@ FROM {{base_image}}
 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
 RUN micromamba install -y -n base -f /tmp/conda.yml \
     {{base_packages}}
-    && micromamba env export --name base --explicit > environment.lock \
+    && micromamba install -y -n base conda-forge::conda-lock \
+    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \
     && echo ">> CONDA_LOCK_START" \
     && cat environment.lock \
     && echo "<< CONDA_LOCK_END" \

--- a/src/main/resources/templates/conda-micromamba-v1/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v1/singularityfile-conda-file.txt
@@ -5,7 +5,8 @@ From: {{base_image}}
 %post
     micromamba install -y -n base -f /scratch/conda.yml
     {{base_packages}}
-    micromamba env export --name base --explicit > environment.lock
+    micromamba install -y -n base conda-forge::conda-lock
+    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
     echo ">> CONDA_LOCK_START"
     cat environment.lock
     echo "<< CONDA_LOCK_END"

--- a/src/main/resources/templates/conda-micromamba-v1/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v1/singularityfile-conda-file.txt
@@ -6,7 +6,7 @@ From: {{base_image}}
     micromamba install -y -n base -f /scratch/conda.yml
     {{base_packages}}
     micromamba install -y -n base conda-forge::conda-lock
-    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
+    micromamba run -n base conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
     echo ">> CONDA_LOCK_START"
     cat environment.lock
     echo "<< CONDA_LOCK_END"

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
@@ -5,8 +5,9 @@ RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \
     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \
     {{base_packages}}
+    && micromamba install -y -n base conda-forge::conda-lock \
+    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \
     && micromamba clean -a -y \
-    && micromamba env export --name base --explicit > environment.lock \
     && echo ">> CONDA_LOCK_START" \
     && cat environment.lock \
     && echo "<< CONDA_LOCK_END"

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
@@ -6,7 +6,7 @@ RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \
         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \
     {{base_packages}}
     && micromamba install -y -n base conda-forge::conda-lock \
-    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \
+    && micromamba run -n base conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \
     && micromamba clean -a -y \
     && echo ">> CONDA_LOCK_START" \
     && cat environment.lock \

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
@@ -9,7 +9,7 @@ From: {{mamba_image}}
             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
     {{base_packages}}
     micromamba install -y -n base conda-forge::conda-lock
-    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
+    micromamba run -n base conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
     micromamba clean -a -y
     echo ">> CONDA_LOCK_START"
     cat environment.lock

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
@@ -8,8 +8,9 @@ From: {{mamba_image}}
         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
     {{base_packages}}
+    micromamba install -y -n base conda-forge::conda-lock
+    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
     micromamba clean -a -y
-    micromamba env export --name base --explicit > environment.lock
     echo ">> CONDA_LOCK_START"
     cat environment.lock
     echo "<< CONDA_LOCK_END"

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -124,7 +124,7 @@ class ContainerHelperTest extends Specification {
                     micromamba install -y -n base -f /scratch/conda.yml
                     micromamba install -y -n base foo::one bar::two
                     micromamba install -y -n base conda-forge::conda-lock
-                    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
+                    micromamba run -n base conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"
@@ -152,7 +152,7 @@ class ContainerHelperTest extends Specification {
                 RUN micromamba install -y -n base -f /tmp/conda.yml \\
                     && micromamba install -y -n base foo::one bar::two \\
                     && micromamba install -y -n base conda-forge::conda-lock \\
-                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
+                    && micromamba run -n base conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END" \\
@@ -739,7 +739,7 @@ class ContainerHelperTest extends Specification {
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba install -y -n base conda-forge::conda-lock \\
-                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
+                    && micromamba run -n base conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && micromamba clean -a -y \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -778,7 +778,7 @@ class ContainerHelperTest extends Specification {
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba install -y -n base conda-forge::conda-lock \\
-                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
+                    && micromamba run -n base conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && micromamba clean -a -y \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -822,7 +822,7 @@ class ContainerHelperTest extends Specification {
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base foo::one bar::two \\
                     && micromamba install -y -n base conda-forge::conda-lock \\
-                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
+                    && micromamba run -n base conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && micromamba clean -a -y \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -123,7 +123,8 @@ class ContainerHelperTest extends Specification {
                 %post
                     micromamba install -y -n base -f /scratch/conda.yml
                     micromamba install -y -n base foo::one bar::two
-                    micromamba env export --name base --explicit > environment.lock
+                    micromamba install -y -n base conda-forge::conda-lock
+                    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"
@@ -150,7 +151,8 @@ class ContainerHelperTest extends Specification {
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
                 RUN micromamba install -y -n base -f /tmp/conda.yml \\
                     && micromamba install -y -n base foo::one bar::two \\
-                    && micromamba env export --name base --explicit > environment.lock \\
+                    && micromamba install -y -n base conda-forge::conda-lock \\
+                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END" \\
@@ -736,8 +738,9 @@ class ContainerHelperTest extends Specification {
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
+                    && micromamba install -y -n base conda-forge::conda-lock \\
+                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && micromamba clean -a -y \\
-                    && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
@@ -774,8 +777,9 @@ class ContainerHelperTest extends Specification {
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
+                    && micromamba install -y -n base conda-forge::conda-lock \\
+                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && micromamba clean -a -y \\
-                    && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
@@ -817,8 +821,9 @@ class ContainerHelperTest extends Specification {
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base foo::one bar::two \\
+                    && micromamba install -y -n base conda-forge::conda-lock \\
+                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && micromamba clean -a -y \\
-                    && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -37,7 +37,8 @@ class TemplateUtilsTest extends Specification {
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
                 RUN micromamba install -y -n base -f /tmp/conda.yml \\
                     && micromamba install -y -n base foo::bar \\
-                    && micromamba env export --name base --explicit > environment.lock \\
+                    && micromamba install -y -n base conda-forge::conda-lock \\
+                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END" \\
@@ -55,7 +56,8 @@ class TemplateUtilsTest extends Specification {
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
                 RUN micromamba install -y -n base -f /tmp/conda.yml \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
-                    && micromamba env export --name base --explicit > environment.lock \\
+                    && micromamba install -y -n base conda-forge::conda-lock \\
+                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END" \\
@@ -196,7 +198,8 @@ class TemplateUtilsTest extends Specification {
                 %post
                     micromamba install -y -n base -f /scratch/conda.yml
                     micromamba install -y -n base foo::bar=1.0
-                    micromamba env export --name base --explicit > environment.lock
+                    micromamba install -y -n base conda-forge::conda-lock
+                    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"
@@ -217,7 +220,8 @@ class TemplateUtilsTest extends Specification {
                 %post
                     micromamba install -y -n base -f /scratch/conda.yml
                     micromamba install -y -n base conda-forge::procps-ng
-                    micromamba env export --name base --explicit > environment.lock
+                    micromamba install -y -n base conda-forge::conda-lock
+                    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"
@@ -488,8 +492,9 @@ class TemplateUtilsTest extends Specification {
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
+                    && micromamba install -y -n base conda-forge::conda-lock \\
+                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && micromamba clean -a -y \\
-                    && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
@@ -513,8 +518,9 @@ class TemplateUtilsTest extends Specification {
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
+                    && micromamba install -y -n base conda-forge::conda-lock \\
+                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && micromamba clean -a -y \\
-                    && micromamba env export --name base --explicit > environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
@@ -774,8 +780,9 @@ class TemplateUtilsTest extends Specification {
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
+                    micromamba install -y -n base conda-forge::conda-lock
+                    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
                     micromamba clean -a -y
-                    micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"
@@ -799,8 +806,9 @@ class TemplateUtilsTest extends Specification {
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
+                    micromamba install -y -n base conda-forge::conda-lock
+                    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
                     micromamba clean -a -y
-                    micromamba env export --name base --explicit > environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -38,7 +38,7 @@ class TemplateUtilsTest extends Specification {
                 RUN micromamba install -y -n base -f /tmp/conda.yml \\
                     && micromamba install -y -n base foo::bar \\
                     && micromamba install -y -n base conda-forge::conda-lock \\
-                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
+                    && micromamba run -n base conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END" \\
@@ -57,7 +57,7 @@ class TemplateUtilsTest extends Specification {
                 RUN micromamba install -y -n base -f /tmp/conda.yml \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba install -y -n base conda-forge::conda-lock \\
-                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
+                    && micromamba run -n base conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END" \\
@@ -199,7 +199,7 @@ class TemplateUtilsTest extends Specification {
                     micromamba install -y -n base -f /scratch/conda.yml
                     micromamba install -y -n base foo::bar=1.0
                     micromamba install -y -n base conda-forge::conda-lock
-                    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
+                    micromamba run -n base conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"
@@ -221,7 +221,7 @@ class TemplateUtilsTest extends Specification {
                     micromamba install -y -n base -f /scratch/conda.yml
                     micromamba install -y -n base conda-forge::procps-ng
                     micromamba install -y -n base conda-forge::conda-lock
-                    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
+                    micromamba run -n base conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"
@@ -493,7 +493,7 @@ class TemplateUtilsTest extends Specification {
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba install -y -n base conda-forge::conda-lock \\
-                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
+                    && micromamba run -n base conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && micromamba clean -a -y \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -519,7 +519,7 @@ class TemplateUtilsTest extends Specification {
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
                     && micromamba install -y -n base conda-forge::procps-ng \\
                     && micromamba install -y -n base conda-forge::conda-lock \\
-                    && conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
+                    && micromamba run -n base conda-lock --file /tmp/conda.yml --platform linux-64 --lockfile environment.lock \\
                     && micromamba clean -a -y \\
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
@@ -781,7 +781,7 @@ class TemplateUtilsTest extends Specification {
                             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
                     micromamba install -y -n base conda-forge::conda-lock
-                    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
+                    micromamba run -n base conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
                     micromamba clean -a -y
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
@@ -807,7 +807,7 @@ class TemplateUtilsTest extends Specification {
                             && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /scratch/conda.yml)
                     micromamba install -y -n base conda-forge::procps-ng
                     micromamba install -y -n base conda-forge::conda-lock
-                    conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
+                    micromamba run -n base conda-lock --file /scratch/conda.yml --platform linux-64 --lockfile environment.lock
                     micromamba clean -a -y
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock


### PR DESCRIPTION
## Summary
- Switch the conda-file build templates (v1 and v2, dockerfile and singularity) from `micromamba env export --name base --explicit` to `conda-lock` for generating `environment.lock`.
- `micromamba env export --explicit` silently omits any `pip:` entries from `environment.yml`, leaving users with mixed conda+pip environments holding an incomplete lock file. `conda-lock` understands `pip` sections and includes them in the lockfile.
- The actual `micromamba install` step that materializes the base env is left untouched, so image contents are produced exactly as before — conda-lock is used only to render the lockfile (so this is a minimal-risk change to image behavior).

## What changed
- `src/main/resources/templates/conda-micromamba-v1/dockerfile-conda-file.txt`
- `src/main/resources/templates/conda-micromamba-v1/singularityfile-conda-file.txt`
- `src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt`
- `src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt`
- Test fixtures in `TemplateUtilsTest` and `ContainerHelperTest` updated for the new template output.

The `conda-packages` variants (inline package lists / lock-URL flow) are not changed: they don't accept a conda.yml and inline CLI args can't carry `pip:` deps, so conda-lock offers no benefit there.

## Test plan
- [x] `TemplateUtilsTest` passes (34 tests)
- [x] `ContainerHelperTest` passes (107 tests)
- [ ] Verify a real build with a mixed conda+pip `environment.yml` produces a lockfile containing the pip packages
- [ ] Confirm `CONDA_LOCK_START` / `CONDA_LOCK_END` extraction in `BuildLogServiceImpl` still works with the conda-lock unified lockfile format

Closes #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)