### PR TITLE
feature: disable the ability for wave to "pull" images directly

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,10 @@ Configure general Wave application settings, such as application name, port, ano
 : When `true`, anonymous users can access the Wave server (default: `false`).
   Modify this option based on your security requirements.
 
+`wave.container.pull.enabled` *(optional)*
+: When `true`, Wave can provision a container by pulling an existing image directly, applying any container configuration on the fly (the augmentation path) (default: `true`).
+  Set to `false` to disable the pull path in locked-down deployments where Wave must not act as an augmenting or pass-through proxy; such requests are rejected and must instead use `freeze` mode to provision the container via an actual image build.
+
 `wave.denyHosts` *(optional)*
 : Hostname patterns to deny. Requests targeting these hosts are rejected.
   Example patterns: `ngrok.app`, `ngrok-free.app`, `//localhost`.

--- a/src/main/groovy/io/seqera/wave/controller/ContainerController.groovy
+++ b/src/main/groovy/io/seqera/wave/controller/ContainerController.groovy
@@ -127,6 +127,16 @@ class ContainerController {
     @Value('${wave.allowAnonymous}')
     private Boolean allowAnonymous
 
+    /**
+     * When {@code false} the container pull path (on-the-fly augmentation and pass-through proxying
+     * of an existing image) is disabled, and requests must use "freeze" mode to provision a container
+     * via an actual image build. Useful for locked-down deployments where Wave must not act as an
+     * augmenting/pass-through pull proxy.
+     */
+    @Inject
+    @Value('${wave.container.pull.enabled:true}')
+    private Boolean allowPull
+
     @Inject
     @Value('${wave.server.url}')
     private String serverUrl
@@ -559,6 +569,12 @@ class ContainerController {
             type = ContainerRequest.Type.Mirror
         }
         else if( req.containerImage ) {
+            // the container pull path (augmentation / pass-through) may be disabled in locked-down
+            // deployments; such requests must instead use "freeze" mode to build the container.
+            // note: a freeze request never reaches this branch because it has already been rewritten
+            // into a container build request by freezeService.freezeBuildRequest(..) above
+            if( allowPull == Boolean.FALSE )
+                throw new BadRequestException("Container pull is not allowed in this Wave deployment - use 'freeze' mode to provision this container")
             // normalize container image
             final coords = ContainerCoordinates.parse(req.containerImage)
             targetImage = coords.getTargetContainer()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,6 +56,10 @@ micronaut:
 ---
 wave:
   allowAnonymous: true
+  container:
+    pull:
+      # when false, disable the container pull/augmentation path; requests must use "freeze" mode
+      enabled: true
   server:
       url: "${WAVE_SERVER_URL:`http://localhost:9090`}"
   security:

--- a/src/test/groovy/io/seqera/wave/controller/ContainerControllerTest.groovy
+++ b/src/test/groovy/io/seqera/wave/controller/ContainerControllerTest.groovy
@@ -60,6 +60,7 @@ import io.seqera.service.pairing.PairingService
 import io.seqera.service.pairing.socket.PairingChannel
 import io.seqera.wave.service.persistence.PersistenceService
 import io.seqera.wave.service.persistence.WaveContainerRecord
+import io.seqera.wave.service.request.ContainerRequest
 import io.seqera.wave.service.request.ContainerRequestService
 import io.seqera.wave.service.request.TokenData
 import io.seqera.wave.service.validation.ValidationService
@@ -145,6 +146,30 @@ class ContainerControllerTest extends Specification {
         then:
         thrown(BadRequestException)
 
+    }
+
+    def 'should reject pull request when container pull is disabled' () {
+        given:
+        def controller = new ContainerController(inclusionService: Mock(ContainerInclusionService), registryProxyService: proxyRegistry, allowPull: false)
+
+        when: 'a plain container image (pull/augment) request is rejected'
+        def req = new SubmitContainerTokenRequest(containerImage: 'ubuntu:latest', containerPlatform: 'linux/amd64')
+        controller.makeRequestData(req, PlatformId.NULL, "")
+        then:
+        def e = thrown(BadRequestException)
+        e.message == "Container pull is not allowed in this Wave deployment - use 'freeze' mode to provision this container"
+    }
+
+    def 'should allow pull request when container pull is enabled' () {
+        given:
+        def controller = new ContainerController(inclusionService: Mock(ContainerInclusionService), registryProxyService: proxyRegistry, allowPull: true)
+
+        when:
+        def req = new SubmitContainerTokenRequest(containerImage: 'ubuntu:latest', containerPlatform: 'linux/amd64')
+        def data = controller.makeRequestData(req, PlatformId.NULL, "")
+        then:
+        data.containerImage == 'docker.io/library/ubuntu:latest'
+        data.type == ContainerRequest.Type.Container
     }
 
     def 'should create request data with freeze mode' () {


### PR DESCRIPTION
## Summary

Adds a `wave.container.pull.enabled` setting (default `true`) that, when set to `false`, disables the container **pull/augmentation path** — the mode where Wave provisions a container by pulling an existing image and applying container config on the fly, acting as an augmenting/pass-through proxy.

When disabled, plain container-image requests are rejected and callers must use **`freeze`** mode to provision the container via an actual image build. This is intended for locked-down deployments where Wave must not serve images directly.


## Why 

In regulated environments customers would like to ensure that wave is not in the direct path for pipeline execution and do not want to rely exclusively on behavioral and procedural enforcement over the use of wave freeze and instead would like it to be the only exclusive option available to them. 

## Alternative considered

A deeper integration on the serve path was also considered however given that the serve path is only valid for a pipeline execution following the addition of the token watcher the limited exposure of current in flight augmented containers would be low to acceptable for organisations looking to implement this functionality. 

If an existing installation wanted to adopt this behaviour they would need to purge the relevant records in redis however given this is net new and potentially only applicable for brand new regulated installations the decision was to keep it as simple as possible to block creation.  

## Details

- New `@Value('${wave.container.pull.enabled:true}')` field on `ContainerController`, following the existing `allowAnonymous` pattern.
- Guard in `ContainerController.makeRequestData`, in the `else if( req.containerImage )` branch — the only path that resolves to `ContainerRequest.Type.Container` (the augmented/pull path):
  ```groovy
  if( allowPull == Boolean.FALSE )
      throw new BadRequestException("Container pull is not allowed in this Wave deployment - use 'freeze' mode to provision this container")
  ```
- The guard sits **after** the freeze rewrite (`freezeService.freezeBuildRequest`), so `freeze` requests — rewritten into `containerFile` builds before the type is decided — are unaffected, as are build and mirror requests.
- Null-safe check (`== Boolean.FALSE`): only an explicit `false` disables the path; unset/`null` behaves as the `true` default. This also keeps directly-constructed controllers in unit tests unaffected.

## Documentation

- Documented `wave.container.pull.enabled` in `docs/configuration.md` (General section).
- Added a commented default under `wave.container.pull` in `application.yml`.

## Tests

Two new specs in `ContainerControllerTest`:
- pull request rejected when `allowPull: false`
- pull request allowed (`Type.Container`) when `allowPull: true`

`./gradlew :test --tests 'io.seqera.wave.controller.ContainerControllerTest'` passes.

## Notes / follow-ups

- Enforcement is at **token creation** only. Existing/build tokens still serve through the registry proxy. A serve-path guard (`RegistryProxyController`/`ContainerAugmenter`) could be a follow-up if belt-and-suspenders enforcement is wanted.
- Not addressed here: the misleading error at `ContainerController.groovy:492` referencing a nonexistent `wave.freeze` setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)