### PR TITLE
fix: make `which` available for R (bioconda) post-links in conda v2 builds

### DIFF
--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
@@ -1,6 +1,10 @@
 FROM {{mamba_image}} AS build
+USER root
 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \
+# expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+RUN micromamba install -y -n base conda-forge::which \
+    && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \
+    && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \
     && cat /tmp/mamba.log \
     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
@@ -1,6 +1,10 @@
 FROM {{mamba_image}} AS build
+USER root
+# expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
 RUN \
-    (micromamba install -y -n base {{channel_opts}} {{target}} > /tmp/mamba.log 2>&1 \
+    micromamba install -y -n base conda-forge::which \
+    && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \
+    && (micromamba install -y -n base {{channel_opts}} {{target}} > /tmp/mamba.log 2>&1 \
     && cat /tmp/mamba.log \
     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \
         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base {{channel_opts}} {{target}})) \

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
@@ -3,6 +3,9 @@ From: {{mamba_image}}
 %files
     {{wave_context_dir}}/conda.yml /scratch/conda.yml
 %post
+    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+    micromamba install -y -n base conda-forge::which
+    ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \
         && cat /tmp/mamba.log \
         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
@@ -1,6 +1,9 @@
 BootStrap: docker
 From: {{mamba_image}}
 %post
+    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+    micromamba install -y -n base conda-forge::which
+    ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
     micromamba install -y -n base {{channel_opts}} {{target}} > /tmp/mamba.log 2>&1 \
         && cat /tmp/mamba.log \
         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \

--- a/src/main/resources/templates/conda-pixi-v1/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-pixi-v1/dockerfile-conda-file.txt
@@ -4,6 +4,7 @@ COPY conda.yml /opt/wave/conda.yml
 WORKDIR /opt/wave
 
 RUN pixi init --import /opt/wave/conda.yml \
+    && pixi add conda-forge::which \
     {{base_packages}}
     && pixi shell-hook > /shell-hook.sh \
     && echo 'exec "$@"' >> /shell-hook.sh \

--- a/src/main/resources/templates/conda-pixi-v1/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-pixi-v1/singularityfile-conda-file.txt
@@ -5,6 +5,7 @@ From: {{pixi_image}}
 %post
     mkdir /opt/wave && cd /opt/wave
     pixi init --import /scratch/conda.yml
+    pixi add conda-forge::which
     {{base_packages}}
     pixi shell-hook > /shell-hook.sh
     echo ">> CONDA_LOCK_START"

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -634,6 +634,7 @@ class ContainerHelperTest extends Specification {
                 WORKDIR /opt/wave
 
                 RUN pixi init --import /opt/wave/conda.yml \\
+                    && pixi add conda-forge::which \\
                     && pixi add conda-forge::procps-ng \\
                     && pixi shell-hook > /shell-hook.sh \\
                     && echo 'exec "$@"' >> /shell-hook.sh \\
@@ -686,6 +687,7 @@ class ContainerHelperTest extends Specification {
                 WORKDIR /opt/wave
                  
                 RUN pixi init --import /opt/wave/conda.yml \\
+                    && pixi add conda-forge::which \\
                     && pixi add foo::one bar::two \\
                     && pixi shell-hook > /shell-hook.sh \\
                     && echo 'exec "$@"' >> /shell-hook.sh \\
@@ -730,8 +732,12 @@ class ContainerHelperTest extends Specification {
         then:
         result =='''\
                 FROM mambaorg/micromamba:2-amazon2023 AS build
+                USER root
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                RUN micromamba install -y -n base conda-forge::which \\
+                    && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
+                    && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
@@ -768,8 +774,12 @@ class ContainerHelperTest extends Specification {
         then:
         result =='''\
                 FROM mambaorg/micromamba:2-amazon2023 AS build
+                USER root
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                RUN micromamba install -y -n base conda-forge::which \\
+                    && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
+                    && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
@@ -811,8 +821,12 @@ class ContainerHelperTest extends Specification {
         then:
         result =='''\
                 FROM mambaorg/micromamba:2.0.0 AS build
+                USER root
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                RUN micromamba install -y -n base conda-forge::which \\
+                    && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
+                    && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
@@ -848,8 +862,12 @@ class ContainerHelperTest extends Specification {
         then:
         result =='''\
                 FROM mambaorg/micromamba:2-amazon2023 AS build
+                USER root
+                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
                 RUN \\
-                    (micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml > /tmp/mamba.log 2>&1 \\
+                    micromamba install -y -n base conda-forge::which \\
+                    && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
+                    && (micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml)) \\

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -358,6 +358,7 @@ class TemplateUtilsTest extends Specification {
                 WORKDIR /opt/wave
 
                 RUN pixi init --import /opt/wave/conda.yml \\
+                    && pixi add conda-forge::which \\
                     && pixi add foo::bar \\
                     && pixi shell-hook > /shell-hook.sh \\
                     && echo 'exec "$@"' >> /shell-hook.sh \\
@@ -393,6 +394,7 @@ class TemplateUtilsTest extends Specification {
                 WORKDIR /opt/wave
 
                 RUN pixi init --import /opt/wave/conda.yml \\
+                    && pixi add conda-forge::which \\
                     && pixi add conda-forge::procps-ng \\
                     && pixi shell-hook > /shell-hook.sh \\
                     && echo 'exec "$@"' >> /shell-hook.sh \\
@@ -431,6 +433,7 @@ class TemplateUtilsTest extends Specification {
                 WORKDIR /opt/wave
 
                 RUN pixi init --import /opt/wave/conda.yml \\
+                    && pixi add conda-forge::which \\
                     && pixi add conda-forge::procps-ng \\
                     && pixi shell-hook > /shell-hook.sh \\
                     && echo 'exec "$@"' >> /shell-hook.sh \\
@@ -482,8 +485,12 @@ class TemplateUtilsTest extends Specification {
         expect:
         TemplateUtils.condaFileToDockerFileUsingV2(CONDA_OPTS) == '''\
                 FROM mambaorg/micromamba:2.1.1 AS build
+                USER root
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                RUN micromamba install -y -n base conda-forge::which \\
+                    && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
+                    && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
@@ -507,8 +514,12 @@ class TemplateUtilsTest extends Specification {
         expect:
         TemplateUtils.condaFileToDockerFileUsingV2(new CondaOpts([:])) == '''\
                 FROM mambaorg/micromamba:1.5.10-noble AS build
+                USER root
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                RUN (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
+                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                RUN micromamba install -y -n base conda-forge::which \\
+                    && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
+                    && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -f /tmp/conda.yml)) \\
@@ -541,8 +552,12 @@ class TemplateUtilsTest extends Specification {
         expect:
         TemplateUtils.condaPackagesToDockerFileUsingV2(PACKAGES, CHANNELS, CONDA_OPTS) == '''\
                 FROM mambaorg/micromamba:2.1.1 AS build
+                USER root
+                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
                 RUN \\
-                    (micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 > /tmp/mamba.log 2>&1 \\
+                    micromamba install -y -n base conda-forge::which \\
+                    && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
+                    && (micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1)) \\
@@ -575,8 +590,12 @@ class TemplateUtilsTest extends Specification {
         expect:
         TemplateUtils.condaPackagesToDockerFileUsingV2(PACKAGES, CHANNELS, CONDA_OPTS) == '''\
                 FROM mambaorg/micromamba:2.1.1 AS build
+                USER root
+                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
                 RUN \\
-                    (micromamba install -y -n base -c conda-forge numpy pandas > /tmp/mamba.log 2>&1 \\
+                    micromamba install -y -n base conda-forge::which \\
+                    && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
+                    && (micromamba install -y -n base -c conda-forge numpy pandas > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
                     || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
                         && CONDA_OVERRIDE_CUDA="99" micromamba install -y -n base -c conda-forge numpy pandas)) \\
@@ -665,6 +684,7 @@ class TemplateUtilsTest extends Specification {
                 %post
                     mkdir /opt/wave && cd /opt/wave
                     pixi init --import /scratch/conda.yml
+                    pixi add conda-forge::which
                     pixi add conda-forge::procps-ng
                     pixi shell-hook > /shell-hook.sh
                     echo ">> CONDA_LOCK_START"
@@ -685,6 +705,7 @@ class TemplateUtilsTest extends Specification {
                 %post
                     mkdir /opt/wave && cd /opt/wave
                     pixi init --import /scratch/conda.yml
+                    pixi add conda-forge::which
                     pixi add conda-forge::procps-ng
                     pixi shell-hook > /shell-hook.sh
                     echo ">> CONDA_LOCK_START"
@@ -712,6 +733,7 @@ class TemplateUtilsTest extends Specification {
                 %post
                     mkdir /opt/wave && cd /opt/wave
                     pixi init --import /scratch/conda.yml
+                    pixi add conda-forge::which
                     pixi shell-hook > /shell-hook.sh
                     echo ">> CONDA_LOCK_START"
                     cat /opt/wave/pixi.lock
@@ -769,6 +791,9 @@ class TemplateUtilsTest extends Specification {
                 %files
                     {{wave_context_dir}}/conda.yml /scratch/conda.yml
                 %post
+                    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                    micromamba install -y -n base conda-forge::which
+                    ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
                     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
@@ -794,6 +819,9 @@ class TemplateUtilsTest extends Specification {
                 %files
                     {{wave_context_dir}}/conda.yml /scratch/conda.yml
                 %post
+                    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                    micromamba install -y -n base conda-forge::which
+                    ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
                     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
@@ -825,6 +853,9 @@ class TemplateUtilsTest extends Specification {
                 BootStrap: docker
                 From: mambaorg/micromamba:2.1.1
                 %post
+                    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                    micromamba install -y -n base conda-forge::which
+                    ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
                     micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\
@@ -856,6 +887,9 @@ class TemplateUtilsTest extends Specification {
                 BootStrap: docker
                 From: mambaorg/micromamba:2.1.1
                 %post
+                    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                    micromamba install -y -n base conda-forge::which
+                    ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
                     micromamba install -y -n base -c conda-forge numpy pandas > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\
                         || (cat /tmp/mamba.log >&2 && grep -q __cuda /tmp/mamba.log \\


### PR DESCRIPTION
## Problem

Conda containers with R/bioconductor packages (e.g. the nf-core rnaseq `TXIMETA_TXIMPORT` step, which installs `bioconductor-tximeta`) build successfully but fail at **runtime**:

```
Loading required package: GenomeInfoDb
Error: package or namespace load failed for 'GenomeInfoDb':
  there is no package called 'GenomeInfoDbData'
```

## Root cause

Bioconductor **data packages** (`GenomeInfoDbData`, etc.) don't ship their payload in the conda package — a conda **post-link** script (`post-link.sh` → `installBiocDataPackage.sh`) downloads it and runs `R CMD INSTALL` at install time.

That `R CMD INSTALL` starts an R session, and bioconda `r-base` shells out to **`/usr/bin/which`** (absolute path) during `utils` `.onLoad` — it ignores `$PATH` and `$R_WHICH`. The v2 build image `mambaorg/micromamba:2-amazon2023` has **no `/usr/bin/which`**, so R can't start, the post-link fails, and the data package is never installed. The post-link failure is **non-fatal** to `micromamba install`, so the build "succeeds" and produces a broken image.

This is why simply installing `conda-forge::which` into `/opt/conda/bin` was **not** enough — R only looks at `/usr/bin/which`.

## Fix

In the conda **micromamba-v2** build stage (as root), symlink the conda `which` to `/usr/bin/which` **before** the user's packages are installed, so bioconda post-link scripts can run R:

```dockerfile
FROM {{mamba_image}} AS build
USER root
...
RUN micromamba install -y -n base conda-forge::which \
    && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \
    && (micromamba install -y -n base -f /tmp/conda.yml ...) ...
```

Applied to all four `conda-micromamba-v2` templates (dockerfile + singularityfile, conda-file + conda-packages). The pixi templates also get `which` as a base package for consistency, though their `*-noble` build image already provides a system `which`. The legacy micromamba **v1** template is unaffected (its Debian-based image ships `which`).

## Verification

Reproduced and fixed locally with real Docker builds on `amazon2023`:
- Before: `R CMD INSTALL` post-link fails (`.onLoad failed ... error in running command`), `GenomeInfoDbData` absent, runtime load fails.
- After: post-link succeeds; final image runs `library(SummarizedExperiment); library(tximport)` → OK.

Unit tests updated: `TemplateUtilsTest`, `ContainerHelperTest` (+ `CondaHelperTest`/`PixiHelperTest` contains-checks) pass.

Refs: https://community.seqera.io/t/which-is-missing-in-recent-seqera-containers/2718

🤖 Generated with [Claude Code](https://claude.com/claude-code)