### PR TITLE
Return direct image for durable (freeze/mirror) requests on the V1 endpoint

### DIFF
--- a/src/main/groovy/io/seqera/wave/util/ContainerHelper.groovy
+++ b/src/main/groovy/io/seqera/wave/util/ContainerHelper.groovy
@@ -116,7 +116,9 @@ class ContainerHelper {
     }
 
     static SubmitContainerTokenResponse makeResponseV1(ContainerRequest data, TokenData token, String waveImage) {
-        final target = waveImage
+        // freeze/mirror images are published to the target registry and must be pulled
+        // directly from there - the Wave proxy token path does not serve them (see RouteHandler)
+        final target = data.durable() ? data.containerImage : waveImage
         final build = data.buildNew ? data.buildId : null
         return new SubmitContainerTokenResponse(data.requestId, token.value, target, token.expiration, data.containerImage, build, null, null, null, null, null)
     }

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -253,10 +253,34 @@ class ContainerHelperTest extends Specification {
         result.cached == null
         result.freeze == null
 
-        where: 
+        where:
         NEW_BUILD   | EXPECTED_BUILD_ID
         false       | null
         true        | '123'
+    }
+
+    @Unroll
+    def 'should create response v1 for durable request returning the direct image' () {
+        given:
+        def data = ContainerRequest.of(
+                containerImage: 'quay.io/org/container:1.0',
+                freeze: IS_FREEZE,
+                type: TYPE )
+        def token = new TokenData('123abc', Instant.now().plusSeconds(100))
+        def target = 'wave.com/wt/123abc/org/container:1.0'
+
+        when:
+        def result = ContainerHelper.makeResponseV1(data, token, target)
+        then:
+        // freeze/mirror images must resolve to the direct target-registry image,
+        // not the Wave proxy token url (which no longer serves durable images)
+        result.targetImage == 'quay.io/org/container:1.0'
+        result.containerImage == 'quay.io/org/container:1.0'
+
+        where:
+        TYPE                          | IS_FREEZE
+        null                          | true
+        ContainerRequest.Type.Mirror  | false
     }
 
     @Unroll


### PR DESCRIPTION
## Summary

Stacked on top of #1087.

#1087 makes the `/v2/wt/<token>` proxy path reject durable (freeze/mirror) requests with a 404 — those images are meant to be pulled directly from the target registry. But the two response builders were asymmetric:

- `makeResponseV2` already returns the **direct** target-registry image for durable requests (`target = data.durable() ? data.containerImage : waveImage`), so V2 clients never receive a `wt/<token>` freeze url.
- `makeResponseV1` returned `targetImage = waveImage` **unconditionally**, so a V1 (`/container-token`) freeze client is handed the proxy url — which #1087 now 404s.

Freeze is **not** v2-gated (only mirror is), and `/container-token` is still live (`@Deprecated`), so a pre-`24.04` Nextflow client (or any other V1 freeze client) would break.

## Impact assessment

- **Current Nextflow: unaffected.** The Wave client is V2-only since #4906 (Nextflow v24.04.0, Apr 2024) and resolves the run image from `targetImage`, which V2 already returns as the direct image.
- **Pre-24.04 Nextflow / other V1 freeze clients:** would 404 on the proxy pull after #1087. This change fixes them — they now receive the direct image in `targetImage` and pull it directly (the correct freeze behavior).

## Changes

- `ContainerHelper.makeResponseV1`: resolve `targetImage` to the direct image (`data.containerImage`) for `durable()` requests, matching `makeResponseV2`. The token is intentionally retained in the V1 response to avoid surprising legacy parsers — only `targetImage` changes.
- `ContainerHelperTest`: add V1 freeze + mirror cases asserting the direct image is returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)