### PR TITLE
fix(deps): upgrade micronaut-platform to 4.10.17 to patch jackson-databind (COMP-1954)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-micronautVersion=4.9.4
+micronautVersion=4.10.17
 micronautEnvs=local,mail,aws-ses
 nettyVersion=4.2.15.Final


### PR DESCRIPTION
## Summary
- Upgrades `micronautVersion` `4.9.4` → `4.10.17`, which brings in `micronaut-core-bom:4.10.26` and `jackson-bom:2.21.5`.
- Resolves the transitive `com.fasterxml.jackson.core:jackson-databind` from the vulnerable `2.19.1` to `2.21.5`.
- Fixes CVE-2026-54512 / GHSA-j3rv-43j4-c7qm.

`jackson-databind` is a transitive dependency managed by the Micronaut platform BOM. Per policy it is fixed by upgrading the directly declared parent (`micronaut-platform`, staying on the 4.x line) rather than pinning a transitive constraint. Verified via `./gradlew dependencyInsight --dependency jackson-databind` that the runtime classpath now resolves `jackson-databind:2.21.5`.

## JIRA
COMP-1954: Fix jackson-databind has a PolymorphicTypeValidator bypass via generic type parameters that allows arbitrary class instantiation

## Security Advisory
https://github.com/seqeralabs/wave/security/dependabot/57

🤖 Generated with [Claude Code](https://claude.ai/code)