### PR TITLE
Quieten expected Platform-connectivity errors in the token watcher

### DIFF
--- a/src/main/groovy/io/seqera/wave/service/request/ContainerRequestServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/request/ContainerRequestServiceImpl.groovy
@@ -134,7 +134,6 @@ class ContainerRequestServiceImpl implements ContainerRequestService {
         meterRegistry?.counter('wave.tokens.refresh', 'result', result)?.increment()
     }
 
-    // Cause chains are never deep; cap the walk so a cyclic chain (e.g. A->B->A) cannot spin forever.
     private static final int MAX_CAUSE_DEPTH = 50
 
     /**
@@ -148,16 +147,16 @@ class ContainerRequestServiceImpl implements ContainerRequestService {
         for( int i = 0; e != null && i < MAX_CAUSE_DEPTH; e = e.cause, i++ ) {
             if( e instanceof TimeoutException || e instanceof HttpResponseException )
                 return true
-            if( e == e.cause )
-                break
         }
         return false
     }
 
     protected static String rootCauseMessage(Throwable t) {
+        if( t == null )
+            return null
         Throwable e = t
         int i = 0
-        while( e.cause != null && e.cause != e && ++i < MAX_CAUSE_DEPTH )
+        while( e.cause != null && e.cause != e && i++ < MAX_CAUSE_DEPTH )
             e = e.cause
         return e.message ?: e.class.simpleName
     }

--- a/src/main/groovy/io/seqera/wave/service/request/ContainerRequestServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/request/ContainerRequestServiceImpl.groovy
@@ -134,24 +134,29 @@ class ContainerRequestServiceImpl implements ContainerRequestService {
         meterRegistry?.counter('wave.tokens.refresh', 'result', result)?.increment()
     }
 
+    // Cause chains are never deep; cap the walk so a cyclic chain (e.g. A->B->A) cannot spin forever.
+    private static final int MAX_CAUSE_DEPTH = 50
+
     /**
      * Whether the given error is an expected Platform connectivity failure (a timeout or an HTTP
      * error reaching Tower) as opposed to an unexpected bug. Such failures are transient and retried,
-     * so they should not be logged at ERROR with a full stack trace. The cause chain is walked with a
-     * bound to guard against self-referential loops.
+     * so they should not be logged at ERROR with a full stack trace. The cause chain is walked up to
+     * {@link #MAX_CAUSE_DEPTH} to guard against cyclic cause references.
      */
     protected static boolean isConnectivityError(Throwable t) {
-        for( Throwable e = t; e != null && e != e.cause; e = e.cause ) {
+        Throwable e = t
+        for( int i = 0; e != null && i < MAX_CAUSE_DEPTH; e = e.cause, i++ ) {
             if( e instanceof TimeoutException || e instanceof HttpResponseException )
                 return true
+            if( e == e.cause )
+                break
         }
         return false
     }
 
     protected static String rootCauseMessage(Throwable t) {
         Throwable e = t
-        while( e.cause != null && e.cause != e )
-            e = e.cause
+        for( int i = 0; e.cause != null && e.cause != e && i < MAX_CAUSE_DEPTH; e = e.cause, i++ ) { }
         return e.message ?: e.class.simpleName
     }
 

--- a/src/main/groovy/io/seqera/wave/service/request/ContainerRequestServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/request/ContainerRequestServiceImpl.groovy
@@ -20,6 +20,7 @@ package io.seqera.wave.service.request
 
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.TimeoutException
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -27,6 +28,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.scheduling.TaskScheduler
 import io.seqera.wave.configuration.ContainerRequestConfig
+import io.seqera.wave.exception.HttpResponseException
 import io.seqera.wave.service.persistence.PersistenceService
 import io.seqera.wave.service.persistence.WaveContainerRecord
 import io.seqera.wave.service.request.ContainerRequestRange.Entry
@@ -132,6 +134,27 @@ class ContainerRequestServiceImpl implements ContainerRequestService {
         meterRegistry?.counter('wave.tokens.refresh', 'result', result)?.increment()
     }
 
+    /**
+     * Whether the given error is an expected Platform connectivity failure (a timeout or an HTTP
+     * error reaching Tower) as opposed to an unexpected bug. Such failures are transient and retried,
+     * so they should not be logged at ERROR with a full stack trace. The cause chain is walked with a
+     * bound to guard against self-referential loops.
+     */
+    protected static boolean isConnectivityError(Throwable t) {
+        for( Throwable e = t; e != null && e != e.cause; e = e.cause ) {
+            if( e instanceof TimeoutException || e instanceof HttpResponseException )
+                return true
+        }
+        return false
+    }
+
+    protected static String rootCauseMessage(Throwable t) {
+        Throwable e = t
+        while( e.cause != null && e.cause != e )
+            e = e.cause
+        return e.message ?: e.class.simpleName
+    }
+
     protected void scheduleRefresh(Entry entry) {
         // Re-check this request one refreshInterval from now. refreshInterval is deliberately shorter
         // than accessTtl so several checks fit inside a token's lifetime — a transient Tower failure
@@ -173,11 +196,20 @@ class ContainerRequestServiceImpl implements ContainerRequestService {
                 Thread.currentThread().interrupt()
             }
             catch (Throwable t) {
-                log.error("Unexpected error in container request watcher while processing key: $it", t)
                 meterRefresh('error')
                 // The entry was already popped by getEntriesUntil; re-add it so a transient failure
                 // (e.g. a Tower blip) does not silently drop the request and let its token lapse.
                 scheduleRefresh(it)
+                if( isConnectivityError(t) ) {
+                    // Expected when the workflow's Platform endpoint is briefly unreachable — e.g. a
+                    // paired self-hosted instance whose pairing WebSocket times out. The token is not
+                    // renewed, so it lapses fail-closed; log a concise warning rather than a full
+                    // stack trace to avoid flooding the logs while the entry is retried.
+                    log.warn "Container request watcher could not confirm workflow status - request=${it.requestId}; workflow=${it.workflowId}; cause=${rootCauseMessage(t)}; will retry"
+                }
+                else {
+                    log.error("Unexpected error in container request watcher while processing key: $it", t)
+                }
             }
         }
     }

--- a/src/main/groovy/io/seqera/wave/service/request/ContainerRequestServiceImpl.groovy
+++ b/src/main/groovy/io/seqera/wave/service/request/ContainerRequestServiceImpl.groovy
@@ -156,7 +156,9 @@ class ContainerRequestServiceImpl implements ContainerRequestService {
 
     protected static String rootCauseMessage(Throwable t) {
         Throwable e = t
-        for( int i = 0; e.cause != null && e.cause != e && i < MAX_CAUSE_DEPTH; e = e.cause, i++ ) { }
+        int i = 0
+        while( e.cause != null && e.cause != e && ++i < MAX_CAUSE_DEPTH )
+            e = e.cause
         return e.message ?: e.class.simpleName
     }
 

--- a/src/test/groovy/io/seqera/wave/service/request/ContainerRequestServiceImplTest.groovy
+++ b/src/test/groovy/io/seqera/wave/service/request/ContainerRequestServiceImplTest.groovy
@@ -22,10 +22,13 @@ import spock.lang.Specification
 
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeoutException
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.seqera.wave.configuration.ContainerRequestConfig
+import io.seqera.wave.exception.HttpResponseException
 import io.seqera.wave.service.persistence.PersistenceService
 import io.seqera.wave.service.persistence.WaveContainerRecord
 import io.seqera.wave.tower.PlatformId
@@ -251,6 +254,25 @@ class ContainerRequestServiceImplTest extends Specification {
         and: 'even though the workflow is still running, the token is not renewed'
         0 * store.put('req-1', _, _)
         0 * range.add(_, _)
+    }
+
+    def 'isConnectivityError should detect Tower connectivity failures in the cause chain'() {
+        expect:
+        ContainerRequestServiceImpl.isConnectivityError(ERR) == EXPECTED
+        where:
+        ERR                                                                                  | EXPECTED
+        new TimeoutException('nope')                                                         | true
+        new HttpResponseException(408, 'Timeout')                                            | true
+        new RuntimeException('wrap', new TimeoutException('nope'))                            | true
+        new ExecutionException(new HttpResponseException(408, 'Timeout'))                     | true
+        new RuntimeException('boom')                                                         | false
+        new NullPointerException()                                                           | false
+    }
+
+    def 'rootCauseMessage should return the deepest cause message'() {
+        expect:
+        ContainerRequestServiceImpl.rootCauseMessage(new RuntimeException('outer', new TimeoutException('inner'))) == 'inner'
+        ContainerRequestServiceImpl.rootCauseMessage(new RuntimeException('solo')) == 'solo'
     }
 
 }


### PR DESCRIPTION
## Problem

Observed in prod after the #782 rollout: when the token watcher's `describeWorkflow` lookup fails because the run's Platform endpoint is briefly unreachable — e.g. a paired self-hosted instance whose pairing WebSocket times out (HTTP 408 / `TimeoutException` on `pairing-inbound-queue`) — the exception propagated to the generic catch-all in `watch()` and was logged at **ERROR with a full stack trace on every retry**.

The behavior is already correct (the token is not renewed → lapses fail-closed → next check sees `gone` and stops tracking), so the stack trace is pure noise. For a chronically-unreachable paired endpoint it repeats every `refresh-interval` per token, floods the logs, and inflates error-rate signals.

## Change

In the watcher's catch-all, distinguish an **expected Platform-connectivity failure** (`TimeoutException` or `HttpResponseException` anywhere in the cause chain) from a genuinely unexpected error:

- connectivity failure → concise one-line `WARN` (request id, workflow id, root-cause message), no stack trace;
- anything else → unchanged `ERROR` + stack trace.

Retry (`scheduleRefresh`) and the `wave.tokens.refresh{result=error}` counter are unchanged for both paths, so the metric-based failure signal is preserved — only the log verbosity changes.

## Tests

Added a data-driven spec for `isConnectivityError` (wrapped `TimeoutException` / `HttpResponseException` / `ExecutionException` → true; plain `RuntimeException` / NPE → false) and `rootCauseMessage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
