### PR TITLE
fix: strip stray leading blank line from extracted conda lock file

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/logs/BuildLogServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/logs/BuildLogServiceImpl.groovy
@@ -194,6 +194,7 @@ class BuildLogServiceImpl implements BuildLogService {
             }
             return logs.substring(start + CONDA_LOCK_START.length(), end)
                     .replaceAll(/#\d+ \d+\.\d+\s*/, '')
+                    .stripLeading()
     }
 
     String fetchValidCondaLock(String buildId) {

--- a/src/test/groovy/io/seqera/wave/service/logs/BuildLogsServiceTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/logs/BuildLogsServiceTest.groovy
@@ -108,12 +108,11 @@ class BuildLogsServiceTest extends Specification implements AwsS3TestContainer {
         def result = service.extractCondaLockFile(logs)
 
         then:
-        result == """
-             # This file may be used to create an environment using:
-             # \$ conda create --name <env> --file <this file>
-             # platform: linux-aarch64
-             @EXPLICIT
-             """.stripIndent()
+        result == """# This file may be used to create an environment using:
+# \$ conda create --name <env> --file <this file>
+# platform: linux-aarch64
+@EXPLICIT
+"""
     }
 
     def 'should extract conda lockfile from s3' (){
@@ -155,12 +154,11 @@ class BuildLogsServiceTest extends Specification implements AwsS3TestContainer {
         service.storeCondaLock(buildID, logs)
 
         then:
-        service.fetchCondaLockString(buildID) == """
-             # This file may be used to create an environment using:
-             # \$ conda create --name <env> --file <this file>
-             # platform: linux-aarch64
-             @EXPLICIT
-             """.stripIndent()
+        service.fetchCondaLockString(buildID) == """# This file may be used to create an environment using:
+# \$ conda create --name <env> --file <this file>
+# platform: linux-aarch64
+@EXPLICIT
+"""
     }
 
     def 'should throw no exception when there is no conda lockfile in logs' (){


### PR DESCRIPTION
## Summary

Fixes #1081.

`extractCondaLockFile()` takes the substring right after the `>> CONDA_LOCK_START` marker text, but that's still before that BuildKit log line's own trailing newline. Every following line's `#N T.T ` prefix gets stripped by the existing regex, but that first newline was never part of a prefix, so it survives untouched as a leading blank line in every extracted conda lock file (confirmed present in every `.conda-lock/*.txt` currently in nf-core/modules built through this path).

## Changes

- `BuildLogServiceImpl.extractCondaLockFile`: added `.stripLeading()` after the existing prefix-stripping regex.
- `BuildLogsServiceTest`: two existing tests (`'should extract conda lockfile'`, `'should extract conda lockfile from s3'`) had the leading blank line baked into their expected output — they were written to match the buggy behavior rather than catch it. Updated both.

## Test plan

- [x] `./gradlew test --tests "io.seqera.wave.service.logs.BuildLogsServiceTest"` — 15/15 passing
- [x] Verified against a synthetic pixi-style BuildKit log (`version: 6\nenvironments:\n...`) as well as the existing `@EXPLICIT`-style fixture, confirming the fix removes exactly the stray blank line and nothing else
