### PR TITLE
fix: bump claude-code-action to v1.0.87 to fix 404 model error NOTASK

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
+        uses: anthropics/claude-code-action@0432df8bfe0572278dd19bca33be32cdc8061ebb # ratchet:anthropics/claude-code-action@v1.0.87
         with:
           anthropic_api_key: ${{ secrets.ENG_ANTHROPIC_API_KEY }}
           # Or use OAuth token instead:


### PR DESCRIPTION
The Claude PR Assistant fails on every `@claude` with:

```
API Error: 404 {"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}
```

The workflow was pinned to the old `# beta` ref of claude-code-action, whose default model (`claude-sonnet-4-20250514`) is retired and now 404s. Bumping to v1.0.87 picks up a current default model. Same API key, no explicit `model:` set, so only the action version changes.

Also moves the pin comment from `# beta` to a `# ratchet:` version so ratchet/renovate keeps it current instead of silently going stale again. `ratchet lint` passes.
