### PR TITLE
fix(deps): upgrade Micronaut to 4.10.17 for patched jackson-databind (COMP-1956)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-micronautVersion=4.9.4
+micronautVersion=4.10.17
 micronautEnvs=local,mail,aws-ses
 nettyVersion=4.2.15.Final


### PR DESCRIPTION
## Summary
- `com.fasterxml.jackson.core:jackson-databind` is a **transitive** dependency in wave, managed by the Micronaut platform BOM (`micronautVersion`). It is not declared directly.
- The current `micronautVersion=4.9.4` resolves jackson-databind to `2.19.1`, which is affected (advisory range `>= 2.19.0, <= 2.21.3`).
- Bumping `micronautVersion` to `4.10.17` (a minor bump within the Micronaut 4.x line) raises the managed jackson-databind to `2.21.5`, which is patched.
- No transitive force-pin / constraint / `resolutionStrategy.force` was used — the fix is applied by upgrading the direct declaring dependency, per policy.

Verified with `./gradlew dependencyInsight --dependency jackson-databind --configuration runtimeClasspath`: resolves to `2.21.5`.

## JIRA
COMP-1956: Fix jackson-databind has a PolymorphicTypeValidator bypass via generic type parameters that allows arbitrary class instantiation

## Security Advisory
- CVE-2026-54512 / GHSA-j3rv-43j4-c7qm
- https://github.com/seqeralabs/wave/security/dependabot/56

🤖 Generated with [Claude Code](https://claude.ai/code)