### PR TITLE
fix(deps): upgrade Micronaut to 4.10.17 to patch jackson-databind (COMP-1957)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-micronautVersion=4.9.4
+micronautVersion=4.10.17
 micronautEnvs=local,mail,aws-ses
 nettyVersion=4.2.15.Final


### PR DESCRIPTION
## Summary
- Bumps `micronautVersion` from `4.9.4` to `4.10.17`
- This aligns the transitively managed `com.fasterxml.jackson.core:jackson-databind` from `2.19.1` (vulnerable) to `2.21.5` (patched)
- Resolves CVE-2026-54513 / GHSA-rmj7-2vxq-3g9f (array subtype allowlist bypass in `BasicPolymorphicTypeValidator.allowIfSubTypeIsArray`)

`jackson-databind` is a transitive dependency managed by the Micronaut platform BOM, so it is fixed by upgrading the declaring parent (Micronaut) rather than pinning the transitive version. Verified via `./gradlew dependencyInsight --dependency jackson-databind`: resolves to `2.21.5`.

## JIRA
COMP-1957: Fix jackson-databind has an array subtype allowlist bypass in BasicPolymorphicTypeValidator (allowIfSubTypeIsArray)

## Security Advisory
https://github.com/seqeralabs/wave/security/dependabot/58

🤖 Generated with [Claude Code](https://claude.ai/code)