### PR TITLE
fix(deps): upgrade Micronaut platform to 4.10.17 to patch jackson-databind (COMP-1955)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-micronautVersion=4.9.4
+micronautVersion=4.10.17
 micronautEnvs=local,mail,aws-ses
 nettyVersion=4.2.15.Final


### PR DESCRIPTION
## Summary
- `com.fasterxml.jackson.core:jackson-databind` is not declared directly in Wave; it is pulled transitively via the Micronaut platform BOM. The vulnerable version `2.19.1` was resolved on `master`.
- Bumps `micronautVersion` `4.9.4` → `4.10.17` (latest 4.x line). This raises the BOM-managed jackson version to `2.21.5`, which is `>= 2.21.4` (the patched release).
- Verified with `./gradlew dependencyInsight --dependency jackson-databind --configuration runtimeClasspath`: now resolves `jackson-databind:2.21.5`.
- No constraints / `resolutionStrategy.force` / overrides were used — the fix upgrades the declaring dependency per policy.

## Vulnerability
jackson-databind array subtype allowlist bypass in `BasicPolymorphicTypeValidator` (`allowIfSubTypeIsArray`). Array types were allowlisted based only on `clazz.isArray()` without validating the component type, re-opening the gadget-instantiation risk PTV is meant to prevent. Severity: High (8.1), CWE-184 / CWE-502.

## JIRA
COMP-1955: Fix jackson-databind has an array subtype allowlist bypass in BasicPolymorphicTypeValidator (allowIfSubTypeIsArray)

## Security Advisory
- CVE-2026-54513 / GHSA-rmj7-2vxq-3g9f
- https://github.com/seqeralabs/wave/security/dependabot/59

🤖 Generated with [Claude Code](https://claude.ai/code)