### PR TITLE
fix: install jq for R (bioconda) post-link scripts in conda v2 builds

### DIFF
--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
@@ -1,8 +1,8 @@
 FROM {{mamba_image}} AS build
 USER root
 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-# expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-RUN micromamba install -y -n base conda-forge::which \
+# expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+RUN micromamba install -y -n base conda-forge::which conda-forge::jq \
     && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \
     && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \
     && cat /tmp/mamba.log \

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
@@ -1,8 +1,8 @@
 FROM {{mamba_image}} AS build
 USER root
-# expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+# expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
 RUN \
-    micromamba install -y -n base conda-forge::which \
+    micromamba install -y -n base conda-forge::which conda-forge::jq \
     && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \
     && (micromamba install -y -n base {{channel_opts}} {{target}} > /tmp/mamba.log 2>&1 \
     && cat /tmp/mamba.log \

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
@@ -3,8 +3,8 @@ From: {{mamba_image}}
 %files
     {{wave_context_dir}}/conda.yml /scratch/conda.yml
 %post
-    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-    micromamba install -y -n base conda-forge::which
+    # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+    micromamba install -y -n base conda-forge::which conda-forge::jq
     ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \
         && cat /tmp/mamba.log \

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
@@ -1,8 +1,8 @@
 BootStrap: docker
 From: {{mamba_image}}
 %post
-    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-    micromamba install -y -n base conda-forge::which
+    # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+    micromamba install -y -n base conda-forge::which conda-forge::jq
     ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
     micromamba install -y -n base {{channel_opts}} {{target}} > /tmp/mamba.log 2>&1 \
         && cat /tmp/mamba.log \

--- a/src/main/resources/templates/conda-pixi-v1/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-pixi-v1/dockerfile-conda-file.txt
@@ -4,7 +4,7 @@ COPY conda.yml /opt/wave/conda.yml
 WORKDIR /opt/wave
 
 RUN pixi init --import /opt/wave/conda.yml \
-    && pixi add conda-forge::which \
+    && pixi add conda-forge::which conda-forge::jq \
     {{base_packages}}
     && pixi shell-hook > /shell-hook.sh \
     && echo 'exec "$@"' >> /shell-hook.sh \

--- a/src/main/resources/templates/conda-pixi-v1/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-pixi-v1/singularityfile-conda-file.txt
@@ -5,7 +5,7 @@ From: {{pixi_image}}
 %post
     mkdir /opt/wave && cd /opt/wave
     pixi init --import /scratch/conda.yml
-    pixi add conda-forge::which
+    pixi add conda-forge::which conda-forge::jq
     {{base_packages}}
     pixi shell-hook > /shell-hook.sh
     echo ">> CONDA_LOCK_START"

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -634,7 +634,7 @@ class ContainerHelperTest extends Specification {
                 WORKDIR /opt/wave
 
                 RUN pixi init --import /opt/wave/conda.yml \\
-                    && pixi add conda-forge::which \\
+                    && pixi add conda-forge::which conda-forge::jq \\
                     && pixi add conda-forge::procps-ng \\
                     && pixi shell-hook > /shell-hook.sh \\
                     && echo 'exec "$@"' >> /shell-hook.sh \\
@@ -687,7 +687,7 @@ class ContainerHelperTest extends Specification {
                 WORKDIR /opt/wave
                  
                 RUN pixi init --import /opt/wave/conda.yml \\
-                    && pixi add conda-forge::which \\
+                    && pixi add conda-forge::which conda-forge::jq \\
                     && pixi add foo::one bar::two \\
                     && pixi shell-hook > /shell-hook.sh \\
                     && echo 'exec "$@"' >> /shell-hook.sh \\
@@ -734,8 +734,8 @@ class ContainerHelperTest extends Specification {
                 FROM mambaorg/micromamba:2-amazon2023 AS build
                 USER root
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-                RUN micromamba install -y -n base conda-forge::which \\
+                # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+                RUN micromamba install -y -n base conda-forge::which conda-forge::jq \\
                     && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
                     && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
@@ -776,8 +776,8 @@ class ContainerHelperTest extends Specification {
                 FROM mambaorg/micromamba:2-amazon2023 AS build
                 USER root
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-                RUN micromamba install -y -n base conda-forge::which \\
+                # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+                RUN micromamba install -y -n base conda-forge::which conda-forge::jq \\
                     && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
                     && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
@@ -823,8 +823,8 @@ class ContainerHelperTest extends Specification {
                 FROM mambaorg/micromamba:2.0.0 AS build
                 USER root
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-                RUN micromamba install -y -n base conda-forge::which \\
+                # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+                RUN micromamba install -y -n base conda-forge::which conda-forge::jq \\
                     && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
                     && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
@@ -863,9 +863,9 @@ class ContainerHelperTest extends Specification {
         result =='''\
                 FROM mambaorg/micromamba:2-amazon2023 AS build
                 USER root
-                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
                 RUN \\
-                    micromamba install -y -n base conda-forge::which \\
+                    micromamba install -y -n base conda-forge::which conda-forge::jq \\
                     && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
                     && (micromamba install -y -n base -c conda-forge -c bioconda -f https://foo.com/lock.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -358,7 +358,7 @@ class TemplateUtilsTest extends Specification {
                 WORKDIR /opt/wave
 
                 RUN pixi init --import /opt/wave/conda.yml \\
-                    && pixi add conda-forge::which \\
+                    && pixi add conda-forge::which conda-forge::jq \\
                     && pixi add foo::bar \\
                     && pixi shell-hook > /shell-hook.sh \\
                     && echo 'exec "$@"' >> /shell-hook.sh \\
@@ -394,7 +394,7 @@ class TemplateUtilsTest extends Specification {
                 WORKDIR /opt/wave
 
                 RUN pixi init --import /opt/wave/conda.yml \\
-                    && pixi add conda-forge::which \\
+                    && pixi add conda-forge::which conda-forge::jq \\
                     && pixi add conda-forge::procps-ng \\
                     && pixi shell-hook > /shell-hook.sh \\
                     && echo 'exec "$@"' >> /shell-hook.sh \\
@@ -433,7 +433,7 @@ class TemplateUtilsTest extends Specification {
                 WORKDIR /opt/wave
 
                 RUN pixi init --import /opt/wave/conda.yml \\
-                    && pixi add conda-forge::which \\
+                    && pixi add conda-forge::which conda-forge::jq \\
                     && pixi add conda-forge::procps-ng \\
                     && pixi shell-hook > /shell-hook.sh \\
                     && echo 'exec "$@"' >> /shell-hook.sh \\
@@ -487,8 +487,8 @@ class TemplateUtilsTest extends Specification {
                 FROM mambaorg/micromamba:2.1.1 AS build
                 USER root
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-                RUN micromamba install -y -n base conda-forge::which \\
+                # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+                RUN micromamba install -y -n base conda-forge::which conda-forge::jq \\
                     && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
                     && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
@@ -516,8 +516,8 @@ class TemplateUtilsTest extends Specification {
                 FROM mambaorg/micromamba:1.5.10-noble AS build
                 USER root
                 COPY --chown=$MAMBA_USER:$MAMBA_USER conda.yml /tmp/conda.yml
-                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-                RUN micromamba install -y -n base conda-forge::which \\
+                # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+                RUN micromamba install -y -n base conda-forge::which conda-forge::jq \\
                     && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
                     && (micromamba install -y -n base -f /tmp/conda.yml > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
@@ -553,9 +553,9 @@ class TemplateUtilsTest extends Specification {
         TemplateUtils.condaPackagesToDockerFileUsingV2(PACKAGES, CHANNELS, CONDA_OPTS) == '''\
                 FROM mambaorg/micromamba:2.1.1 AS build
                 USER root
-                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
                 RUN \\
-                    micromamba install -y -n base conda-forge::which \\
+                    micromamba install -y -n base conda-forge::which conda-forge::jq \\
                     && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
                     && (micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
@@ -591,9 +591,9 @@ class TemplateUtilsTest extends Specification {
         TemplateUtils.condaPackagesToDockerFileUsingV2(PACKAGES, CHANNELS, CONDA_OPTS) == '''\
                 FROM mambaorg/micromamba:2.1.1 AS build
                 USER root
-                # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
+                # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
                 RUN \\
-                    micromamba install -y -n base conda-forge::which \\
+                    micromamba install -y -n base conda-forge::which conda-forge::jq \\
                     && ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which \\
                     && (micromamba install -y -n base -c conda-forge numpy pandas > /tmp/mamba.log 2>&1 \\
                     && cat /tmp/mamba.log \\
@@ -684,7 +684,7 @@ class TemplateUtilsTest extends Specification {
                 %post
                     mkdir /opt/wave && cd /opt/wave
                     pixi init --import /scratch/conda.yml
-                    pixi add conda-forge::which
+                    pixi add conda-forge::which conda-forge::jq
                     pixi add conda-forge::procps-ng
                     pixi shell-hook > /shell-hook.sh
                     echo ">> CONDA_LOCK_START"
@@ -705,7 +705,7 @@ class TemplateUtilsTest extends Specification {
                 %post
                     mkdir /opt/wave && cd /opt/wave
                     pixi init --import /scratch/conda.yml
-                    pixi add conda-forge::which
+                    pixi add conda-forge::which conda-forge::jq
                     pixi add conda-forge::procps-ng
                     pixi shell-hook > /shell-hook.sh
                     echo ">> CONDA_LOCK_START"
@@ -733,7 +733,7 @@ class TemplateUtilsTest extends Specification {
                 %post
                     mkdir /opt/wave && cd /opt/wave
                     pixi init --import /scratch/conda.yml
-                    pixi add conda-forge::which
+                    pixi add conda-forge::which conda-forge::jq
                     pixi shell-hook > /shell-hook.sh
                     echo ">> CONDA_LOCK_START"
                     cat /opt/wave/pixi.lock
@@ -791,8 +791,8 @@ class TemplateUtilsTest extends Specification {
                 %files
                     {{wave_context_dir}}/conda.yml /scratch/conda.yml
                 %post
-                    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-                    micromamba install -y -n base conda-forge::which
+                    # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+                    micromamba install -y -n base conda-forge::which conda-forge::jq
                     ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
                     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\
@@ -819,8 +819,8 @@ class TemplateUtilsTest extends Specification {
                 %files
                     {{wave_context_dir}}/conda.yml /scratch/conda.yml
                 %post
-                    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-                    micromamba install -y -n base conda-forge::which
+                    # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+                    micromamba install -y -n base conda-forge::which conda-forge::jq
                     ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
                     micromamba install -y -n base -f /scratch/conda.yml > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\
@@ -853,8 +853,8 @@ class TemplateUtilsTest extends Specification {
                 BootStrap: docker
                 From: mambaorg/micromamba:2.1.1
                 %post
-                    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-                    micromamba install -y -n base conda-forge::which
+                    # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+                    micromamba install -y -n base conda-forge::which conda-forge::jq
                     ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
                     micromamba install -y -n base -c conda-forge -c bioconda bwa=0.7.15 salmon=1.1.1 > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\
@@ -887,8 +887,8 @@ class TemplateUtilsTest extends Specification {
                 BootStrap: docker
                 From: mambaorg/micromamba:2.1.1
                 %post
-                    # expose `which` at /usr/bin/which for R (bioconda) post-link scripts; the amazon2023 base image lacks it
-                    micromamba install -y -n base conda-forge::which
+                    # expose `which`+`jq` for R (bioconda) post-link scripts (installBiocDataPackage.sh); the amazon2023 base image lacks them
+                    micromamba install -y -n base conda-forge::which conda-forge::jq
                     ln -sf "$MAMBA_ROOT_PREFIX/bin/which" /usr/bin/which
                     micromamba install -y -n base -c conda-forge numpy pandas > /tmp/mamba.log 2>&1 \\
                         && cat /tmp/mamba.log \\


### PR DESCRIPTION
## Problem

Follow-up to #1070. Conda containers with R/bioconductor **data** packages (e.g. `bioconductor-tximeta` -> `GenomeInfoDbData`) still failed at runtime with:

```
Error: package or namespace load failed for 'GenomeInfoDb':
 there is no package called 'GenomeInfoDbData'
```

even after the `which` fix from #1070.

## Root cause

Bioconductor data packages install their payload via the conda post-link script `installBiocDataPackage.sh`, which parses the download URL with `yq`. `yq` shells out to **`jq`**, and the `micromamba:2-amazon2023` build image ships neither `which` (fixed in #1070) nor `jq`.

Without `jq`, `yq` errors out, the resolved filename comes back empty, the tarball is never downloaded, and the data package is **silently** not installed. The post-link failure is non-fatal to `micromamba install`, so the build still produces a broken image.

## Reproduced

Real Docker build on `mambaorg/micromamba:2-amazon2023`:

- **Without jq:** `yq: Error starting jq: ... No such file or directory: 'jq'` -> `FN=` empty -> R library missing `GenomeInfoDbData`.
- **With `conda-forge::jq`:** `yq` resolves the filename, `curl` downloads `GenomeInfoDbData_1.2.15.tar.gz` from bioconductor.org, `R CMD INSTALL` succeeds, package present.

Also confirmed that switching the base image to plain `mambaorg/micromamba:2` (Debian) does **not** help — it ships `which` but still lacks `jq`, so the same failure occurs. `jq` is required regardless of base image.

## Fix

Install `conda-forge::jq` alongside `conda-forge::which` in the build stage across all four `conda-micromamba-v2` templates and both `conda-pixi-v1` templates. Template assertion tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
