### PR TITLE
fix: use micromamba 2 image for conda/micromamba:v2 builds

### DIFF
--- a/src/main/groovy/io/seqera/wave/util/CondaHelper.groovy
+++ b/src/main/groovy/io/seqera/wave/util/CondaHelper.groovy
@@ -85,6 +85,15 @@ class CondaHelper {
 
         final lockFileUri = tryGetLockFile(spec.entries)
         final opts = spec.condaOpts ?: CondaOpts.v2()
+        // The CondaOpts ctor always fills mambaImage with the v1 default image (the value
+        // can also be bumped client-side e.g. by Nextflow), but the v2 template requires
+        // micromamba 2.x. Override any micromamba 1.x image with the v2 default; an explicit
+        // 2.x or custom image is left untouched.
+        // ponytail: matches micromamba major version 1 by tag, not one exact string, so a
+        // bumped v1 tag still resolves correctly. A user deliberately pairing the v2 template
+        // with a v1 image gets overridden (nonsensical anyway).
+        if( isMicromambaV1(opts.mambaImage) )
+            opts.mambaImage = CondaOpts.DEFAULT_MAMBA_IMAGE_V2
         if( containerImage )
             opts.baseImage = containerImage
 
@@ -100,6 +109,18 @@ class CondaHelper {
                     ? condaFileToSingularityFileV2(opts)
                     : condaFileToDockerFileUsingV2(opts)
         }
+    }
+
+    /**
+     * Tells whether the given image is a micromamba major version 1 image,
+     * e.g. {@code mambaorg/micromamba:1.5.10-noble}. Matches by tag so any v1
+     * tag is recognised, while v2 ({@code 2.x}) and custom images are not.
+     *
+     * @param image The mamba image reference
+     * @return {@code true} when the image tag is a micromamba 1.x release
+     */
+    static boolean isMicromambaV1(String image) {
+        image && image ==~ /.*micromamba:1[.\-].*/
     }
 
     /**

--- a/src/main/groovy/io/seqera/wave/util/CondaHelper.groovy
+++ b/src/main/groovy/io/seqera/wave/util/CondaHelper.groovy
@@ -88,10 +88,8 @@ class CondaHelper {
         // The CondaOpts ctor always fills mambaImage with the v1 default image (the value
         // can also be bumped client-side e.g. by Nextflow), but the v2 template requires
         // micromamba 2.x. Override any micromamba 1.x image with the v2 default; an explicit
-        // 2.x or custom image is left untouched.
-        // ponytail: matches micromamba major version 1 by tag, not one exact string, so a
-        // bumped v1 tag still resolves correctly. A user deliberately pairing the v2 template
-        // with a v1 image gets overridden (nonsensical anyway).
+        // 2.x or custom image is left untouched. Matching is by tag (not one exact string),
+        // so a bumped v1 tag still resolves correctly.
         if( isMicromambaV1(opts.mambaImage) )
             opts.mambaImage = CondaOpts.DEFAULT_MAMBA_IMAGE_V2
         if( containerImage )

--- a/src/test/groovy/io/seqera/wave/util/CondaHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/CondaHelperTest.groovy
@@ -222,6 +222,62 @@ class CondaHelperTest extends Specification {
         result.contains('micromamba install -y -n base foo::one bar::two')
     }
 
+    def 'should default to v2 mamba image when condaOpts has no mambaImage'() {
+        given:
+        def CHANNELS = ['conda-forge']
+        def PACKAGES = ['bwa=0.7.15']
+        // condaOpts provided but without an explicit mambaImage (the common request shape)
+        def CONDA_OPTS = new CondaOpts([basePackages: 'foo::one bar::two'])
+        def packages = new PackagesSpec(type: PackagesSpec.Type.CONDA, entries: PACKAGES, channels: CHANNELS, condaOpts: CONDA_OPTS)
+
+        when:
+        def result = CondaHelper.containerFileV2(packages, null, false)
+
+        then:
+        result.contains('FROM mambaorg/micromamba:2-amazon2023 AS build')
+        result.contains('micromamba install -y -n base foo::one bar::two')
+    }
+
+    def 'should override a v1 mamba image with the v2 default in v2'() {
+        given:
+        def CHANNELS = ['conda-forge']
+        def PACKAGES = ['bwa=0.7.15']
+        // client (e.g. Nextflow) sends a bumped v1 default image; v2 build must still use micromamba 2
+        def CONDA_OPTS = new CondaOpts([mambaImage: MAMBA_IMAGE])
+        def packages = new PackagesSpec(type: PackagesSpec.Type.CONDA, entries: PACKAGES, channels: CHANNELS, condaOpts: CONDA_OPTS)
+
+        when:
+        def result = CondaHelper.containerFileV2(packages, null, false)
+
+        then:
+        result.contains("FROM ${EXPECTED} AS build")
+
+        where:
+        MAMBA_IMAGE                          | EXPECTED
+        'mambaorg/micromamba:1.5.10-noble'   | 'mambaorg/micromamba:2-amazon2023'  // current v1 default
+        'mambaorg/micromamba:1.5.11-noble'   | 'mambaorg/micromamba:2-amazon2023'  // hypothetical bumped v1 tag
+        'mambaorg/micromamba:1-noble'        | 'mambaorg/micromamba:2-amazon2023'
+        'mambaorg/micromamba:2.0.0'          | 'mambaorg/micromamba:2.0.0'         // explicit v2 image kept
+        'quay.io/custom/base:latest'         | 'quay.io/custom/base:latest'        // custom image kept
+    }
+
+    @spock.lang.Unroll
+    def 'should detect micromamba v1 image: #image -> #expected'() {
+        expect:
+        CondaHelper.isMicromambaV1(image) == expected
+        where:
+        image                                | expected
+        'mambaorg/micromamba:1.5.10-noble'   | true
+        'mambaorg/micromamba:1.5.11-noble'   | true
+        'mambaorg/micromamba:1-noble'        | true
+        'my.registry/mambaorg/micromamba:1.5.10-noble' | true
+        'mambaorg/micromamba:2-amazon2023'   | false
+        'mambaorg/micromamba:2.0.0'          | false
+        'quay.io/custom/base:latest'         | false
+        null                                 | false
+        ''                                   | false
+    }
+
     def 'should throw exception for non-CONDA package type in v2'() {
         given:
         def packages = new PackagesSpec(type: PackagesSpec.Type.CRAN, entries: ['dplyr'])


### PR DESCRIPTION
## Problem

The `CondaOpts` constructor always fills `mambaImage` with the v1 default image (and clients such as Nextflow may bump this to another v1 tag). But the v2 container template requires micromamba 2.x, so a v2 build could end up wired to a micromamba 1.x base image.

## Fix

In `CondaHelper.containerFileV2`, override any micromamba 1.x image with `CondaOpts.DEFAULT_MAMBA_IMAGE_V2`. An explicit 2.x image or a custom image is left untouched. Detection is done by tag (`isMicromambaV1`) rather than exact-string match, so any bumped v1 tag (e.g. `1.5.11-noble`, `1-noble`) still resolves correctly.

## Tests

Added `CondaHelperTest` coverage:
- defaults to the v2 image when `condaOpts` has no explicit `mambaImage`
- overrides a v1 image (including bumped/custom v1 tags) with the v2 default, while preserving explicit v2 and custom images
- `isMicromambaV1` matrix (v1 tags, v2 tags, custom images, null/empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)