### PR TITLE
docs: spec and implementation plan for JWKS multi-issuer authentication

### DIFF
--- a/docs/superpowers/plans/2026-07-22-jwks-multi-issuer-auth.md
+++ b/docs/superpowers/plans/2026-07-22-jwks-multi-issuer-auth.md
@@ -23,6 +23,81 @@
 
 ---
 
+## Backward compatibility: existing token propagation & validation model
+
+**Requirement:** JWKS validation must not alter Wave's existing custom token handling — the
+delegated-credential model centred on `TowerConnector` (`JwtAuth`, `JwtAuthStore`, `JwtMonitor`,
+the 401→refresh cycle) — for any traffic that flows through it today. Older Platform instances and
+every non-asymmetric token must behave exactly as before.
+
+### What that model does today
+
+Two distinct concerns share the same `towerAccessToken`:
+
+1. **Authentication** (identity resolution) — `UserServiceImpl.getUserByAccessToken` forwards the
+   token to `/user-info` and trusts the answer. This is the *validation model* JWKS replaces, and
+   only for asymmetric JWTs.
+2. **Delegated propagation** — after authentication, Wave calls Platform APIs *on behalf of the
+   user* for the whole pipeline lifetime (credentials, workflow describe). `TowerConnector`
+   attaches `Authorization: Bearer <bearer>` (`sendAsync1`, `TowerConnector.groovy:216`) and, on a
+   401, POSTs `grant_type=refresh_token` to `/oauth/access_token`, parses the `JWT`/`JWT_REFRESH_TOKEN`
+   cookies, and updates `JwtAuthStore` (30-day TTL, kept warm by `JwtMonitor`). This is *credential
+   lifecycle*, not authentication.
+
+JWKS touches only concern (1). The spec already scopes concern (2) as "not touched"; this section
+states *why* that holds and *where* the two could still collide.
+
+### Why the propagation model is unaffected (by construction)
+
+- **JWKS fetch bypasses the auth/refresh path.** `PairingJwksClient` calls the low-level abstract
+  `TowerConnector.sendAsync(endpoint, ProxyHttpRequest)` (raw proxy send), **not** `sendAsync1`. It
+  never reads `JwtAuthStore`, never attaches a Bearer, never triggers a refresh — the JWKS document
+  is public. Adding JWKS retrieval therefore cannot perturb the token store or the refresh cache.
+- **Refreshed tokens are HS256 and are never JWKS-validated.** The token minted by
+  `/oauth/access_token` (the `JWT` cookie) is a Platform HS256 session token. Even when the *inbound*
+  token is RS256, every *refreshed* token that subsequently flows through `sendAsync1` is HS256. This
+  is fine: JWKS validation runs exactly once, on the inbound `auth.bearer` at identity-resolution
+  time — never on tokens in flight through `TowerConnector`. The refresh cycle keeps producing HS256
+  tokens and keeps working untouched.
+- **Keying and storage are unchanged.** `JwtAuth.key = md5(endpoint:token)` and `JwtAuthStore` are
+  not modified; JWKS reads `auth.bearer` before the existing `userInfo` call and adds no store entries.
+- **Dual-path routing preserves every legacy token.** HS256 session JWTs and opaque PATs —
+  everything Wave receives today — route to the unchanged `/user-info` path because
+  `JwtInspector.isAsymmetricJwt` returns false. With `wave.auth.jwks.enabled=false` (default) even
+  RS256 tokens take the legacy path. No currently-deployed token/endpoint combination changes behavior.
+
+### Residual risks — things to verify, not assume
+
+1. **`micronaut-security-jwt` on the classpath changes Wave's *own* request validation.** Wave does
+   not use Micronaut Security for the tower token (it lives in the request body, handled manually).
+   Adding the dependency activates Micronaut's JWT token readers/validators in the security filter,
+   which could start acting on the `Authorization` header of Wave's own endpoints or shift
+   basic-auth/anonymous behavior. This is the one real backward-compat hazard and it lives *outside*
+   `TowerConnector`. Task 5's regression step must confirm the admin basic-auth and anonymous routes
+   are unchanged; disable the unused bearer reader via config
+   (`micronaut.security.token.jwt.bearer.enabled: false`) if anything regresses — never via code.
+2. **Phase 2 removes the implicit "is this token usable for delegation?" check.** In phase 1 the
+   `/user-info` call still runs after JWKS success, so delegation-capability stays implicitly proven.
+   When phase 2 drops `/user-info` for verified JWTs, a token can pass JWKS validation yet be unusable
+   for on-behalf-of API calls (e.g. an RS256 launch token with narrower scope than a session JWT).
+   The propagation code is unchanged, but the *guarantee* that a JWKS-verified identity carries
+   working delegated credentials is weakened. Phase 2 must re-establish that guarantee before
+   dropping the call — it is not a free simplification.
+3. **RS256 inbound token + existing refresh semantics.** An RS256 access token obtained via
+   token-exchange (prerequisite P3) is typically short-lived. If it expires mid-pipeline,
+   `sendAsync1`'s 401→refresh path handles it exactly as today (yielding an HS256 cookie token). No
+   code change needed, but its *lifetime* characteristics differ from today's session JWTs — exercise
+   this in the staging integration step.
+
+### Net assessment
+
+The requirement is satisfied by design: JWKS is purely **additive and read-only** with respect to
+the propagation/refresh machinery in `TowerConnector`. The only genuine backward-compat surface is
+the `micronaut-security-jwt` dependency's effect on Wave's own security filter (risk 1) — already
+noted in Task 5, reiterated here as the item that must be actively verified rather than assumed.
+
+---
+
 ### Task 1: lib-auth-jwks module scaffold + JwtInspector
 
 **Files:**

--- a/docs/superpowers/plans/2026-07-22-jwks-multi-issuer-auth.md
+++ b/docs/superpowers/plans/2026-07-22-jwks-multi-issuer-auth.md
@@ -2,23 +2,23 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Local JWKS-based validation of Platform JWTs in Wave, multi-issuer, working over the pairing websocket tunnel, with the reusable core in a new libseqera module `lib-auth-jwks`.
+**Goal:** Local JWKS-based validation of Platform JWTs in Wave, multi-issuer, working over the pairing websocket tunnel, with the reusable core in a new libseqera module `lib-auth-jwks` built on Micronaut Security's JWKS machinery.
 
-**Architecture:** A framework-free Java library (`lib-auth-jwks`, package `io.seqera.auth.jwks`) provides token inspection and JWKS verification behind two seams: `JwksFetcher` (transport) and `JwksCacheStore` (caching). Wave plugs the pairing tunnel into the fetcher seam (`TowerConnector`) and a Redis state store into the cache seam, and gates the whole thing behind `wave.auth.jwks.enabled` inside `UserServiceImpl.getUserByAccessToken` — the single choke point both `ContainerController` and `InspectController` go through. Asymmetric JWTs get verified locally; HS256 JWTs and opaque PATs continue on today's `/user-info` delegation path untouched.
+**Architecture:** `lib-auth-jwks` (Micronaut library, package `io.seqera.auth.jwks`) adds the one thing `micronaut-security-jwt` lacks — dynamic per-issuer JWKS resolution — by composing Micronaut's own beans: `JwkSetFetcher<JWKSet>` (fetch + caching), `JwkValidator` (signature verification), and the `JwksClient` transport seam. Wave plugs the pairing tunnel into that seam (`PairingJwksClient` over `TowerConnector`) and gates everything behind `wave.auth.jwks.enabled` inside `UserServiceImpl.getUserByAccessToken` — the single choke point both `ContainerController` and `InspectController` go through. Asymmetric JWTs get verified locally; HS256 JWTs and opaque PATs continue on today's `/user-info` delegation path untouched.
 
-**Tech Stack:** Java 17 (lib main sources), Groovy/Spock (tests + Wave), `com.nimbusds:nimbus-jose-jwt:9.40`, Micronaut 4.x (Wave side only), libseqera `lib-data-store-state-redis`.
+**Tech Stack:** Java 17 (lib main sources), Groovy/Spock (tests + Wave), `io.micronaut.security:micronaut-security-jwt` 4.11.x (brings Nimbus JOSE), Micronaut 4.x.
 
 **Spec:** `docs/superpowers/specs/2026-07-22-jwks-multi-issuer-auth-design.md` (in the wave repo).
 
 ## Global Constraints
 
-- Tasks 1–4 run in `/Users/pditommaso/Projects/libseqera`, tasks 5–8 in `/Users/pditommaso/Projects/wave`. Commit in the repo you changed.
-- `lib-auth-jwks` must have **no Micronaut, Redis, or Wave dependency** — only `nimbus-jose-jwt` (api) and the Spock test framework that the convention plugins already provide.
+- Tasks 1–2 run in `/Users/pditommaso/Projects/libseqera`, tasks 3–5 in `/Users/pditommaso/Projects/wave`. Commit in the repo you changed.
+- `lib-auth-jwks` depends ONLY on `io.micronaut.security:micronaut-security-jwt` (api) plus the Micronaut annotation processing the module plugin provides — no Wave, lib-pairing, Redis, or HTTP-client code.
 - Lib module: `group 'io.seqera'`, `VERSION` file `0.1.0`, package `io.seqera.auth.jwks`, sourceCompatibility 17 (set by conventions — don't override).
 - Copy the Apache-2.0 license header from any existing libseqera source file into every new libseqera file; copy the Wave (AGPL) header from any existing Wave source file into every new Wave file. Not repeated in the code blocks below.
 - Allowed JWT algorithms everywhere: RS256/RS384/RS512/ES256/ES384/ES512. Never `none`, never HS*.
 - Wave feature flag `wave.auth.jwks.enabled` defaults to `false` — merged code must be a no-op until enabled.
-- Config defaults (from spec): path `/.well-known/jwks.json`, cache-duration `6h`, refresh-min-interval `60s`, clock-skew `60s`, fetch-timeout `30s`.
+- Config defaults (from spec): path `/.well-known/jwks.json`, refresh-min-interval `60s`, clock-skew `60s`, fetch-timeout `30s`. JWKS caching is Micronaut's `JwkSetFetcher` (in-memory, 60s) — no custom cache layer.
 - Wave tests: `./gradlew test --tests '<ClassName>'`. Lib tests: `./gradlew :lib-auth-jwks:test`.
 
 ---
@@ -26,7 +26,7 @@
 ### Task 1: lib-auth-jwks module scaffold + JwtInspector
 
 **Files:**
-- Modify: `/Users/pditommaso/Projects/libseqera/settings.gradle` (add include, keep the list's rough grouping — put it after `include('lib-activator')`)
+- Modify: `/Users/pditommaso/Projects/libseqera/settings.gradle` (add include after `include('lib-activator')`)
 - Create: `lib-auth-jwks/build.gradle`
 - Create: `lib-auth-jwks/VERSION`
 - Create: `lib-auth-jwks/README.md`
@@ -50,19 +50,38 @@ include('lib-auth-jwks')
 0.1.0
 ```
 
-`lib-auth-jwks/build.gradle` (same shape as `lib-crypto/build.gradle`):
+`lib-auth-jwks/build.gradle` (same shape as `lib-pairing/build.gradle`, minus the pieces this lib doesn't need):
 
 ```gradle
 plugins {
     id 'io.seqera.java-library-conventions'
     id 'io.seqera.groovy-library-conventions'
+    // Micronaut minimal lib
+    // https://micronaut-projects.github.io/micronaut-gradle-plugin/latest/
+    id "io.micronaut.minimal.library" version '4.5.3'
 }
 
 group = 'io.seqera'
 version = "${project.file('VERSION').text.trim()}"
 
 dependencies {
-    api 'com.nimbusds:nimbus-jose-jwt:9.40'
+    // Micronaut Security JWKS machinery (brings nimbus-jose-jwt transitively)
+    api "io.micronaut.security:micronaut-security-jwt:4.11.2"
+
+    // Micronaut
+    compileOnly "io.micronaut:micronaut-inject-groovy:${micronautCoreVersion}"
+
+    // Testing
+    testImplementation "io.micronaut:micronaut-inject-groovy:${micronautCoreVersion}"
+    testImplementation "io.micronaut.test:micronaut-test-spock:${micronautTestVersion}"
+}
+
+micronaut {
+    version '4.8.3'
+    processing {
+        incremental(true)
+    }
+    importMicronautPlatform = false
 }
 ```
 
@@ -71,14 +90,18 @@ dependencies {
 ```markdown
 # lib-auth-jwks
 
-Framework-free JWKS-based JWT verification with pluggable transport and caching.
+Dynamic multi-issuer JWKS verification on top of Micronaut Security.
 
-Designed for services that accept JWTs from multiple dynamically-registered issuers,
-where the issuer may only be reachable over a custom channel (e.g. a reverse
-websocket tunnel). Provide a `JwksFetcher` for the transport and optionally a
-`JwksCacheStore` for distributed caching; `JwksJwtVerifier` does the rest.
+Micronaut's `SignatureConfiguration` beans are fixed at startup via static config; this
+library adds per-request issuer resolution for services that accept JWTs from
+dynamically-registered issuers. It composes Micronaut's own JWKS machinery —
+`JwkSetFetcher` (fetch + caching), `JwkValidator` (signature verification) and the
+`JwksClient` transport seam — so a consumer can route JWKS retrieval over any channel
+(e.g. a reverse websocket tunnel) by providing a custom `JwksClient` bean.
 
-Entry points: `JwtInspector` (cheap token-shape checks), `JwksJwtVerifier.verify(token, expectedIssuer)`.
+Entry points: `JwtInspector` (cheap token-shape checks),
+`DynamicJwksVerifier.verify(token, expectedIssuer)`.
+Consumers must provide a `JwksVerifierConfig` bean.
 ```
 
 Run: `cd /Users/pditommaso/Projects/libseqera && ./gradlew :lib-auth-jwks:assemble`
@@ -203,65 +226,236 @@ git commit -m "feat: add lib-auth-jwks module with JwtInspector"
 
 ---
 
-### Task 2: Core types — config, results, exceptions, cache store, fetcher interface
+### Task 2: DynamicJwksVerifier — dynamic multi-issuer layer over Micronaut JWKS beans
 
 **Files:**
-- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/JwksConfig.java`
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/JwksVerifierConfig.java`
 - Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/VerifiedJwt.java`
-- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/CachedJwks.java`
-- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/JwksFetcher.java`
-- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/JwksCacheStore.java`
-- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/InMemoryJwksCacheStore.java`
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/DynamicJwksVerifier.java`
 - Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/exception/InvalidTokenException.java`
 - Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/exception/UnknownIssuerException.java`
 - Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/exception/JwksUnavailableException.java`
-- Test: `lib-auth-jwks/src/test/groovy/io/seqera/auth/jwks/InMemoryJwksCacheStoreTest.groovy`
+- Create: `lib-auth-jwks/changelog.txt`
+- Test: `lib-auth-jwks/src/test/groovy/io/seqera/auth/jwks/DynamicJwksVerifierTest.groovy`
 
 **Interfaces:**
-- Produces (used by Tasks 3, 4, and the Wave tasks):
-  - `record JwksConfig(String jwksPath, Duration cacheDuration, Duration refreshMinInterval, Duration clockSkew, Duration fetchTimeout)` + `JwksConfig.defaults()`
+- Consumes (Micronaut Security, verified against v4.11.2 source):
+  - `io.micronaut.security.token.jwt.signature.jwks.JwkSetFetcher<T>` — `Publisher<T> fetch(@Nullable String providerName, @Nullable String url)`, `void clearCache(String url)`
+  - `io.micronaut.security.token.jwt.signature.jwks.JwkValidator` — `boolean validate(SignedJWT jwt, JWK jwk)` (default impl `DefaultJwkValidator`, RSA/EC only)
+- Produces (used by the Wave tasks):
+  - `interface JwksVerifierConfig { String getJwksPath(); Duration getRefreshMinInterval(); Duration getClockSkew(); Duration getFetchTimeout(); }`
   - `record VerifiedJwt(String issuer, String subject, Instant expiration, Map<String,Object> claims)`
-  - `record CachedJwks(String json, Instant createdAt)`
-  - `interface JwksFetcher { CompletableFuture<String> fetch(String endpoint); }`
-  - `interface JwksCacheStore { CachedJwks load(String endpoint); void save(String endpoint, String jwksJson); }` — `load`/`save` naming is deliberate: it avoids an erasure clash with `AbstractStateStore.get/put` in downstream implementations.
+  - `DynamicJwksVerifier` (`@Singleton`, `@Requires(beans = JwksVerifierConfig.class)`): `VerifiedJwt verify(String token, String expectedIssuer)`; static `String normalizeIssuer(String)`
   - Exceptions: `InvalidTokenException`, `UnknownIssuerException`, `JwksUnavailableException` — all `RuntimeException`, all with `(String)` and `(String, Throwable)` constructors.
 
-- [ ] **Step 1: Write the failing test**
+**Behavior spec (mirrors the design doc):**
+1. Parse token; non-JWT or disallowed alg → `InvalidTokenException`.
+2. Fetch the JWKS via `jwkSetFetcher.fetch(normalizedEndpoint, normalizedEndpoint + jwksPath)`, blocking up to `fetchTimeout`. Fetch error or empty key set → `JwksUnavailableException` (Micronaut's fetcher caches internally; no custom cache).
+3. Token `kid` absent from the key set → rate-limited `clearCache(url)` + re-fetch (min interval `refreshMinInterval` per endpoint); re-fetch failure keeps the current key set.
+4. Key selection via Nimbus `JWKSelector(JWKMatcher.forJWSHeader(...))`, verification via `jwkValidator.validate` — no match or all failures → `InvalidTokenException`.
+5. `exp`/`nbf` via Nimbus `DefaultJWTClaimsVerifier` with `clockSkew`; failure → `InvalidTokenException`.
+6. Compare `normalizeIssuer(iss claim)` with `normalizeIssuer(expectedIssuer)`; mismatch or missing → `UnknownIssuerException`.
 
-`src/test/groovy/io/seqera/auth/jwks/InMemoryJwksCacheStoreTest.groovy`:
+- [ ] **Step 1: Write the failing tests**
+
+`src/test/groovy/io/seqera/auth/jwks/DynamicJwksVerifierTest.groovy`:
 
 ```groovy
 package io.seqera.auth.jwks
 
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import io.micronaut.security.token.jwt.signature.jwks.DefaultJwkValidator
+import io.micronaut.security.token.jwt.signature.jwks.JwkSetFetcher
+import io.seqera.auth.jwks.exception.InvalidTokenException
+import io.seqera.auth.jwks.exception.JwksUnavailableException
+import io.seqera.auth.jwks.exception.UnknownIssuerException
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
+import spock.lang.Shared
 import spock.lang.Specification
 
-class InMemoryJwksCacheStoreTest extends Specification {
+class DynamicJwksVerifierTest extends Specification {
 
-    def 'should save and load a jwks document' () {
-        given:
-        def store = new InMemoryJwksCacheStore()
+    static final String ISSUER = 'https://tower.example.com'
 
+    @Shared RSAKey keyA
+    @Shared RSAKey keyB
+    @Shared JWKSet jwksA
+    @Shared JWKSet jwksB
+
+    def setupSpec() {
+        keyA = new RSAKeyGenerator(2048).keyID('key-a').generate()
+        keyB = new RSAKeyGenerator(2048).keyID('key-b').generate()
+        jwksA = new JWKSet(keyA.toPublicJWK())
+        jwksB = new JWKSet(keyB.toPublicJWK())
+    }
+
+    static class TestConfig implements JwksVerifierConfig {
+        String jwksPath = '/.well-known/jwks.json'
+        Duration refreshMinInterval = Duration.ofSeconds(60)
+        Duration clockSkew = Duration.ofSeconds(60)
+        Duration fetchTimeout = Duration.ofSeconds(5)
+    }
+
+    static String token(RSAKey key, Map opts = [:]) {
+        final claims = new JWTClaimsSet.Builder()
+                .issuer((String) opts.getOrDefault('iss', ISSUER))
+                .subject('user-123')
+                .expirationTime(new Date(System.currentTimeMillis() + (long) opts.getOrDefault('ttlMillis', 60_000L)))
+                .build()
+        final jwt = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(key.keyID).build(),
+                claims )
+        jwt.sign(new RSASSASigner(key))
+        return jwt.serialize()
+    }
+
+    /**
+     * Stub fetcher: returns the i-th key set on the i-th call (last one repeats);
+     * a null entry simulates a fetch failure. Tracks fetch and clearCache counts.
+     */
+    static class StubFetcher implements JwkSetFetcher<JWKSet> {
+        final List<JWKSet> responses
+        final AtomicInteger fetchCount = new AtomicInteger()
+        final AtomicInteger clearCount = new AtomicInteger()
+
+        StubFetcher(List<JWKSet> responses) { this.responses = responses }
+
+        @Override
+        Optional<JWKSet> fetch(String url) { return Optional.empty() }
+
+        @Override
+        Publisher<JWKSet> fetch(String providerName, String url) {
+            final i = Math.min(fetchCount.getAndIncrement(), responses.size() - 1)
+            final r = responses[i]
+            return r == null ? Mono.error(new RuntimeException('boom')) : Mono.just(r)
+        }
+
+        @Override
+        void clearCache(String url) { clearCount.incrementAndGet() }
+    }
+
+    private DynamicJwksVerifier verifier(StubFetcher fetcher, JwksVerifierConfig config = new TestConfig()) {
+        new DynamicJwksVerifier(fetcher, new DefaultJwkValidator(), config)
+    }
+
+    def 'should verify a valid token' () {
+        when:
+        def result = verifier(new StubFetcher([jwksA])).verify(token(keyA), ISSUER)
+        then:
+        result.issuer() == ISSUER
+        result.subject() == 'user-123'
+        result.expiration() != null
+    }
+
+    def 'should accept issuer with cosmetic differences' () {
         expect:
-        store.load('https://tower.example.com') == null
+        verifier(new StubFetcher([jwksA])).verify(token(keyA), 'HTTPS://Tower.Example.Com/').subject() == 'user-123'
+    }
+
+    def 'should reject a tampered token' () {
+        given:
+        def parts = token(keyA).tokenize('.')
+        def tampered = parts[0] + '.' + Base64.urlEncoder.withoutPadding().encodeToString('{"sub":"evil"}'.bytes) + '.' + parts[2]
 
         when:
-        store.save('https://tower.example.com', '{"keys":[]}')
-        def entry = store.load('https://tower.example.com')
+        verifier(new StubFetcher([jwksA])).verify(tampered, ISSUER)
         then:
-        entry.json() == '{"keys":[]}'
-        entry.createdAt() != null
+        thrown(InvalidTokenException)
+    }
+
+    def 'should reject an expired token' () {
+        when: 'expired well beyond the 60s clock skew'
+        verifier(new StubFetcher([jwksA])).verify(token(keyA, ttlMillis: -120_000L), ISSUER)
+        then:
+        thrown(InvalidTokenException)
+    }
+
+    def 'should reject a wrong issuer' () {
+        when:
+        verifier(new StubFetcher([jwksA])).verify(token(keyA, iss: 'https://evil.example.com'), ISSUER)
+        then:
+        thrown(UnknownIssuerException)
+    }
+
+    def 'should reject symmetric and unsupported algorithms' () {
+        when:
+        verifier(new StubFetcher([jwksA])).verify(JwtInspectorTest.hs256Token(), ISSUER)
+        then:
+        thrown(InvalidTokenException)
+    }
+
+    def 'should refetch jwks on unknown kid' () {
+        given: 'the stub has no cache, so each verify fetches: two regular fetches return the old set, the refetch returns the rotated one'
+        def fetcher = new StubFetcher([jwksA, jwksA, jwksB])
+        def v = verifier(fetcher, new TestConfig(refreshMinInterval: Duration.ZERO))
+
+        expect: 'prime with key-a (fetch #1)'
+        v.verify(token(keyA), ISSUER)
+
+        and: 'a token signed with rotated key-b (fetch #2 = old set, kid miss) triggers clearCache + refetch (#3) and verifies'
+        v.verify(token(keyB), ISSUER).subject() == 'user-123'
+        fetcher.clearCount.get() == 1
+        fetcher.fetchCount.get() == 3
+    }
+
+    def 'should rate-limit refetch on unknown kid' () {
+        given: 'a fetcher that always returns the OLD key set'
+        def fetcher = new StubFetcher([jwksA])
+        def v = verifier(fetcher)   // refreshMinInterval 60s
+        v.verify(token(keyA), ISSUER)   // fetch #1
+
+        when: 'two consecutive unknown-kid misses'
+        try { v.verify(token(keyB), ISSUER) } catch (InvalidTokenException ignored) { }
+        try { v.verify(token(keyB), ISSUER) } catch (InvalidTokenException ignored) { }
+        then: 'only one cache-clearing refetch happened — the second miss was inside the min interval'
+        fetcher.clearCount.get() == 1
+    }
+
+    def 'should fail when fetch fails' () {
+        when:
+        verifier(new StubFetcher([null])).verify(token(keyA), ISSUER)
+        then:
+        thrown(JwksUnavailableException)
+    }
+
+    def 'should normalize issuer urls' () {
+        expect:
+        DynamicJwksVerifier.normalizeIssuer(input) == expected
+
+        where:
+        input                             | expected
+        'https://tower.example.com'       | 'https://tower.example.com'
+        'https://tower.example.com/'      | 'https://tower.example.com'
+        'HTTPS://Tower.Example.COM//'     | 'https://tower.example.com'
+        'https://foo.com/API/'            | 'https://foo.com/API'
+        null                              | null
     }
 }
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+Note: the stub fetcher has no cache (unlike Micronaut's real one), so every `verify` performs a
+fetch; the rate-limit invariant is asserted on `clearCount` — exactly one cache-clearing refetch
+across two unknown-kid misses inside the min interval.
 
-Run: `./gradlew :lib-auth-jwks:test --tests 'InMemoryJwksCacheStoreTest'`
-Expected: FAIL (class not found)
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :lib-auth-jwks:test --tests 'DynamicJwksVerifierTest'`
+Expected: FAIL (classes not found)
 
 - [ ] **Step 3: Write the implementation**
 
-`JwksConfig.java`:
+`JwksVerifierConfig.java`:
 
 ```java
 package io.seqera.auth.jwks;
@@ -269,23 +463,22 @@ package io.seqera.auth.jwks;
 import java.time.Duration;
 
 /**
- * Settings for JWKS retrieval and JWT verification.
+ * Settings for dynamic JWKS verification. Implemented by the consuming
+ * service (same pattern as lib-pairing's PairingConfig).
  */
-public record JwksConfig(
-        String jwksPath,
-        Duration cacheDuration,
-        Duration refreshMinInterval,
-        Duration clockSkew,
-        Duration fetchTimeout )
-{
-    public static JwksConfig defaults() {
-        return new JwksConfig(
-                "/.well-known/jwks.json",
-                Duration.ofHours(6),
-                Duration.ofSeconds(60),
-                Duration.ofSeconds(60),
-                Duration.ofSeconds(30) );
-    }
+public interface JwksVerifierConfig {
+
+    /** Path of the JWKS document relative to the issuer endpoint, e.g. {@code /.well-known/jwks.json} */
+    String getJwksPath();
+
+    /** Minimum interval between JWKS re-fetches triggered by an unknown {@code kid} */
+    Duration getRefreshMinInterval();
+
+    /** Accepted clock skew for {@code exp}/{@code nbf} validation */
+    Duration getClockSkew();
+
+    /** Maximum time to wait for a JWKS fetch */
+    Duration getFetchTimeout();
 }
 ```
 
@@ -305,85 +498,6 @@ public record VerifiedJwt(
         String subject,
         Instant expiration,
         Map<String, Object> claims ) {
-}
-```
-
-`CachedJwks.java`:
-
-```java
-package io.seqera.auth.jwks;
-
-import java.time.Instant;
-
-/**
- * A cached JWKS document with its retrieval timestamp. Freshness is
- * decided by the verifier, so stores may retain stale copies as a
- * fallback for when the issuer is temporarily unreachable.
- */
-public record CachedJwks(String json, Instant createdAt) {
-}
-```
-
-`JwksFetcher.java`:
-
-```java
-package io.seqera.auth.jwks;
-
-import java.util.concurrent.CompletableFuture;
-
-/**
- * Transport seam: retrieve the raw JWKS JSON document for an issuer
- * endpoint. Implementations may use direct HTTP or any custom channel
- * (e.g. a reverse websocket tunnel).
- */
-public interface JwksFetcher {
-
-    CompletableFuture<String> fetch(String endpoint);
-}
-```
-
-`JwksCacheStore.java`:
-
-```java
-package io.seqera.auth.jwks;
-
-/**
- * Caching seam for JWKS documents, keyed by issuer endpoint.
- */
-public interface JwksCacheStore {
-
-    CachedJwks load(String endpoint);
-
-    void save(String endpoint, String jwksJson);
-}
-```
-
-`InMemoryJwksCacheStore.java`:
-
-```java
-package io.seqera.auth.jwks;
-
-import java.time.Instant;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-/**
- * Default in-process cache. Entries are never evicted — the set of
- * issuers a service talks to is small and bounded by design.
- */
-public class InMemoryJwksCacheStore implements JwksCacheStore {
-
-    private final Map<String, CachedJwks> cache = new ConcurrentHashMap<>();
-
-    @Override
-    public CachedJwks load(String endpoint) {
-        return cache.get(endpoint);
-    }
-
-    @Override
-    public void save(String endpoint, String jwksJson) {
-        cache.put(endpoint, new CachedJwks(jwksJson, Instant.now()));
-    }
 }
 ```
 
@@ -409,467 +523,66 @@ public class InvalidTokenException extends RuntimeException {
 
 `exception/UnknownIssuerException.java` — same body, class name `UnknownIssuerException`, javadoc: "The token's `iss` claim does not match the expected issuer."
 
-`exception/JwksUnavailableException.java` — same body, class name `JwksUnavailableException`, javadoc: "The JWKS document could not be retrieved and no cached copy exists."
+`exception/JwksUnavailableException.java` — same body, class name `JwksUnavailableException`, javadoc: "The JWKS document could not be retrieved."
 
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `./gradlew :lib-auth-jwks:test --tests 'InMemoryJwksCacheStoreTest'`
-Expected: PASS
-
-- [ ] **Step 5: Commit (libseqera repo)**
-
-```bash
-git add lib-auth-jwks
-git commit -m "feat: lib-auth-jwks core types, cache store and fetcher seams"
-```
-
----
-
-### Task 3: HttpJwksFetcher (default direct-HTTP transport)
-
-**Files:**
-- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/HttpJwksFetcher.java`
-- Test: `lib-auth-jwks/src/test/groovy/io/seqera/auth/jwks/HttpJwksFetcherTest.groovy`
-
-**Interfaces:**
-- Consumes: `JwksFetcher`, `JwksConfig` (`jwksPath`, `fetchTimeout`), `JwksUnavailableException` (Task 2).
-- Produces: `HttpJwksFetcher(JwksConfig)` implementing `JwksFetcher`; static helper `HttpJwksFetcher.joinPath(String endpoint, String path): String`.
-
-- [ ] **Step 1: Write the failing test** (uses the JDK's built-in `HttpServer`, no new dependency)
-
-`src/test/groovy/io/seqera/auth/jwks/HttpJwksFetcherTest.groovy`:
-
-```groovy
-package io.seqera.auth.jwks
-
-import java.util.concurrent.CompletionException
-
-import com.sun.net.httpserver.HttpServer
-import io.seqera.auth.jwks.exception.JwksUnavailableException
-import spock.lang.Specification
-
-class HttpJwksFetcherTest extends Specification {
-
-    def 'should join endpoint and path' () {
-        expect:
-        HttpJwksFetcher.joinPath(endpoint, path) == expected
-
-        where:
-        endpoint                        | path                       | expected
-        'https://foo.com'               | '/.well-known/jwks.json'   | 'https://foo.com/.well-known/jwks.json'
-        'https://foo.com/'              | '/.well-known/jwks.json'   | 'https://foo.com/.well-known/jwks.json'
-        'https://foo.com'               | 'oauth/certs'              | 'https://foo.com/oauth/certs'
-    }
-
-    def 'should fetch jwks document over http' () {
-        given:
-        def server = HttpServer.create(new InetSocketAddress(0), 0)
-        server.createContext('/.well-known/jwks.json') { exchange ->
-            final body = '{"keys":[]}'.bytes
-            exchange.sendResponseHeaders(200, body.length)
-            exchange.responseBody.withCloseable { it.write(body) }
-        }
-        server.start()
-        def fetcher = new HttpJwksFetcher(JwksConfig.defaults())
-
-        expect:
-        fetcher.fetch("http://localhost:${server.address.port}").join() == '{"keys":[]}'
-
-        cleanup:
-        server.stop(0)
-    }
-
-    def 'should fail on non-200 status' () {
-        given:
-        def server = HttpServer.create(new InetSocketAddress(0), 0)
-        server.createContext('/.well-known/jwks.json') { exchange ->
-            exchange.sendResponseHeaders(404, -1)
-            exchange.close()
-        }
-        server.start()
-        def fetcher = new HttpJwksFetcher(JwksConfig.defaults())
-
-        when:
-        fetcher.fetch("http://localhost:${server.address.port}").join()
-        then:
-        def e = thrown(CompletionException)
-        e.cause instanceof JwksUnavailableException
-
-        cleanup:
-        server.stop(0)
-    }
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `./gradlew :lib-auth-jwks:test --tests 'HttpJwksFetcherTest'`
-Expected: FAIL (class not found)
-
-- [ ] **Step 3: Write the implementation**
-
-`HttpJwksFetcher.java`:
-
-```java
-package io.seqera.auth.jwks;
-
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-
-import io.seqera.auth.jwks.exception.JwksUnavailableException;
-
-/**
- * Default {@link JwksFetcher} performing a plain HTTP GET against the
- * issuer endpoint. Suitable when the issuer is directly reachable.
- */
-public class HttpJwksFetcher implements JwksFetcher {
-
-    private final HttpClient client;
-    private final JwksConfig config;
-
-    public HttpJwksFetcher(JwksConfig config) {
-        this.config = config;
-        this.client = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .followRedirects(HttpClient.Redirect.NORMAL)
-                .build();
-    }
-
-    @Override
-    public CompletableFuture<String> fetch(String endpoint) {
-        final String target = joinPath(endpoint, config.jwksPath());
-        final HttpRequest request = HttpRequest.newBuilder(URI.create(target))
-                .GET()
-                .timeout(config.fetchTimeout())
-                .build();
-        return client
-                .sendAsync(request, HttpResponse.BodyHandlers.ofString())
-                .thenApply(resp -> {
-                    if (resp.statusCode() == 200)
-                        return resp.body();
-                    throw new JwksUnavailableException("Unexpected status " + resp.statusCode() + " fetching JWKS from " + target);
-                });
-    }
-
-    static String joinPath(String endpoint, String path) {
-        final String base = endpoint.replaceAll("/+$", "");
-        return path.startsWith("/") ? base + path : base + "/" + path;
-    }
-}
-```
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `./gradlew :lib-auth-jwks:test --tests 'HttpJwksFetcherTest'`
-Expected: PASS
-
-- [ ] **Step 5: Commit (libseqera repo)**
-
-```bash
-git add lib-auth-jwks
-git commit -m "feat: lib-auth-jwks default HTTP fetcher"
-```
-
----
-
-### Task 4: JwksJwtVerifier — the verification engine
-
-**Files:**
-- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/JwksJwtVerifier.java`
-- Create: `lib-auth-jwks/changelog.txt`
-- Test: `lib-auth-jwks/src/test/groovy/io/seqera/auth/jwks/JwksJwtVerifierTest.groovy`
-
-**Interfaces:**
-- Consumes: everything from Tasks 2–3.
-- Produces: `JwksJwtVerifier(JwksFetcher, JwksCacheStore, JwksConfig)`; `VerifiedJwt verify(String token, String expectedIssuer)` throwing `InvalidTokenException` / `UnknownIssuerException` / `JwksUnavailableException`; static `String normalizeIssuer(String)`.
-
-**Behavior spec (mirrors the design doc):**
-1. Parse token; non-JWT or disallowed alg → `InvalidTokenException`.
-2. Load JWKS for the normalized issuer endpoint: fresh cache hit → use it; stale or missing → fetch; fetch failure with any cached copy → use the stale copy; fetch failure with no copy → `JwksUnavailableException`.
-3. Token `kid` absent from the key set → rate-limited re-fetch (min interval `refreshMinInterval`, per endpoint), then proceed with whatever key set we have.
-4. Verify signature + `exp`/`nbf` (clock skew from config) via Nimbus `DefaultJWTProcessor`; failures → `InvalidTokenException`.
-5. Compare `normalizeIssuer(iss claim)` with `normalizeIssuer(expectedIssuer)`; mismatch or missing → `UnknownIssuerException`.
-
-- [ ] **Step 1: Write the failing tests**
-
-`src/test/groovy/io/seqera/auth/jwks/JwksJwtVerifierTest.groovy`:
-
-```groovy
-package io.seqera.auth.jwks
-
-import java.time.Duration
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.atomic.AtomicInteger
-
-import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.JWSHeader
-import com.nimbusds.jose.crypto.RSASSASigner
-import com.nimbusds.jose.jwk.JWKSet
-import com.nimbusds.jose.jwk.RSAKey
-import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
-import com.nimbusds.jwt.JWTClaimsSet
-import com.nimbusds.jwt.SignedJWT
-import io.seqera.auth.jwks.exception.InvalidTokenException
-import io.seqera.auth.jwks.exception.JwksUnavailableException
-import io.seqera.auth.jwks.exception.UnknownIssuerException
-import spock.lang.Shared
-import spock.lang.Specification
-
-class JwksJwtVerifierTest extends Specification {
-
-    static final String ISSUER = 'https://tower.example.com'
-
-    @Shared RSAKey keyA
-    @Shared RSAKey keyB
-    @Shared String jwksA
-    @Shared String jwksB
-
-    def setupSpec() {
-        keyA = new RSAKeyGenerator(2048).keyID('key-a').generate()
-        keyB = new RSAKeyGenerator(2048).keyID('key-b').generate()
-        jwksA = new JWKSet(keyA.toPublicJWK()).toString()
-        jwksB = new JWKSet(keyB.toPublicJWK()).toString()
-    }
-
-    static String token(RSAKey key, Map opts = [:]) {
-        final claims = new JWTClaimsSet.Builder()
-                .issuer((String) opts.getOrDefault('iss', ISSUER))
-                .subject('user-123')
-                .expirationTime(new Date(System.currentTimeMillis() + (long) opts.getOrDefault('ttlMillis', 60_000L)))
-                .build()
-        final jwt = new SignedJWT(
-                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(key.keyID).build(),
-                claims )
-        jwt.sign(new RSASSASigner(key))
-        return jwt.serialize()
-    }
-
-    static JwksFetcher fetcherOf(String... responses) {
-        final count = new AtomicInteger()
-        return { endpoint ->
-            final i = Math.min(count.getAndIncrement(), responses.length - 1)
-            final r = responses[i]
-            r == null
-                    ? CompletableFuture.<String>failedFuture(new JwksUnavailableException('boom'))
-                    : CompletableFuture.completedFuture(r)
-        } as JwksFetcher
-    }
-
-    static JwksConfig config(Map opts = [:]) {
-        new JwksConfig(
-                '/.well-known/jwks.json',
-                (Duration) opts.getOrDefault('cacheDuration', Duration.ofHours(6)),
-                (Duration) opts.getOrDefault('refreshMinInterval', Duration.ofSeconds(60)),
-                Duration.ofSeconds(60),
-                Duration.ofSeconds(5) )
-    }
-
-    def 'should verify a valid token' () {
-        given:
-        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
-
-        when:
-        def result = verifier.verify(token(keyA), ISSUER)
-        then:
-        result.issuer() == ISSUER
-        result.subject() == 'user-123'
-        result.expiration() != null
-    }
-
-    def 'should accept issuer with cosmetic differences' () {
-        given:
-        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
-
-        expect:
-        verifier.verify(token(keyA), 'HTTPS://Tower.Example.Com/').subject() == 'user-123'
-    }
-
-    def 'should reject a token signed by an unknown key' () {
-        given: 'the JWKS only contains key-a but the token is signed with key-b'
-        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
-
-        when:
-        verifier.verify(token(keyB), ISSUER)
-        then:
-        thrown(InvalidTokenException)
-    }
-
-    def 'should reject a tampered token' () {
-        given:
-        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
-        def parts = token(keyA).tokenize('.')
-        def tampered = parts[0] + '.' + Base64.urlEncoder.withoutPadding().encodeToString('{"sub":"evil"}'.bytes) + '.' + parts[2]
-
-        when:
-        verifier.verify(tampered, ISSUER)
-        then:
-        thrown(InvalidTokenException)
-    }
-
-    def 'should reject an expired token' () {
-        given:
-        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
-
-        when: 'expired well beyond the 60s clock skew'
-        verifier.verify(token(keyA, ttlMillis: -120_000L), ISSUER)
-        then:
-        thrown(InvalidTokenException)
-    }
-
-    def 'should reject a wrong issuer' () {
-        given:
-        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
-
-        when:
-        verifier.verify(token(keyA, iss: 'https://evil.example.com'), ISSUER)
-        then:
-        thrown(UnknownIssuerException)
-    }
-
-    def 'should reject symmetric and unsupported algorithms' () {
-        given:
-        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
-
-        when:
-        verifier.verify(JwtInspectorTest.hs256Token(), ISSUER)
-        then:
-        thrown(InvalidTokenException)
-    }
-
-    def 'should refetch jwks on unknown kid' () {
-        given: 'first fetch returns the old key set, second fetch the rotated one'
-        def verifier = new JwksJwtVerifier(
-                fetcherOf(jwksA, jwksB),
-                new InMemoryJwksCacheStore(),
-                config(refreshMinInterval: Duration.ZERO) )
-
-        expect: 'prime the cache with key-a'
-        verifier.verify(token(keyA), ISSUER)
-
-        and: 'a token signed with rotated key-b triggers a refetch and verifies'
-        verifier.verify(token(keyB), ISSUER).subject() == 'user-123'
-    }
-
-    def 'should rate-limit refetch on unknown kid' () {
-        given: 'a fetcher that always returns the OLD key set, counting invocations'
-        def count = new AtomicInteger()
-        def fetcher = { String ep ->
-            count.incrementAndGet()
-            CompletableFuture.completedFuture(jwksA)
-        } as JwksFetcher
-        def verifier = new JwksJwtVerifier(
-                fetcher,
-                new InMemoryJwksCacheStore(),
-                config(refreshMinInterval: Duration.ofHours(1)) )
-        verifier.verify(token(keyA), ISSUER)   // initial fetch (#1)
-
-        when: 'two consecutive unknown-kid misses'
-        try { verifier.verify(token(keyB), ISSUER) } catch (InvalidTokenException ignored) { }
-        try { verifier.verify(token(keyB), ISSUER) } catch (InvalidTokenException ignored) { }
-        then: 'only one refetch happened — the second miss was throttled'
-        count.get() == 2
-    }
-
-    def 'should fall back to stale cache when fetch fails' () {
-        given: 'cache duration zero means every hit is stale; second fetch fails'
-        def verifier = new JwksJwtVerifier(
-                fetcherOf(jwksA, null),
-                new InMemoryJwksCacheStore(),
-                config(cacheDuration: Duration.ZERO) )
-        verifier.verify(token(keyA), ISSUER)
-
-        expect: 'still verifies using the stale cached copy'
-        verifier.verify(token(keyA), ISSUER).subject() == 'user-123'
-    }
-
-    def 'should fail when fetch fails and no cache exists' () {
-        given:
-        def verifier = new JwksJwtVerifier(fetcherOf(null), new InMemoryJwksCacheStore(), config())
-
-        when:
-        verifier.verify(token(keyA), ISSUER)
-        then:
-        thrown(JwksUnavailableException)
-    }
-
-    def 'should normalize issuer urls' () {
-        expect:
-        JwksJwtVerifier.normalizeIssuer(input) == expected
-
-        where:
-        input                             | expected
-        'https://tower.example.com'       | 'https://tower.example.com'
-        'https://tower.example.com/'      | 'https://tower.example.com'
-        'HTTPS://Tower.Example.COM//'     | 'https://tower.example.com'
-        'https://foo.com/API/'            | 'https://foo.com/API'
-        null                              | null
-    }
-}
-```
-
-Note: in the rate-limit test both misses throw `InvalidTokenException` (the key set never contains `key-b`); the assertion is on the fetch count — initial fetch plus exactly one refetch, the second miss being inside the min interval.
-
-- [ ] **Step 2: Run tests to verify they fail**
-
-Run: `./gradlew :lib-auth-jwks:test --tests 'JwksJwtVerifierTest'`
-Expected: FAIL (class not found)
-
-- [ ] **Step 3: Write the implementation**
-
-`JwksJwtVerifier.java`:
+`DynamicJwksVerifier.java`:
 
 ```java
 package io.seqera.auth.jwks;
 
 import java.text.ParseException;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
-import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKMatcher;
+import com.nimbusds.jose.jwk.JWKSelector;
 import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
-import com.nimbusds.jose.proc.BadJOSEException;
-import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
-import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.security.token.jwt.signature.jwks.JwkSetFetcher;
+import io.micronaut.security.token.jwt.signature.jwks.JwkValidator;
 import io.seqera.auth.jwks.exception.InvalidTokenException;
 import io.seqera.auth.jwks.exception.JwksUnavailableException;
 import io.seqera.auth.jwks.exception.UnknownIssuerException;
+import jakarta.inject.Singleton;
+import reactor.core.publisher.Mono;
 
 /**
  * Verifies JWTs against the JWKS document of a dynamically-resolved issuer.
  *
- * The issuer's JWKS is retrieved through the pluggable {@link JwksFetcher}
- * and cached in the pluggable {@link JwksCacheStore}. An unknown {@code kid}
- * triggers a rate-limited re-fetch to pick up key rotation; a fetch failure
- * falls back to the last cached copy when one exists.
+ * Micronaut Security's {@code SignatureConfiguration} beans are fixed at
+ * startup; this verifier resolves the JWKS URL per request from the expected
+ * issuer endpoint instead, while reusing Micronaut's own machinery:
+ * {@link JwkSetFetcher} for retrieval and caching (and, through it, the
+ * {@code JwksClient} transport seam) and {@link JwkValidator} for signature
+ * verification. An unknown {@code kid} triggers a rate-limited cache clear +
+ * re-fetch to pick up key rotation.
  */
-public class JwksJwtVerifier {
+@Singleton
+@Requires(beans = JwksVerifierConfig.class)
+public class DynamicJwksVerifier {
 
     static final Set<JWSAlgorithm> ALLOWED_ALGS = Set.of(
             JWSAlgorithm.RS256, JWSAlgorithm.RS384, JWSAlgorithm.RS512,
             JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512 );
 
-    private final JwksFetcher fetcher;
-    private final JwksCacheStore cache;
-    private final JwksConfig config;
+    private final JwkSetFetcher<JWKSet> jwkSetFetcher;
+    private final JwkValidator jwkValidator;
+    private final JwksVerifierConfig config;
     private final Map<String, Instant> lastRefresh = new ConcurrentHashMap<>();
 
-    public JwksJwtVerifier(JwksFetcher fetcher, JwksCacheStore cache, JwksConfig config) {
-        this.fetcher = fetcher;
-        this.cache = cache;
+    public DynamicJwksVerifier(JwkSetFetcher<JWKSet> jwkSetFetcher, JwkValidator jwkValidator, JwksVerifierConfig config) {
+        this.jwkSetFetcher = jwkSetFetcher;
+        this.jwkValidator = jwkValidator;
         this.config = config;
     }
 
@@ -880,12 +593,19 @@ public class JwksJwtVerifier {
             throw new InvalidTokenException("Unsupported JWT signature algorithm: " + alg);
 
         final String issuer = normalizeIssuer(expectedIssuer);
-        JWKSet jwks = loadJwks(issuer);
+        final String url = jwksUrl(issuer);
+        JWKSet jwks = fetchJwks(issuer, url);
         final String kid = jwt.getHeader().getKeyID();
-        if (kid != null && jwks.getKeyByKeyId(kid) == null)
-            jwks = refreshJwks(issuer, jwks);
+        if (kid != null && jwks.getKeyByKeyId(kid) == null) {
+            final JWKSet refreshed = refreshJwks(issuer, url);
+            if (refreshed != null)
+                jwks = refreshed;
+        }
 
-        final JWTClaimsSet claims = process(jwt, jwks);
+        if (!verifySignature(jwt, jwks))
+            throw new InvalidTokenException("JWT signature verification failed");
+
+        final JWTClaimsSet claims = verifyClaims(jwt);
         final String iss = claims.getIssuer();
         if (iss == null || !normalizeIssuer(iss).equals(issuer))
             throw new UnknownIssuerException("JWT issuer '" + iss + "' does not match expected issuer '" + expectedIssuer + "'");
@@ -906,73 +626,57 @@ public class JwksJwtVerifier {
         }
     }
 
-    private JWKSet loadJwks(String endpoint) {
-        final CachedJwks cached = cache.load(endpoint);
-        final boolean fresh = cached != null
-                && cached.createdAt().plus(config.cacheDuration()).isAfter(Instant.now());
-        if (fresh)
-            return parseJwks(cached.json());
+    private String jwksUrl(String issuer) {
+        final String path = config.getJwksPath();
+        return path.startsWith("/") ? issuer + path : issuer + "/" + path;
+    }
+
+    private JWKSet fetchJwks(String providerName, String url) {
+        final JWKSet result;
         try {
-            return fetchAndStore(endpoint);
+            result = Mono.from(jwkSetFetcher.fetch(providerName, url))
+                    .block(config.getFetchTimeout());
+        }
+        catch (RuntimeException e) {
+            throw new JwksUnavailableException("Failed to fetch JWKS from " + url, e);
+        }
+        if (result == null || result.getKeys().isEmpty())
+            throw new JwksUnavailableException("No JWKS keys available from " + url);
+        return result;
+    }
+
+    private JWKSet refreshJwks(String providerName, String url) {
+        final Instant last = lastRefresh.get(providerName);
+        if (last != null && last.plus(config.getRefreshMinInterval()).isAfter(Instant.now()))
+            return null;    // rate limited — keep the current key set
+        lastRefresh.put(providerName, Instant.now());
+        jwkSetFetcher.clearCache(url);
+        try {
+            return fetchJwks(providerName, url);
         }
         catch (JwksUnavailableException e) {
-            if (cached != null)
-                return parseJwks(cached.json());   // stale fallback
-            throw e;
+            return null;
         }
     }
 
-    private JWKSet refreshJwks(String endpoint, JWKSet current) {
-        final Instant last = lastRefresh.get(endpoint);
-        if (last != null && last.plus(config.refreshMinInterval()).isAfter(Instant.now()))
-            return current;    // rate limited — keep the current key set
-        lastRefresh.put(endpoint, Instant.now());
-        try {
-            return fetchAndStore(endpoint);
+    private boolean verifySignature(SignedJWT jwt, JWKSet jwks) {
+        final List<JWK> matches = new JWKSelector(JWKMatcher.forJWSHeader(jwt.getHeader())).select(jwks);
+        for (JWK jwk : matches) {
+            if (jwkValidator.validate(jwt, jwk))
+                return true;
         }
-        catch (JwksUnavailableException e) {
-            return current;
-        }
+        return false;
     }
 
-    private JWKSet fetchAndStore(String endpoint) {
-        final String json;
+    private JWTClaimsSet verifyClaims(SignedJWT jwt) {
         try {
-            json = fetcher.fetch(endpoint).get(config.fetchTimeout().toMillis(), TimeUnit.MILLISECONDS);
+            final DefaultJWTClaimsVerifier<SecurityContext> verifier = new DefaultJWTClaimsVerifier<>(null, Set.of("exp"));
+            verifier.setMaxClockSkew((int) config.getClockSkew().toSeconds());
+            final JWTClaimsSet claims = jwt.getJWTClaimsSet();
+            verifier.verify(claims, null);
+            return claims;
         }
-        catch (ExecutionException e) {
-            if (e.getCause() instanceof JwksUnavailableException cause)
-                throw cause;
-            throw new JwksUnavailableException("Failed to fetch JWKS from " + endpoint, e.getCause());
-        }
-        catch (Exception e) {
-            if (e instanceof InterruptedException)
-                Thread.currentThread().interrupt();
-            throw new JwksUnavailableException("Failed to fetch JWKS from " + endpoint, e);
-        }
-        cache.save(endpoint, json);
-        return parseJwks(json);
-    }
-
-    private JWKSet parseJwks(String json) {
-        try {
-            return JWKSet.parse(json);
-        }
-        catch (ParseException e) {
-            throw new JwksUnavailableException("Malformed JWKS document", e);
-        }
-    }
-
-    private JWTClaimsSet process(SignedJWT jwt, JWKSet jwks) {
-        try {
-            final DefaultJWTProcessor<SecurityContext> processor = new DefaultJWTProcessor<>();
-            processor.setJWSKeySelector(new JWSVerificationKeySelector<>(ALLOWED_ALGS, new ImmutableJWKSet<>(jwks)));
-            final DefaultJWTClaimsVerifier<SecurityContext> claimsVerifier = new DefaultJWTClaimsVerifier<>(null, Set.of("exp"));
-            claimsVerifier.setMaxClockSkew((int) config.clockSkew().toSeconds());
-            processor.setJWTClaimsSetVerifier(claimsVerifier);
-            return processor.process(jwt, null);
-        }
-        catch (BadJOSEException | JOSEException e) {
+        catch (ParseException | BadJWTException e) {
             throw new InvalidTokenException("JWT validation failed - cause: " + e.getMessage(), e);
         }
     }
@@ -1000,8 +704,9 @@ public class JwksJwtVerifier {
 `lib-auth-jwks/changelog.txt`:
 
 ```
-0.1.0 - <today's date>
-- Initial release: JwksJwtVerifier, JwtInspector, HttpJwksFetcher, pluggable JwksFetcher/JwksCacheStore seams
+0.1.0 - 22 Jul 2026
+- Initial release: DynamicJwksVerifier (multi-issuer JWKS verification over
+  Micronaut Security's JwkSetFetcher/JwkValidator/JwksClient machinery), JwtInspector
 ```
 
 - [ ] **Step 4: Run the full module test suite**
@@ -1012,78 +717,86 @@ Expected: PASS (all specs)
 - [ ] **Step 5: Publish to maven local for the Wave tasks**
 
 Run: `./gradlew :lib-auth-jwks:publishToMavenLocal`
-Expected: BUILD SUCCESSFUL. (The final Wave release requires `lib-auth-jwks:0.1.0` published to maven.seqera.io via the libseqera release process — same as every other lib bump; the Wave PR must not merge before that.)
+Expected: BUILD SUCCESSFUL. (The final Wave release requires `lib-auth-jwks:0.1.0` published to maven.seqera.io via the libseqera release process — the Wave PR must not merge before that.)
 
 - [ ] **Step 6: Commit (libseqera repo)**
 
 ```bash
 git add lib-auth-jwks
-git commit -m "feat: lib-auth-jwks JWKS-based JWT verifier"
+git commit -m "feat: lib-auth-jwks dynamic multi-issuer JWKS verifier"
 ```
 
 ---
 
-### Task 5: Wave — dependency + PairingJwksFetcher (JWKS over the pairing tunnel)
+### Task 3: Wave — dependencies + PairingJwksClient (JWKS over the pairing tunnel)
 
 **Files:**
 - Modify: `/Users/pditommaso/Projects/wave/build.gradle` (dependencies block, next to the other `io.seqera:` entries around line 48; repositories block at line 22 for local dev only)
+- Modify: `src/main/resources/application.yml` (disable Micronaut's HTTP JWKS client)
 - Create: `src/main/groovy/io/seqera/wave/auth/JwksAuthConfig.groovy`
-- Create: `src/main/groovy/io/seqera/wave/auth/PairingJwksFetcher.groovy`
-- Test: `src/test/groovy/io/seqera/wave/auth/PairingJwksFetcherTest.groovy`
+- Create: `src/main/groovy/io/seqera/wave/auth/PairingJwksClient.groovy`
+- Test: `src/test/groovy/io/seqera/wave/auth/PairingJwksClientTest.groovy`
 
 **Interfaces:**
-- Consumes: `JwksFetcher`, `JwksUnavailableException`, `JwksConfig` (lib); `TowerConnector.sendAsync(String endpoint, ProxyHttpRequest): CompletableFuture<ProxyHttpResponse>` (existing, `TowerConnector.groovy:322`); `io.seqera.service.pairing.socket.msg.ProxyHttpRequest` (fields: `msgId`, `method`, `uri`, `auth`, `body`, `headers`); `static io.seqera.random.LongRndKey.rndHex` (same import `TowerConnector.groovy:54` uses).
-- Produces: `JwksAuthConfig` bean (fields `enabled`, `path`, `cacheDuration`, `refreshMinInterval`, `clockSkew`, `fetchTimeout`; method `toJwksConfig(): JwksConfig`); `PairingJwksFetcher implements JwksFetcher`.
+- Consumes: `io.micronaut.security.token.jwt.signature.jwks.JwksClient` — `Publisher<String> load(@Nullable String providerName, @NonNull String url)`; `JwksVerifierConfig`, `JwksUnavailableException` (lib); `TowerConnector.sendAsync(String endpoint, ProxyHttpRequest): CompletableFuture<ProxyHttpResponse>` (existing, `TowerConnector.groovy:322`); `io.seqera.service.pairing.socket.msg.ProxyHttpRequest` (fields: `msgId`, `method`, `uri`, `auth`, `body`, `headers`); `static io.seqera.random.LongRndKey.rndHex` (same import `TowerConnector.groovy:54` uses).
+- Produces: `JwksAuthConfig` bean implementing `JwksVerifierConfig` plus the Wave-only `enabled` flag; `PairingJwksClient` — the sole `JwksClient` bean (Micronaut's `HttpClientJwksClient` disabled by config), which makes both Micronaut's `DefaultJwkSetFetcher` and lib's `DynamicJwksVerifier` route JWKS retrieval through the pairing tunnel.
 
-- [ ] **Step 1: Add the dependency**
+- [ ] **Step 1: Add the dependencies and config**
 
 In `build.gradle` dependencies, after `implementation 'io.seqera:lib-pairing:1.0.0'`:
 
 ```gradle
 implementation 'io.seqera:lib-auth-jwks:0.1.0'
+implementation 'io.micronaut.security:micronaut-security-jwt'
 ```
 
-For local development only (NOT to be committed if the team prefers otherwise — check before merging), add `mavenLocal()` as the FIRST entry of the `repositories` block so the locally-published `0.1.0` resolves:
+(`micronaut-security-jwt` is unversioned — managed by the Micronaut platform BOM like the existing `micronaut-security` entry.)
 
-```gradle
-repositories {
-    mavenLocal()
-    mavenCentral()
-    ...
-}
+For local development only (drop before merge): add `mavenLocal()` as the FIRST entry of the `repositories` block so the locally-published `0.1.0` resolves.
+
+In `application.yml`, under the existing `micronaut.security` section (around line 50), add:
+
+```yaml
+    token:
+      jwt:
+        signatures:
+          jwks-client:
+            http-client:
+              enabled: false
 ```
+
+(This disables `HttpClientJwksClient` so `PairingJwksClient` becomes the sole `JwksClient` bean — otherwise the `JwkSetFetcher` injection of `JwksClient` would be ambiguous.)
 
 Run: `cd /Users/pditommaso/Projects/wave && ./gradlew compileGroovy`
 Expected: BUILD SUCCESSFUL
 
 - [ ] **Step 2: Write the failing test**
 
-`src/test/groovy/io/seqera/wave/auth/PairingJwksFetcherTest.groovy` (copy the Wave license header):
+`src/test/groovy/io/seqera/wave/auth/PairingJwksClientTest.groovy` (copy the Wave license header):
 
 ```groovy
 package io.seqera.wave.auth
 
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionException
 
 import io.seqera.auth.jwks.exception.JwksUnavailableException
 import io.seqera.service.pairing.socket.msg.ProxyHttpRequest
 import io.seqera.service.pairing.socket.msg.ProxyHttpResponse
 import io.seqera.wave.tower.client.connector.TowerConnector
+import reactor.core.publisher.Mono
 import spock.lang.Specification
 
-class PairingJwksFetcherTest extends Specification {
+class PairingJwksClientTest extends Specification {
 
     def 'should fetch jwks via the tower connector' () {
         given:
         def connector = Mock(TowerConnector)
-        def config = new JwksAuthConfig(path: '/.well-known/jwks.json')
-        def fetcher = new PairingJwksFetcher(connector, config)
+        def client = new PairingJwksClient(connector)
 
         when:
-        def result = fetcher.fetch('https://tower.example.com/').join()
+        def result = Mono.from(client.load('https://tower.example.com', 'https://tower.example.com/.well-known/jwks.json')).block()
         then:
-        1 * connector.sendAsync('https://tower.example.com/', _ as ProxyHttpRequest) >> { String ep, ProxyHttpRequest req ->
+        1 * connector.sendAsync('https://tower.example.com', _ as ProxyHttpRequest) >> { String ep, ProxyHttpRequest req ->
             assert req.uri == 'https://tower.example.com/.well-known/jwks.json'
             assert req.method == 'GET'
             assert req.auth == null
@@ -1098,20 +811,26 @@ class PairingJwksFetcherTest extends Specification {
         def connector = Mock(TowerConnector) {
             sendAsync(_, _) >> CompletableFuture.completedFuture(new ProxyHttpResponse(msgId: 'x', status: 404, body: null))
         }
-        def fetcher = new PairingJwksFetcher(connector, new JwksAuthConfig(path: '/.well-known/jwks.json'))
+        def client = new PairingJwksClient(connector)
 
         when:
-        fetcher.fetch('https://tower.example.com').join()
+        Mono.from(client.load('https://tower.example.com', 'https://tower.example.com/.well-known/jwks.json')).block()
         then:
-        def e = thrown(CompletionException)
-        e.cause instanceof JwksUnavailableException
+        thrown(JwksUnavailableException)
+    }
+
+    def 'should fail when provider name is missing' () {
+        when:
+        Mono.from(new PairingJwksClient(Mock(TowerConnector)).load(null, 'https://x/.well-known/jwks.json')).block()
+        then:
+        thrown(IllegalArgumentException)
     }
 }
 ```
 
 - [ ] **Step 3: Run test to verify it fails**
 
-Run: `./gradlew test --tests 'PairingJwksFetcherTest'`
+Run: `./gradlew test --tests 'PairingJwksClientTest'`
 Expected: FAIL (classes not found)
 
 - [ ] **Step 4: Write the implementation**
@@ -1125,17 +844,19 @@ import java.time.Duration
 
 import groovy.transform.CompileStatic
 import io.micronaut.context.annotation.Value
-import io.seqera.auth.jwks.JwksConfig
+import io.seqera.auth.jwks.JwksVerifierConfig
 import jakarta.inject.Singleton
 
 /**
  * Configuration for JWKS-based validation of Platform JWT tokens.
+ * Implements the lib-auth-jwks config contract and adds the Wave-level
+ * enable flag.
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Singleton
 @CompileStatic
-class JwksAuthConfig {
+class JwksAuthConfig implements JwksVerifierConfig {
 
     /**
      * When {@code false} (default) all tokens follow the legacy delegation
@@ -1145,10 +866,7 @@ class JwksAuthConfig {
     boolean enabled
 
     @Value('${wave.auth.jwks.path:`/.well-known/jwks.json`}')
-    String path
-
-    @Value('${wave.auth.jwks.cache-duration:6h}')
-    Duration cacheDuration
+    String jwksPath
 
     @Value('${wave.auth.jwks.refresh-min-interval:60s}')
     Duration refreshMinInterval
@@ -1158,66 +876,67 @@ class JwksAuthConfig {
 
     @Value('${wave.auth.jwks.fetch-timeout:30s}')
     Duration fetchTimeout
-
-    JwksConfig toJwksConfig() {
-        return new JwksConfig(path, cacheDuration, refreshMinInterval, clockSkew, fetchTimeout)
-    }
 }
 ```
 
-`src/main/groovy/io/seqera/wave/auth/PairingJwksFetcher.groovy`:
+`src/main/groovy/io/seqera/wave/auth/PairingJwksClient.groovy`:
 
 ```groovy
 package io.seqera.wave.auth
 
-import java.util.concurrent.CompletableFuture
-
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import io.seqera.auth.jwks.JwksFetcher
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.security.token.jwt.signature.jwks.JwksClient
 import io.seqera.auth.jwks.exception.JwksUnavailableException
 import io.seqera.service.pairing.socket.msg.ProxyHttpRequest
 import io.seqera.service.pairing.socket.msg.ProxyHttpResponse
 import io.seqera.wave.tower.client.connector.TowerConnector
 import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Mono
 
 import static io.seqera.random.LongRndKey.rndHex
 
 /**
- * Retrieves a Platform JWKS document through the Tower connector, i.e.
- * over the pairing websocket tunnel (or direct HTTP when the legacy
- * connector is active). This is what makes JWKS work for Platform
- * instances behind private networks.
+ * Micronaut {@link JwksClient} that retrieves a Platform JWKS document
+ * through the Tower connector, i.e. over the pairing websocket tunnel
+ * (or direct HTTP when the legacy connector is active). This is what makes
+ * JWKS work for Platform instances behind private networks.
+ *
+ * The provider name carries the Tower endpoint used for tunnel routing.
+ * Micronaut's own HTTP JWKS client is disabled in application.yml so this
+ * is the sole {@link JwksClient} bean.
  *
  * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
  */
 @Slf4j
 @Singleton
 @CompileStatic
-class PairingJwksFetcher implements JwksFetcher {
+class PairingJwksClient implements JwksClient {
 
     private final TowerConnector connector
-    private final JwksAuthConfig config
 
-    PairingJwksFetcher(TowerConnector connector, JwksAuthConfig config) {
+    PairingJwksClient(TowerConnector connector) {
         this.connector = connector
-        this.config = config
     }
 
     @Override
-    CompletableFuture<String> fetch(String endpoint) {
-        final uri = endpoint.replaceAll('/+$', '') + (config.path.startsWith('/') ? config.path : '/' + config.path)
+    Publisher<String> load(@Nullable String providerName, @NonNull String url) {
+        if( !providerName )
+            return Mono.error(new IllegalArgumentException("Missing JWKS provider name - it should hold the Tower endpoint for pairing channel routing"))
         final request = new ProxyHttpRequest(
                 msgId: rndHex(),
                 method: 'GET',
-                uri: uri )
-        log.debug "Fetching JWKS document from '$uri'"
-        return connector
-                .sendAsync(endpoint, request)
-                .thenApply { ProxyHttpResponse resp ->
-                    if( resp.status == 200 )
-                        return resp.body
-                    throw new JwksUnavailableException("Unexpected status ${resp.status} fetching JWKS from '$uri'")
+                uri: url )
+        log.debug "Fetching JWKS document from '$url'"
+        return Mono
+                .fromFuture(connector.sendAsync(providerName, request))
+                .map { ProxyHttpResponse resp ->
+                    if( resp.status != 200 )
+                        throw new JwksUnavailableException("Unexpected status ${resp.status} fetching JWKS from '$url'")
+                    return resp.body
                 }
     }
 }
@@ -1225,174 +944,28 @@ class PairingJwksFetcher implements JwksFetcher {
 
 - [ ] **Step 5: Run test to verify it passes**
 
-Run: `./gradlew test --tests 'PairingJwksFetcherTest'`
+Run: `./gradlew test --tests 'PairingJwksClientTest'`
 Expected: PASS
 
 - [ ] **Step 6: Commit (wave repo)**
 
 ```bash
 cd /Users/pditommaso/Projects/wave
-git add build.gradle src/main/groovy/io/seqera/wave/auth src/test/groovy/io/seqera/wave/auth
-git commit -m "feat: JWKS fetcher over the pairing channel and jwks auth config"
+git add build.gradle src/main/resources/application.yml src/main/groovy/io/seqera/wave/auth src/test/groovy/io/seqera/wave/auth
+git commit -m "feat: JWKS client over the pairing channel and jwks auth config"
 ```
 
 ---
 
-### Task 6: Wave — Redis-backed JWKS cache store
+### Task 4: Wave — UserServiceImpl wiring (the flag-gated dual path)
 
 **Files:**
-- Create: `src/main/groovy/io/seqera/wave/auth/JwksEntry.groovy`
-- Create: `src/main/groovy/io/seqera/wave/auth/RedisJwksCacheStore.groovy`
-- Test: `src/test/groovy/io/seqera/wave/auth/RedisJwksCacheStoreTest.groovy`
-
-**Interfaces:**
-- Consumes: `JwksCacheStore`/`CachedJwks` (lib); `io.seqera.data.store.state.AbstractStateStore` + `io.seqera.data.store.state.impl.StateProvider` and `io.seqera.serde.moshi.MoshiEncodeStrategy` (same pattern as `JwtAuthStore.groovy:34-51`).
-- Produces: `RedisJwksCacheStore` bean implementing `JwksCacheStore` (note: `load`/`save` interface names deliberately avoid clashing with `AbstractStateStore.get/put`). Redis prefix `jwks-cache/v1`, retention 7 days (freshness within the retention window is decided by the verifier's `cacheDuration`).
-
-- [ ] **Step 1: Write the failing test** (`@MicronautTest` resolves the local `StateProvider` when Redis is absent — same approach as other Wave state-store tests)
-
-`src/test/groovy/io/seqera/wave/auth/RedisJwksCacheStoreTest.groovy`:
-
-```groovy
-package io.seqera.wave.auth
-
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
-import spock.lang.Specification
-
-@MicronautTest
-class RedisJwksCacheStoreTest extends Specification {
-
-    @Inject
-    RedisJwksCacheStore store
-
-    def 'should save and load a jwks document' () {
-        expect:
-        store.load('https://tower.example.com') == null
-
-        when:
-        store.save('https://tower.example.com', '{"keys":[]}')
-        def entry = store.load('https://tower.example.com')
-        then:
-        entry.json() == '{"keys":[]}'
-        entry.createdAt() != null
-    }
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `./gradlew test --tests 'RedisJwksCacheStoreTest'`
-Expected: FAIL (class not found)
-
-- [ ] **Step 3: Write the implementation**
-
-`src/main/groovy/io/seqera/wave/auth/JwksEntry.groovy`:
-
-```groovy
-package io.seqera.wave.auth
-
-import java.time.Instant
-
-import groovy.transform.Canonical
-import groovy.transform.CompileStatic
-
-/**
- * Serializable state-store entry holding a cached JWKS document.
- *
- * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
- */
-@Canonical
-@CompileStatic
-class JwksEntry {
-    String json
-    Instant createdAt
-}
-```
-
-`src/main/groovy/io/seqera/wave/auth/RedisJwksCacheStore.groovy`:
-
-```groovy
-package io.seqera.wave.auth
-
-import java.time.Duration
-import java.time.Instant
-
-import groovy.transform.CompileStatic
-import io.seqera.auth.jwks.CachedJwks
-import io.seqera.auth.jwks.JwksCacheStore
-import io.seqera.data.store.state.AbstractStateStore
-import io.seqera.data.store.state.impl.StateProvider
-import io.seqera.serde.moshi.MoshiEncodeStrategy
-import jakarta.inject.Singleton
-
-/**
- * JWKS cache backed by the Wave state store (Redis in production, local
- * in dev), so all replicas share fetched key sets and retain stale
- * copies for fallback when the issuer is unreachable.
- *
- * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
- */
-@Singleton
-@CompileStatic
-class RedisJwksCacheStore extends AbstractStateStore<JwksEntry> implements JwksCacheStore {
-
-    RedisJwksCacheStore(StateProvider<String,String> provider) {
-        super(provider, new MoshiEncodeStrategy<JwksEntry>() {})
-    }
-
-    @Override
-    protected String getPrefix() {
-        return 'jwks-cache/v1'
-    }
-
-    /**
-     * Retention, not freshness: the verifier treats entries older than its
-     * configured cache-duration as stale but may still use them as a
-     * fallback when the issuer cannot be reached.
-     */
-    @Override
-    protected Duration getDuration() {
-        return Duration.ofDays(7)
-    }
-
-    @Override
-    CachedJwks load(String endpoint) {
-        final entry = get(endpoint)
-        return entry ? new CachedJwks(entry.json, entry.createdAt) : null
-    }
-
-    @Override
-    void save(String endpoint, String jwksJson) {
-        put(endpoint, new JwksEntry(jwksJson, Instant.now()))
-    }
-}
-```
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `./gradlew test --tests 'RedisJwksCacheStoreTest'`
-Expected: PASS
-
-- [ ] **Step 5: Commit (wave repo)**
-
-```bash
-git add src/main/groovy/io/seqera/wave/auth src/test/groovy/io/seqera/wave/auth
-git commit -m "feat: Redis-backed JWKS cache store"
-```
-
----
-
-### Task 7: Wave — verifier bean + UserServiceImpl wiring (the flag-gated dual path)
-
-**Files:**
-- Create: `src/main/groovy/io/seqera/wave/auth/JwksAuthFactory.groovy`
 - Modify: `src/main/groovy/io/seqera/wave/service/UserServiceImpl.groovy` (whole class shown below)
 - Test: `src/test/groovy/io/seqera/wave/service/UserServiceImplJwksTest.groovy`
 
 **Interfaces:**
-- Consumes: `JwksJwtVerifier`, `JwtInspector`, lib exceptions; `JwksAuthConfig` (Task 5), `PairingJwksFetcher` (Task 5), `RedisJwksCacheStore` (Task 6); existing `TowerClient.userInfo(String, JwtAuth)` and `UnauthorizedException`.
-- Produces: `JwksJwtVerifier` singleton bean; the dual-path behavior in `UserServiceImpl.getUserByAccessToken` — the ONLY behavioral change in Wave, covering both `ContainerController` and `InspectController` since both resolve identity through this method.
+- Consumes: `DynamicJwksVerifier`, `JwtInspector`, `VerifiedJwt`, lib exceptions; `JwksAuthConfig` (Task 3); existing `TowerClient.userInfo(String, JwtAuth): GetUserInfoResponse` (`TowerClient.groovy:70`) and `UnauthorizedException`. The `DynamicJwksVerifier` bean comes from the lib (it activates because Wave's `JwksAuthConfig` satisfies its `@Requires(beans = JwksVerifierConfig.class)`).
+- Produces: the dual-path behavior in `UserServiceImpl.getUserByAccessToken` — the ONLY behavioral change in Wave, covering both `ContainerController` and `InspectController` since both resolve identity through this method.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -1401,18 +974,6 @@ git commit -m "feat: Redis-backed JWKS cache store"
 ```groovy
 package io.seqera.wave.service
 
-import io.seqera.auth.jwks.JwksJwtVerifier
-import io.seqera.auth.jwks.VerifiedJwt
-import io.seqera.auth.jwks.exception.InvalidTokenException
-import io.seqera.auth.jwks.exception.JwksUnavailableException
-import io.seqera.wave.auth.JwksAuthConfig
-import io.seqera.wave.exception.UnauthorizedException
-import io.seqera.wave.tower.User
-import io.seqera.wave.tower.auth.JwtAuth
-import io.seqera.wave.tower.client.TowerClient
-import io.seqera.wave.tower.client.GetUserInfoResponse
-import spock.lang.Specification
-
 import java.security.KeyPairGenerator
 
 import com.nimbusds.jose.JWSAlgorithm
@@ -1420,12 +981,23 @@ import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.crypto.RSASSASigner
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
+import io.seqera.auth.jwks.DynamicJwksVerifier
+import io.seqera.auth.jwks.VerifiedJwt
+import io.seqera.auth.jwks.exception.InvalidTokenException
+import io.seqera.auth.jwks.exception.JwksUnavailableException
+import io.seqera.wave.auth.JwksAuthConfig
+import io.seqera.wave.exception.UnauthorizedException
+import io.seqera.wave.tower.User
+import io.seqera.wave.tower.auth.JwtAuth
+import io.seqera.wave.tower.client.GetUserInfoResponse
+import io.seqera.wave.tower.client.TowerClient
+import spock.lang.Specification
 
 class UserServiceImplJwksTest extends Specification {
 
+    static final String ENDPOINT = 'https://tower.example.com'
     // a structurally valid RS256 JWT (not verifiable — only parsed by JwtInspector)
     static final String RS256_TOKEN = rs256Token()
-    static final String ENDPOINT = 'https://tower.example.com'
 
     static String rs256Token() {
         final keyPair = KeyPairGenerator.getInstance('RSA').tap { initialize(2048) }.generateKeyPair()
@@ -1445,13 +1017,13 @@ class UserServiceImplJwksTest extends Specification {
         final result = new UserServiceImpl()
         result.@towerClient = opts.towerClient as TowerClient
         result.@jwksConfig = opts.config as JwksAuthConfig
-        result.@jwksVerifier = opts.verifier as JwksJwtVerifier
+        result.@jwksVerifier = opts.verifier as DynamicJwksVerifier
         return result
     }
 
     def 'should verify asymmetric jwt via jwks when enabled' () {
         given:
-        def verifier = Mock(JwksJwtVerifier)
+        def verifier = Mock(DynamicJwksVerifier)
         def towerClient = Mock(TowerClient)
         def srv = service(config: new JwksAuthConfig(enabled: true), verifier: verifier, towerClient: towerClient)
 
@@ -1465,7 +1037,7 @@ class UserServiceImplJwksTest extends Specification {
 
     def 'should reject invalid jwt when enabled' () {
         given:
-        def verifier = Mock(JwksJwtVerifier) {
+        def verifier = Mock(DynamicJwksVerifier) {
             verify(_, _) >> { throw new InvalidTokenException('bad signature') }
         }
         def towerClient = Mock(TowerClient)
@@ -1480,7 +1052,7 @@ class UserServiceImplJwksTest extends Specification {
 
     def 'should reject when jwks is unavailable and token is asymmetric jwt' () {
         given:
-        def verifier = Mock(JwksJwtVerifier) {
+        def verifier = Mock(DynamicJwksVerifier) {
             verify(_, _) >> { throw new JwksUnavailableException('no route') }
         }
         def towerClient = Mock(TowerClient)
@@ -1495,7 +1067,7 @@ class UserServiceImplJwksTest extends Specification {
 
     def 'should skip jwks for opaque tokens even when enabled' () {
         given:
-        def verifier = Mock(JwksJwtVerifier)
+        def verifier = Mock(DynamicJwksVerifier)
         def towerClient = Mock(TowerClient)
         def srv = service(config: new JwksAuthConfig(enabled: true), verifier: verifier, towerClient: towerClient)
 
@@ -1509,7 +1081,7 @@ class UserServiceImplJwksTest extends Specification {
 
     def 'should skip jwks when disabled' () {
         given:
-        def verifier = Mock(JwksJwtVerifier)
+        def verifier = Mock(DynamicJwksVerifier)
         def towerClient = Mock(TowerClient)
         def srv = service(config: new JwksAuthConfig(enabled: false), verifier: verifier, towerClient: towerClient)
 
@@ -1522,43 +1094,19 @@ class UserServiceImplJwksTest extends Specification {
 }
 ```
 
-Note: `GetUserInfoResponse` is the actual return type of `TowerClient.userInfo` (see `TowerClient.groovy:70`); the `rs256Token()` helper is inlined because the lib's test classes are not on Wave's test classpath.
+Note: `Mock(DynamicJwksVerifier)` mocks a concrete class — Spock handles it via the bytecode
+library already on the Wave test classpath; the class has a public constructor and non-final
+methods. The `rs256Token()` helper is inlined because the lib's test classes are not on Wave's
+test classpath.
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `./gradlew test --tests 'UserServiceImplJwksTest'`
-Expected: FAIL (no `jwksConfig`/`jwksVerifier` fields on `UserServiceImpl`, `JwksAuthFactory` missing)
+Expected: FAIL (no `jwksConfig`/`jwksVerifier` fields on `UserServiceImpl`)
 
 - [ ] **Step 3: Write the implementation**
 
-`src/main/groovy/io/seqera/wave/auth/JwksAuthFactory.groovy`:
-
-```groovy
-package io.seqera.wave.auth
-
-import groovy.transform.CompileStatic
-import io.micronaut.context.annotation.Factory
-import io.seqera.auth.jwks.JwksJwtVerifier
-import jakarta.inject.Singleton
-
-/**
- * Assembles the lib-auth-jwks verifier with the Wave-specific transport
- * (pairing tunnel) and cache (Redis state store) implementations.
- *
- * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
- */
-@Factory
-@CompileStatic
-class JwksAuthFactory {
-
-    @Singleton
-    JwksJwtVerifier jwksJwtVerifier(PairingJwksFetcher fetcher, RedisJwksCacheStore cacheStore, JwksAuthConfig config) {
-        return new JwksJwtVerifier(fetcher, cacheStore, config.toJwksConfig())
-    }
-}
-```
-
-`UserServiceImpl.groovy` — replace the class body (keep the existing license header and add the new imports):
+`UserServiceImpl.groovy` — replace the class body (keep the existing license header):
 
 ```groovy
 package io.seqera.wave.service
@@ -1566,7 +1114,7 @@ package io.seqera.wave.service
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.micronaut.core.annotation.Nullable
-import io.seqera.auth.jwks.JwksJwtVerifier
+import io.seqera.auth.jwks.DynamicJwksVerifier
 import io.seqera.auth.jwks.JwtInspector
 import io.seqera.auth.jwks.exception.InvalidTokenException
 import io.seqera.auth.jwks.exception.JwksUnavailableException
@@ -1597,7 +1145,7 @@ class UserServiceImpl implements UserService {
 
     @Inject
     @Nullable
-    private JwksJwtVerifier jwksVerifier
+    private DynamicJwksVerifier jwksVerifier
 
     @Override
     User getUserByAccessToken(String endpoint, JwtAuth auth) {
@@ -1646,22 +1194,22 @@ Expected: PASS (flag defaults to false → zero behavior change; if any of those
 - [ ] **Step 6: Commit (wave repo)**
 
 ```bash
-git add src/main/groovy/io/seqera/wave/auth/JwksAuthFactory.groovy src/main/groovy/io/seqera/wave/service/UserServiceImpl.groovy src/test/groovy/io/seqera/wave/service/UserServiceImplJwksTest.groovy
+git add src/main/groovy/io/seqera/wave/service/UserServiceImpl.groovy src/test/groovy/io/seqera/wave/service/UserServiceImplJwksTest.groovy
 git commit -m "feat: flag-gated JWKS validation of Platform JWT tokens"
 ```
 
 ---
 
-### Task 8: Full regression + docs touch-up
+### Task 5: Full regression + docs touch-up
 
 **Files:**
-- Modify: `src/main/resources/application.yml` (documentation-only commented block, optional)
+- Modify: `src/main/resources/application.yml` (documentation-only commented block)
 - Modify: `docs/superpowers/specs/2026-07-22-jwks-multi-issuer-auth-design.md` (only if implementation deviated — keep the spec truthful)
 
 - [ ] **Step 1: Full Wave test suite**
 
 Run: `cd /Users/pditommaso/Projects/wave && ./gradlew test`
-Expected: PASS. Fix any regression before proceeding (most likely candidates: Micronaut context tests that now instantiate the new beans — all new beans must be constructible with default config and no Redis).
+Expected: PASS. Pay special attention to security-related suites: adding `micronaut-security-jwt` to the classpath activates Micronaut's JWT token readers in the security filter. Wave's config (`intercept-url-map` `/**` → `isAnonymous()`, basic-auth on admin endpoints) must behave exactly as before — if any basic-auth or anonymous-route test regresses, disable the unused JWT filter pieces via config (e.g. `micronaut.security.token.jwt.bearer.enabled: false`) rather than code.
 
 - [ ] **Step 2: Full lib test suite**
 
@@ -1677,12 +1225,15 @@ In `application.yml`, next to the existing `wave:` documentation patterns, add a
 # When enabled, asymmetric-signed JWTs are verified locally against the
 # issuer JWKS fetched over the pairing channel; PATs and HS256 tokens
 # keep using the legacy /user-info delegation path.
+# JWKS documents are cached in-memory by Micronaut's JwkSetFetcher (60s);
+# for distributed caching configure a Micronaut cache named 'jwks'
+# (see libseqera micronaut-cache-redis) — CacheableJwkSetFetcher activates
+# automatically.
 #wave:
 #  auth:
 #    jwks:
 #      enabled: true
 #      path: '/.well-known/jwks.json'
-#      cache-duration: 6h
 #      refresh-min-interval: 60s
 #      clock-skew: 60s
 #      fetch-timeout: 30s
@@ -1699,7 +1250,16 @@ git commit -m "docs: JWKS auth configuration reference"
 
 ## Out of scope (deliberate)
 
-- **Platform-side work (P1–P3 in the spec):** asymmetric signing, JWKS endpoint, `iss` claim. Nothing in this plan delivers user-visible value until Platform ships those; the Wave code is flag-off inert until then.
-- **Phase 2** (identity from claims, dropping `/user-info` for verified JWTs) and **Phase 3** (`Authorization: Bearer` header migration).
-- **End-to-end integration test** with a mock Platform over a real pairing websocket: verified in staging during rollout instead; the seams are individually covered by the tests above.
-- **lib-auth-jwks release to maven.seqera.io:** follows the standard libseqera release process; the Wave PR depends on it and must not merge first (and the temporary `mavenLocal()` entry must be dropped from `build.gradle` before merge).
+- **Platform-side work (P3/P4 in the spec):** a generic token-exchange grant (or RS256
+  launch tokens) and making `TOWER_OIDC_PEM_PATH` required. The JWKS endpoint, RS256 signing
+  and `iss` claim already exist in the `platform-oidc` module. Nothing in this plan delivers
+  user-visible value until P3/P4 ship; the Wave code is flag-off inert until then.
+- **Phase 2** (identity from claims, dropping `/user-info` for verified JWTs) and **Phase 3**
+  (`Authorization: Bearer` header migration).
+- **Distributed JWKS caching:** available later by configuring a Micronaut `jwks` cache
+  (libseqera `micronaut-cache-redis`) — zero code changes, so not part of this plan.
+- **End-to-end integration test** with a mock Platform over a real pairing websocket: verified
+  in staging during rollout instead; the seams are individually covered by the tests above.
+- **lib-auth-jwks release to maven.seqera.io:** follows the standard libseqera release process;
+  the Wave PR depends on it and must not merge first (and the temporary `mavenLocal()` entry
+  must be dropped from `build.gradle` before merge).

--- a/docs/superpowers/plans/2026-07-22-jwks-multi-issuer-auth.md
+++ b/docs/superpowers/plans/2026-07-22-jwks-multi-issuer-auth.md
@@ -1,0 +1,1705 @@
+# JWKS Multi-Issuer Authentication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Local JWKS-based validation of Platform JWTs in Wave, multi-issuer, working over the pairing websocket tunnel, with the reusable core in a new libseqera module `lib-auth-jwks`.
+
+**Architecture:** A framework-free Java library (`lib-auth-jwks`, package `io.seqera.auth.jwks`) provides token inspection and JWKS verification behind two seams: `JwksFetcher` (transport) and `JwksCacheStore` (caching). Wave plugs the pairing tunnel into the fetcher seam (`TowerConnector`) and a Redis state store into the cache seam, and gates the whole thing behind `wave.auth.jwks.enabled` inside `UserServiceImpl.getUserByAccessToken` — the single choke point both `ContainerController` and `InspectController` go through. Asymmetric JWTs get verified locally; HS256 JWTs and opaque PATs continue on today's `/user-info` delegation path untouched.
+
+**Tech Stack:** Java 17 (lib main sources), Groovy/Spock (tests + Wave), `com.nimbusds:nimbus-jose-jwt:9.40`, Micronaut 4.x (Wave side only), libseqera `lib-data-store-state-redis`.
+
+**Spec:** `docs/superpowers/specs/2026-07-22-jwks-multi-issuer-auth-design.md` (in the wave repo).
+
+## Global Constraints
+
+- Tasks 1–4 run in `/Users/pditommaso/Projects/libseqera`, tasks 5–8 in `/Users/pditommaso/Projects/wave`. Commit in the repo you changed.
+- `lib-auth-jwks` must have **no Micronaut, Redis, or Wave dependency** — only `nimbus-jose-jwt` (api) and the Spock test framework that the convention plugins already provide.
+- Lib module: `group 'io.seqera'`, `VERSION` file `0.1.0`, package `io.seqera.auth.jwks`, sourceCompatibility 17 (set by conventions — don't override).
+- Copy the Apache-2.0 license header from any existing libseqera source file into every new libseqera file; copy the Wave (AGPL) header from any existing Wave source file into every new Wave file. Not repeated in the code blocks below.
+- Allowed JWT algorithms everywhere: RS256/RS384/RS512/ES256/ES384/ES512. Never `none`, never HS*.
+- Wave feature flag `wave.auth.jwks.enabled` defaults to `false` — merged code must be a no-op until enabled.
+- Config defaults (from spec): path `/.well-known/jwks.json`, cache-duration `6h`, refresh-min-interval `60s`, clock-skew `60s`, fetch-timeout `30s`.
+- Wave tests: `./gradlew test --tests '<ClassName>'`. Lib tests: `./gradlew :lib-auth-jwks:test`.
+
+---
+
+### Task 1: lib-auth-jwks module scaffold + JwtInspector
+
+**Files:**
+- Modify: `/Users/pditommaso/Projects/libseqera/settings.gradle` (add include, keep the list's rough grouping — put it after `include('lib-activator')`)
+- Create: `lib-auth-jwks/build.gradle`
+- Create: `lib-auth-jwks/VERSION`
+- Create: `lib-auth-jwks/README.md`
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/JwtInspector.java`
+- Test: `lib-auth-jwks/src/test/groovy/io/seqera/auth/jwks/JwtInspectorTest.groovy`
+
+**Interfaces:**
+- Produces: `JwtInspector.isSignedJwt(String): boolean`, `JwtInspector.isAsymmetricJwt(String): boolean` (both static, null-safe → false).
+
+- [ ] **Step 1: Register the module and create the build files**
+
+`settings.gradle` — add after `include('lib-activator')`:
+
+```gradle
+include('lib-auth-jwks')
+```
+
+`lib-auth-jwks/VERSION`:
+
+```
+0.1.0
+```
+
+`lib-auth-jwks/build.gradle` (same shape as `lib-crypto/build.gradle`):
+
+```gradle
+plugins {
+    id 'io.seqera.java-library-conventions'
+    id 'io.seqera.groovy-library-conventions'
+}
+
+group = 'io.seqera'
+version = "${project.file('VERSION').text.trim()}"
+
+dependencies {
+    api 'com.nimbusds:nimbus-jose-jwt:9.40'
+}
+```
+
+`lib-auth-jwks/README.md`:
+
+```markdown
+# lib-auth-jwks
+
+Framework-free JWKS-based JWT verification with pluggable transport and caching.
+
+Designed for services that accept JWTs from multiple dynamically-registered issuers,
+where the issuer may only be reachable over a custom channel (e.g. a reverse
+websocket tunnel). Provide a `JwksFetcher` for the transport and optionally a
+`JwksCacheStore` for distributed caching; `JwksJwtVerifier` does the rest.
+
+Entry points: `JwtInspector` (cheap token-shape checks), `JwksJwtVerifier.verify(token, expectedIssuer)`.
+```
+
+Run: `cd /Users/pditommaso/Projects/libseqera && ./gradlew :lib-auth-jwks:assemble`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 2: Write the failing test**
+
+`src/test/groovy/io/seqera/auth/jwks/JwtInspectorTest.groovy`:
+
+```groovy
+package io.seqera.auth.jwks
+
+import java.security.KeyPairGenerator
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.MACSigner
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import spock.lang.Specification
+
+class JwtInspectorTest extends Specification {
+
+    static String rs256Token() {
+        final keyPair = KeyPairGenerator.getInstance('RSA').tap { initialize(2048) }.generateKeyPair()
+        final jwt = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID('k1').build(),
+                new JWTClaimsSet.Builder().subject('user-1').build() )
+        jwt.sign(new RSASSASigner(keyPair.private))
+        return jwt.serialize()
+    }
+
+    static String hs256Token() {
+        final jwt = new SignedJWT(
+                new JWSHeader(JWSAlgorithm.HS256),
+                new JWTClaimsSet.Builder().subject('user-1').build() )
+        jwt.sign(new MACSigner(new byte[32]))
+        return jwt.serialize()
+    }
+
+    def 'should detect signed jwt' () {
+        expect:
+        JwtInspector.isSignedJwt(rs256Token())
+        JwtInspector.isSignedJwt(hs256Token())
+        !JwtInspector.isSignedJwt('eyJrandom-opaque-pat')
+        !JwtInspector.isSignedJwt('')
+        !JwtInspector.isSignedJwt(null)
+    }
+
+    def 'should detect asymmetric alg' () {
+        expect:
+        JwtInspector.isAsymmetricJwt(rs256Token())
+        !JwtInspector.isAsymmetricJwt(hs256Token())
+        !JwtInspector.isAsymmetricJwt('not-a-jwt')
+        !JwtInspector.isAsymmetricJwt(null)
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `./gradlew :lib-auth-jwks:test --tests 'JwtInspectorTest'`
+Expected: FAIL — `unable to resolve class ... JwtInspector` (compilation error counts as the failing state)
+
+- [ ] **Step 4: Write minimal implementation**
+
+`src/main/java/io/seqera/auth/jwks/JwtInspector.java`:
+
+```java
+package io.seqera.auth.jwks;
+
+import java.text.ParseException;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jwt.SignedJWT;
+
+/**
+ * Cheap, signature-free checks on the shape of a token, used to route
+ * between local JWKS verification and legacy delegation paths.
+ */
+public class JwtInspector {
+
+    public static boolean isSignedJwt(String token) {
+        if (token == null || token.isBlank())
+            return false;
+        try {
+            SignedJWT.parse(token);
+            return true;
+        }
+        catch (ParseException e) {
+            return false;
+        }
+    }
+
+    public static boolean isAsymmetricJwt(String token) {
+        if (token == null || token.isBlank())
+            return false;
+        try {
+            final JWSAlgorithm alg = SignedJWT.parse(token).getHeader().getAlgorithm();
+            return JWSAlgorithm.Family.RSA.contains(alg) || JWSAlgorithm.Family.EC.contains(alg);
+        }
+        catch (ParseException e) {
+            return false;
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./gradlew :lib-auth-jwks:test --tests 'JwtInspectorTest'`
+Expected: PASS
+
+- [ ] **Step 6: Commit (libseqera repo)**
+
+```bash
+cd /Users/pditommaso/Projects/libseqera
+git add settings.gradle lib-auth-jwks
+git commit -m "feat: add lib-auth-jwks module with JwtInspector"
+```
+
+---
+
+### Task 2: Core types — config, results, exceptions, cache store, fetcher interface
+
+**Files:**
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/JwksConfig.java`
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/VerifiedJwt.java`
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/CachedJwks.java`
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/JwksFetcher.java`
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/JwksCacheStore.java`
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/InMemoryJwksCacheStore.java`
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/exception/InvalidTokenException.java`
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/exception/UnknownIssuerException.java`
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/exception/JwksUnavailableException.java`
+- Test: `lib-auth-jwks/src/test/groovy/io/seqera/auth/jwks/InMemoryJwksCacheStoreTest.groovy`
+
+**Interfaces:**
+- Produces (used by Tasks 3, 4, and the Wave tasks):
+  - `record JwksConfig(String jwksPath, Duration cacheDuration, Duration refreshMinInterval, Duration clockSkew, Duration fetchTimeout)` + `JwksConfig.defaults()`
+  - `record VerifiedJwt(String issuer, String subject, Instant expiration, Map<String,Object> claims)`
+  - `record CachedJwks(String json, Instant createdAt)`
+  - `interface JwksFetcher { CompletableFuture<String> fetch(String endpoint); }`
+  - `interface JwksCacheStore { CachedJwks load(String endpoint); void save(String endpoint, String jwksJson); }` — `load`/`save` naming is deliberate: it avoids an erasure clash with `AbstractStateStore.get/put` in downstream implementations.
+  - Exceptions: `InvalidTokenException`, `UnknownIssuerException`, `JwksUnavailableException` — all `RuntimeException`, all with `(String)` and `(String, Throwable)` constructors.
+
+- [ ] **Step 1: Write the failing test**
+
+`src/test/groovy/io/seqera/auth/jwks/InMemoryJwksCacheStoreTest.groovy`:
+
+```groovy
+package io.seqera.auth.jwks
+
+import spock.lang.Specification
+
+class InMemoryJwksCacheStoreTest extends Specification {
+
+    def 'should save and load a jwks document' () {
+        given:
+        def store = new InMemoryJwksCacheStore()
+
+        expect:
+        store.load('https://tower.example.com') == null
+
+        when:
+        store.save('https://tower.example.com', '{"keys":[]}')
+        def entry = store.load('https://tower.example.com')
+        then:
+        entry.json() == '{"keys":[]}'
+        entry.createdAt() != null
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :lib-auth-jwks:test --tests 'InMemoryJwksCacheStoreTest'`
+Expected: FAIL (class not found)
+
+- [ ] **Step 3: Write the implementation**
+
+`JwksConfig.java`:
+
+```java
+package io.seqera.auth.jwks;
+
+import java.time.Duration;
+
+/**
+ * Settings for JWKS retrieval and JWT verification.
+ */
+public record JwksConfig(
+        String jwksPath,
+        Duration cacheDuration,
+        Duration refreshMinInterval,
+        Duration clockSkew,
+        Duration fetchTimeout )
+{
+    public static JwksConfig defaults() {
+        return new JwksConfig(
+                "/.well-known/jwks.json",
+                Duration.ofHours(6),
+                Duration.ofSeconds(60),
+                Duration.ofSeconds(60),
+                Duration.ofSeconds(30) );
+    }
+}
+```
+
+`VerifiedJwt.java`:
+
+```java
+package io.seqera.auth.jwks;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Immutable view over the claims of a successfully verified JWT.
+ */
+public record VerifiedJwt(
+        String issuer,
+        String subject,
+        Instant expiration,
+        Map<String, Object> claims ) {
+}
+```
+
+`CachedJwks.java`:
+
+```java
+package io.seqera.auth.jwks;
+
+import java.time.Instant;
+
+/**
+ * A cached JWKS document with its retrieval timestamp. Freshness is
+ * decided by the verifier, so stores may retain stale copies as a
+ * fallback for when the issuer is temporarily unreachable.
+ */
+public record CachedJwks(String json, Instant createdAt) {
+}
+```
+
+`JwksFetcher.java`:
+
+```java
+package io.seqera.auth.jwks;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Transport seam: retrieve the raw JWKS JSON document for an issuer
+ * endpoint. Implementations may use direct HTTP or any custom channel
+ * (e.g. a reverse websocket tunnel).
+ */
+public interface JwksFetcher {
+
+    CompletableFuture<String> fetch(String endpoint);
+}
+```
+
+`JwksCacheStore.java`:
+
+```java
+package io.seqera.auth.jwks;
+
+/**
+ * Caching seam for JWKS documents, keyed by issuer endpoint.
+ */
+public interface JwksCacheStore {
+
+    CachedJwks load(String endpoint);
+
+    void save(String endpoint, String jwksJson);
+}
+```
+
+`InMemoryJwksCacheStore.java`:
+
+```java
+package io.seqera.auth.jwks;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Default in-process cache. Entries are never evicted — the set of
+ * issuers a service talks to is small and bounded by design.
+ */
+public class InMemoryJwksCacheStore implements JwksCacheStore {
+
+    private final Map<String, CachedJwks> cache = new ConcurrentHashMap<>();
+
+    @Override
+    public CachedJwks load(String endpoint) {
+        return cache.get(endpoint);
+    }
+
+    @Override
+    public void save(String endpoint, String jwksJson) {
+        cache.put(endpoint, new CachedJwks(jwksJson, Instant.now()));
+    }
+}
+```
+
+`exception/InvalidTokenException.java` (repeat the same shape for the other two):
+
+```java
+package io.seqera.auth.jwks.exception;
+
+/**
+ * The token failed cryptographic or claims validation.
+ */
+public class InvalidTokenException extends RuntimeException {
+
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+
+    public InvalidTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+```
+
+`exception/UnknownIssuerException.java` — same body, class name `UnknownIssuerException`, javadoc: "The token's `iss` claim does not match the expected issuer."
+
+`exception/JwksUnavailableException.java` — same body, class name `JwksUnavailableException`, javadoc: "The JWKS document could not be retrieved and no cached copy exists."
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :lib-auth-jwks:test --tests 'InMemoryJwksCacheStoreTest'`
+Expected: PASS
+
+- [ ] **Step 5: Commit (libseqera repo)**
+
+```bash
+git add lib-auth-jwks
+git commit -m "feat: lib-auth-jwks core types, cache store and fetcher seams"
+```
+
+---
+
+### Task 3: HttpJwksFetcher (default direct-HTTP transport)
+
+**Files:**
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/HttpJwksFetcher.java`
+- Test: `lib-auth-jwks/src/test/groovy/io/seqera/auth/jwks/HttpJwksFetcherTest.groovy`
+
+**Interfaces:**
+- Consumes: `JwksFetcher`, `JwksConfig` (`jwksPath`, `fetchTimeout`), `JwksUnavailableException` (Task 2).
+- Produces: `HttpJwksFetcher(JwksConfig)` implementing `JwksFetcher`; static helper `HttpJwksFetcher.joinPath(String endpoint, String path): String`.
+
+- [ ] **Step 1: Write the failing test** (uses the JDK's built-in `HttpServer`, no new dependency)
+
+`src/test/groovy/io/seqera/auth/jwks/HttpJwksFetcherTest.groovy`:
+
+```groovy
+package io.seqera.auth.jwks
+
+import java.util.concurrent.CompletionException
+
+import com.sun.net.httpserver.HttpServer
+import io.seqera.auth.jwks.exception.JwksUnavailableException
+import spock.lang.Specification
+
+class HttpJwksFetcherTest extends Specification {
+
+    def 'should join endpoint and path' () {
+        expect:
+        HttpJwksFetcher.joinPath(endpoint, path) == expected
+
+        where:
+        endpoint                        | path                       | expected
+        'https://foo.com'               | '/.well-known/jwks.json'   | 'https://foo.com/.well-known/jwks.json'
+        'https://foo.com/'              | '/.well-known/jwks.json'   | 'https://foo.com/.well-known/jwks.json'
+        'https://foo.com'               | 'oauth/certs'              | 'https://foo.com/oauth/certs'
+    }
+
+    def 'should fetch jwks document over http' () {
+        given:
+        def server = HttpServer.create(new InetSocketAddress(0), 0)
+        server.createContext('/.well-known/jwks.json') { exchange ->
+            final body = '{"keys":[]}'.bytes
+            exchange.sendResponseHeaders(200, body.length)
+            exchange.responseBody.withCloseable { it.write(body) }
+        }
+        server.start()
+        def fetcher = new HttpJwksFetcher(JwksConfig.defaults())
+
+        expect:
+        fetcher.fetch("http://localhost:${server.address.port}").join() == '{"keys":[]}'
+
+        cleanup:
+        server.stop(0)
+    }
+
+    def 'should fail on non-200 status' () {
+        given:
+        def server = HttpServer.create(new InetSocketAddress(0), 0)
+        server.createContext('/.well-known/jwks.json') { exchange ->
+            exchange.sendResponseHeaders(404, -1)
+            exchange.close()
+        }
+        server.start()
+        def fetcher = new HttpJwksFetcher(JwksConfig.defaults())
+
+        when:
+        fetcher.fetch("http://localhost:${server.address.port}").join()
+        then:
+        def e = thrown(CompletionException)
+        e.cause instanceof JwksUnavailableException
+
+        cleanup:
+        server.stop(0)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :lib-auth-jwks:test --tests 'HttpJwksFetcherTest'`
+Expected: FAIL (class not found)
+
+- [ ] **Step 3: Write the implementation**
+
+`HttpJwksFetcher.java`:
+
+```java
+package io.seqera.auth.jwks;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import io.seqera.auth.jwks.exception.JwksUnavailableException;
+
+/**
+ * Default {@link JwksFetcher} performing a plain HTTP GET against the
+ * issuer endpoint. Suitable when the issuer is directly reachable.
+ */
+public class HttpJwksFetcher implements JwksFetcher {
+
+    private final HttpClient client;
+    private final JwksConfig config;
+
+    public HttpJwksFetcher(JwksConfig config) {
+        this.config = config;
+        this.client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
+    }
+
+    @Override
+    public CompletableFuture<String> fetch(String endpoint) {
+        final String target = joinPath(endpoint, config.jwksPath());
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(target))
+                .GET()
+                .timeout(config.fetchTimeout())
+                .build();
+        return client
+                .sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenApply(resp -> {
+                    if (resp.statusCode() == 200)
+                        return resp.body();
+                    throw new JwksUnavailableException("Unexpected status " + resp.statusCode() + " fetching JWKS from " + target);
+                });
+    }
+
+    static String joinPath(String endpoint, String path) {
+        final String base = endpoint.replaceAll("/+$", "");
+        return path.startsWith("/") ? base + path : base + "/" + path;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :lib-auth-jwks:test --tests 'HttpJwksFetcherTest'`
+Expected: PASS
+
+- [ ] **Step 5: Commit (libseqera repo)**
+
+```bash
+git add lib-auth-jwks
+git commit -m "feat: lib-auth-jwks default HTTP fetcher"
+```
+
+---
+
+### Task 4: JwksJwtVerifier — the verification engine
+
+**Files:**
+- Create: `lib-auth-jwks/src/main/java/io/seqera/auth/jwks/JwksJwtVerifier.java`
+- Create: `lib-auth-jwks/changelog.txt`
+- Test: `lib-auth-jwks/src/test/groovy/io/seqera/auth/jwks/JwksJwtVerifierTest.groovy`
+
+**Interfaces:**
+- Consumes: everything from Tasks 2–3.
+- Produces: `JwksJwtVerifier(JwksFetcher, JwksCacheStore, JwksConfig)`; `VerifiedJwt verify(String token, String expectedIssuer)` throwing `InvalidTokenException` / `UnknownIssuerException` / `JwksUnavailableException`; static `String normalizeIssuer(String)`.
+
+**Behavior spec (mirrors the design doc):**
+1. Parse token; non-JWT or disallowed alg → `InvalidTokenException`.
+2. Load JWKS for the normalized issuer endpoint: fresh cache hit → use it; stale or missing → fetch; fetch failure with any cached copy → use the stale copy; fetch failure with no copy → `JwksUnavailableException`.
+3. Token `kid` absent from the key set → rate-limited re-fetch (min interval `refreshMinInterval`, per endpoint), then proceed with whatever key set we have.
+4. Verify signature + `exp`/`nbf` (clock skew from config) via Nimbus `DefaultJWTProcessor`; failures → `InvalidTokenException`.
+5. Compare `normalizeIssuer(iss claim)` with `normalizeIssuer(expectedIssuer)`; mismatch or missing → `UnknownIssuerException`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/test/groovy/io/seqera/auth/jwks/JwksJwtVerifierTest.groovy`:
+
+```groovy
+package io.seqera.auth.jwks
+
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import io.seqera.auth.jwks.exception.InvalidTokenException
+import io.seqera.auth.jwks.exception.JwksUnavailableException
+import io.seqera.auth.jwks.exception.UnknownIssuerException
+import spock.lang.Shared
+import spock.lang.Specification
+
+class JwksJwtVerifierTest extends Specification {
+
+    static final String ISSUER = 'https://tower.example.com'
+
+    @Shared RSAKey keyA
+    @Shared RSAKey keyB
+    @Shared String jwksA
+    @Shared String jwksB
+
+    def setupSpec() {
+        keyA = new RSAKeyGenerator(2048).keyID('key-a').generate()
+        keyB = new RSAKeyGenerator(2048).keyID('key-b').generate()
+        jwksA = new JWKSet(keyA.toPublicJWK()).toString()
+        jwksB = new JWKSet(keyB.toPublicJWK()).toString()
+    }
+
+    static String token(RSAKey key, Map opts = [:]) {
+        final claims = new JWTClaimsSet.Builder()
+                .issuer((String) opts.getOrDefault('iss', ISSUER))
+                .subject('user-123')
+                .expirationTime(new Date(System.currentTimeMillis() + (long) opts.getOrDefault('ttlMillis', 60_000L)))
+                .build()
+        final jwt = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(key.keyID).build(),
+                claims )
+        jwt.sign(new RSASSASigner(key))
+        return jwt.serialize()
+    }
+
+    static JwksFetcher fetcherOf(String... responses) {
+        final count = new AtomicInteger()
+        return { endpoint ->
+            final i = Math.min(count.getAndIncrement(), responses.length - 1)
+            final r = responses[i]
+            r == null
+                    ? CompletableFuture.<String>failedFuture(new JwksUnavailableException('boom'))
+                    : CompletableFuture.completedFuture(r)
+        } as JwksFetcher
+    }
+
+    static JwksConfig config(Map opts = [:]) {
+        new JwksConfig(
+                '/.well-known/jwks.json',
+                (Duration) opts.getOrDefault('cacheDuration', Duration.ofHours(6)),
+                (Duration) opts.getOrDefault('refreshMinInterval', Duration.ofSeconds(60)),
+                Duration.ofSeconds(60),
+                Duration.ofSeconds(5) )
+    }
+
+    def 'should verify a valid token' () {
+        given:
+        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
+
+        when:
+        def result = verifier.verify(token(keyA), ISSUER)
+        then:
+        result.issuer() == ISSUER
+        result.subject() == 'user-123'
+        result.expiration() != null
+    }
+
+    def 'should accept issuer with cosmetic differences' () {
+        given:
+        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
+
+        expect:
+        verifier.verify(token(keyA), 'HTTPS://Tower.Example.Com/').subject() == 'user-123'
+    }
+
+    def 'should reject a token signed by an unknown key' () {
+        given: 'the JWKS only contains key-a but the token is signed with key-b'
+        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
+
+        when:
+        verifier.verify(token(keyB), ISSUER)
+        then:
+        thrown(InvalidTokenException)
+    }
+
+    def 'should reject a tampered token' () {
+        given:
+        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
+        def parts = token(keyA).tokenize('.')
+        def tampered = parts[0] + '.' + Base64.urlEncoder.withoutPadding().encodeToString('{"sub":"evil"}'.bytes) + '.' + parts[2]
+
+        when:
+        verifier.verify(tampered, ISSUER)
+        then:
+        thrown(InvalidTokenException)
+    }
+
+    def 'should reject an expired token' () {
+        given:
+        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
+
+        when: 'expired well beyond the 60s clock skew'
+        verifier.verify(token(keyA, ttlMillis: -120_000L), ISSUER)
+        then:
+        thrown(InvalidTokenException)
+    }
+
+    def 'should reject a wrong issuer' () {
+        given:
+        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
+
+        when:
+        verifier.verify(token(keyA, iss: 'https://evil.example.com'), ISSUER)
+        then:
+        thrown(UnknownIssuerException)
+    }
+
+    def 'should reject symmetric and unsupported algorithms' () {
+        given:
+        def verifier = new JwksJwtVerifier(fetcherOf(jwksA), new InMemoryJwksCacheStore(), config())
+
+        when:
+        verifier.verify(JwtInspectorTest.hs256Token(), ISSUER)
+        then:
+        thrown(InvalidTokenException)
+    }
+
+    def 'should refetch jwks on unknown kid' () {
+        given: 'first fetch returns the old key set, second fetch the rotated one'
+        def verifier = new JwksJwtVerifier(
+                fetcherOf(jwksA, jwksB),
+                new InMemoryJwksCacheStore(),
+                config(refreshMinInterval: Duration.ZERO) )
+
+        expect: 'prime the cache with key-a'
+        verifier.verify(token(keyA), ISSUER)
+
+        and: 'a token signed with rotated key-b triggers a refetch and verifies'
+        verifier.verify(token(keyB), ISSUER).subject() == 'user-123'
+    }
+
+    def 'should rate-limit refetch on unknown kid' () {
+        given: 'a fetcher that always returns the OLD key set, counting invocations'
+        def count = new AtomicInteger()
+        def fetcher = { String ep ->
+            count.incrementAndGet()
+            CompletableFuture.completedFuture(jwksA)
+        } as JwksFetcher
+        def verifier = new JwksJwtVerifier(
+                fetcher,
+                new InMemoryJwksCacheStore(),
+                config(refreshMinInterval: Duration.ofHours(1)) )
+        verifier.verify(token(keyA), ISSUER)   // initial fetch (#1)
+
+        when: 'two consecutive unknown-kid misses'
+        try { verifier.verify(token(keyB), ISSUER) } catch (InvalidTokenException ignored) { }
+        try { verifier.verify(token(keyB), ISSUER) } catch (InvalidTokenException ignored) { }
+        then: 'only one refetch happened — the second miss was throttled'
+        count.get() == 2
+    }
+
+    def 'should fall back to stale cache when fetch fails' () {
+        given: 'cache duration zero means every hit is stale; second fetch fails'
+        def verifier = new JwksJwtVerifier(
+                fetcherOf(jwksA, null),
+                new InMemoryJwksCacheStore(),
+                config(cacheDuration: Duration.ZERO) )
+        verifier.verify(token(keyA), ISSUER)
+
+        expect: 'still verifies using the stale cached copy'
+        verifier.verify(token(keyA), ISSUER).subject() == 'user-123'
+    }
+
+    def 'should fail when fetch fails and no cache exists' () {
+        given:
+        def verifier = new JwksJwtVerifier(fetcherOf(null), new InMemoryJwksCacheStore(), config())
+
+        when:
+        verifier.verify(token(keyA), ISSUER)
+        then:
+        thrown(JwksUnavailableException)
+    }
+
+    def 'should normalize issuer urls' () {
+        expect:
+        JwksJwtVerifier.normalizeIssuer(input) == expected
+
+        where:
+        input                             | expected
+        'https://tower.example.com'       | 'https://tower.example.com'
+        'https://tower.example.com/'      | 'https://tower.example.com'
+        'HTTPS://Tower.Example.COM//'     | 'https://tower.example.com'
+        'https://foo.com/API/'            | 'https://foo.com/API'
+        null                              | null
+    }
+}
+```
+
+Note: in the rate-limit test both misses throw `InvalidTokenException` (the key set never contains `key-b`); the assertion is on the fetch count — initial fetch plus exactly one refetch, the second miss being inside the min interval.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./gradlew :lib-auth-jwks:test --tests 'JwksJwtVerifierTest'`
+Expected: FAIL (class not found)
+
+- [ ] **Step 3: Write the implementation**
+
+`JwksJwtVerifier.java`:
+
+```java
+package io.seqera.auth.jwks;
+
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import io.seqera.auth.jwks.exception.InvalidTokenException;
+import io.seqera.auth.jwks.exception.JwksUnavailableException;
+import io.seqera.auth.jwks.exception.UnknownIssuerException;
+
+/**
+ * Verifies JWTs against the JWKS document of a dynamically-resolved issuer.
+ *
+ * The issuer's JWKS is retrieved through the pluggable {@link JwksFetcher}
+ * and cached in the pluggable {@link JwksCacheStore}. An unknown {@code kid}
+ * triggers a rate-limited re-fetch to pick up key rotation; a fetch failure
+ * falls back to the last cached copy when one exists.
+ */
+public class JwksJwtVerifier {
+
+    static final Set<JWSAlgorithm> ALLOWED_ALGS = Set.of(
+            JWSAlgorithm.RS256, JWSAlgorithm.RS384, JWSAlgorithm.RS512,
+            JWSAlgorithm.ES256, JWSAlgorithm.ES384, JWSAlgorithm.ES512 );
+
+    private final JwksFetcher fetcher;
+    private final JwksCacheStore cache;
+    private final JwksConfig config;
+    private final Map<String, Instant> lastRefresh = new ConcurrentHashMap<>();
+
+    public JwksJwtVerifier(JwksFetcher fetcher, JwksCacheStore cache, JwksConfig config) {
+        this.fetcher = fetcher;
+        this.cache = cache;
+        this.config = config;
+    }
+
+    public VerifiedJwt verify(String token, String expectedIssuer) {
+        final SignedJWT jwt = parse(token);
+        final JWSAlgorithm alg = jwt.getHeader().getAlgorithm();
+        if (!ALLOWED_ALGS.contains(alg))
+            throw new InvalidTokenException("Unsupported JWT signature algorithm: " + alg);
+
+        final String issuer = normalizeIssuer(expectedIssuer);
+        JWKSet jwks = loadJwks(issuer);
+        final String kid = jwt.getHeader().getKeyID();
+        if (kid != null && jwks.getKeyByKeyId(kid) == null)
+            jwks = refreshJwks(issuer, jwks);
+
+        final JWTClaimsSet claims = process(jwt, jwks);
+        final String iss = claims.getIssuer();
+        if (iss == null || !normalizeIssuer(iss).equals(issuer))
+            throw new UnknownIssuerException("JWT issuer '" + iss + "' does not match expected issuer '" + expectedIssuer + "'");
+
+        return new VerifiedJwt(
+                iss,
+                claims.getSubject(),
+                claims.getExpirationTime() != null ? claims.getExpirationTime().toInstant() : null,
+                claims.getClaims() );
+    }
+
+    private SignedJWT parse(String token) {
+        try {
+            return SignedJWT.parse(token);
+        }
+        catch (ParseException e) {
+            throw new InvalidTokenException("Malformed JWT token", e);
+        }
+    }
+
+    private JWKSet loadJwks(String endpoint) {
+        final CachedJwks cached = cache.load(endpoint);
+        final boolean fresh = cached != null
+                && cached.createdAt().plus(config.cacheDuration()).isAfter(Instant.now());
+        if (fresh)
+            return parseJwks(cached.json());
+        try {
+            return fetchAndStore(endpoint);
+        }
+        catch (JwksUnavailableException e) {
+            if (cached != null)
+                return parseJwks(cached.json());   // stale fallback
+            throw e;
+        }
+    }
+
+    private JWKSet refreshJwks(String endpoint, JWKSet current) {
+        final Instant last = lastRefresh.get(endpoint);
+        if (last != null && last.plus(config.refreshMinInterval()).isAfter(Instant.now()))
+            return current;    // rate limited — keep the current key set
+        lastRefresh.put(endpoint, Instant.now());
+        try {
+            return fetchAndStore(endpoint);
+        }
+        catch (JwksUnavailableException e) {
+            return current;
+        }
+    }
+
+    private JWKSet fetchAndStore(String endpoint) {
+        final String json;
+        try {
+            json = fetcher.fetch(endpoint).get(config.fetchTimeout().toMillis(), TimeUnit.MILLISECONDS);
+        }
+        catch (ExecutionException e) {
+            if (e.getCause() instanceof JwksUnavailableException cause)
+                throw cause;
+            throw new JwksUnavailableException("Failed to fetch JWKS from " + endpoint, e.getCause());
+        }
+        catch (Exception e) {
+            if (e instanceof InterruptedException)
+                Thread.currentThread().interrupt();
+            throw new JwksUnavailableException("Failed to fetch JWKS from " + endpoint, e);
+        }
+        cache.save(endpoint, json);
+        return parseJwks(json);
+    }
+
+    private JWKSet parseJwks(String json) {
+        try {
+            return JWKSet.parse(json);
+        }
+        catch (ParseException e) {
+            throw new JwksUnavailableException("Malformed JWKS document", e);
+        }
+    }
+
+    private JWTClaimsSet process(SignedJWT jwt, JWKSet jwks) {
+        try {
+            final DefaultJWTProcessor<SecurityContext> processor = new DefaultJWTProcessor<>();
+            processor.setJWSKeySelector(new JWSVerificationKeySelector<>(ALLOWED_ALGS, new ImmutableJWKSet<>(jwks)));
+            final DefaultJWTClaimsVerifier<SecurityContext> claimsVerifier = new DefaultJWTClaimsVerifier<>(null, Set.of("exp"));
+            claimsVerifier.setMaxClockSkew((int) config.clockSkew().toSeconds());
+            processor.setJWTClaimsSetVerifier(claimsVerifier);
+            return processor.process(jwt, null);
+        }
+        catch (BadJOSEException | JOSEException e) {
+            throw new InvalidTokenException("JWT validation failed - cause: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Normalize an issuer/endpoint URL for comparison: trim, drop trailing
+     * slashes, lower-case the scheme and host (path is case-sensitive).
+     */
+    public static String normalizeIssuer(String endpoint) {
+        if (endpoint == null)
+            return null;
+        String result = endpoint.trim().replaceAll("/+$", "");
+        final int sep = result.indexOf("://");
+        if (sep != -1) {
+            final int pathStart = result.indexOf('/', sep + 3);
+            final String head = pathStart == -1 ? result : result.substring(0, pathStart);
+            final String tail = pathStart == -1 ? "" : result.substring(pathStart);
+            result = head.toLowerCase() + tail;
+        }
+        return result;
+    }
+}
+```
+
+`lib-auth-jwks/changelog.txt`:
+
+```
+0.1.0 - <today's date>
+- Initial release: JwksJwtVerifier, JwtInspector, HttpJwksFetcher, pluggable JwksFetcher/JwksCacheStore seams
+```
+
+- [ ] **Step 4: Run the full module test suite**
+
+Run: `./gradlew :lib-auth-jwks:test`
+Expected: PASS (all specs)
+
+- [ ] **Step 5: Publish to maven local for the Wave tasks**
+
+Run: `./gradlew :lib-auth-jwks:publishToMavenLocal`
+Expected: BUILD SUCCESSFUL. (The final Wave release requires `lib-auth-jwks:0.1.0` published to maven.seqera.io via the libseqera release process — same as every other lib bump; the Wave PR must not merge before that.)
+
+- [ ] **Step 6: Commit (libseqera repo)**
+
+```bash
+git add lib-auth-jwks
+git commit -m "feat: lib-auth-jwks JWKS-based JWT verifier"
+```
+
+---
+
+### Task 5: Wave — dependency + PairingJwksFetcher (JWKS over the pairing tunnel)
+
+**Files:**
+- Modify: `/Users/pditommaso/Projects/wave/build.gradle` (dependencies block, next to the other `io.seqera:` entries around line 48; repositories block at line 22 for local dev only)
+- Create: `src/main/groovy/io/seqera/wave/auth/JwksAuthConfig.groovy`
+- Create: `src/main/groovy/io/seqera/wave/auth/PairingJwksFetcher.groovy`
+- Test: `src/test/groovy/io/seqera/wave/auth/PairingJwksFetcherTest.groovy`
+
+**Interfaces:**
+- Consumes: `JwksFetcher`, `JwksUnavailableException`, `JwksConfig` (lib); `TowerConnector.sendAsync(String endpoint, ProxyHttpRequest): CompletableFuture<ProxyHttpResponse>` (existing, `TowerConnector.groovy:322`); `io.seqera.service.pairing.socket.msg.ProxyHttpRequest` (fields: `msgId`, `method`, `uri`, `auth`, `body`, `headers`); `static io.seqera.random.LongRndKey.rndHex` (same import `TowerConnector.groovy:54` uses).
+- Produces: `JwksAuthConfig` bean (fields `enabled`, `path`, `cacheDuration`, `refreshMinInterval`, `clockSkew`, `fetchTimeout`; method `toJwksConfig(): JwksConfig`); `PairingJwksFetcher implements JwksFetcher`.
+
+- [ ] **Step 1: Add the dependency**
+
+In `build.gradle` dependencies, after `implementation 'io.seqera:lib-pairing:1.0.0'`:
+
+```gradle
+implementation 'io.seqera:lib-auth-jwks:0.1.0'
+```
+
+For local development only (NOT to be committed if the team prefers otherwise — check before merging), add `mavenLocal()` as the FIRST entry of the `repositories` block so the locally-published `0.1.0` resolves:
+
+```gradle
+repositories {
+    mavenLocal()
+    mavenCentral()
+    ...
+}
+```
+
+Run: `cd /Users/pditommaso/Projects/wave && ./gradlew compileGroovy`
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 2: Write the failing test**
+
+`src/test/groovy/io/seqera/wave/auth/PairingJwksFetcherTest.groovy` (copy the Wave license header):
+
+```groovy
+package io.seqera.wave.auth
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+
+import io.seqera.auth.jwks.exception.JwksUnavailableException
+import io.seqera.service.pairing.socket.msg.ProxyHttpRequest
+import io.seqera.service.pairing.socket.msg.ProxyHttpResponse
+import io.seqera.wave.tower.client.connector.TowerConnector
+import spock.lang.Specification
+
+class PairingJwksFetcherTest extends Specification {
+
+    def 'should fetch jwks via the tower connector' () {
+        given:
+        def connector = Mock(TowerConnector)
+        def config = new JwksAuthConfig(path: '/.well-known/jwks.json')
+        def fetcher = new PairingJwksFetcher(connector, config)
+
+        when:
+        def result = fetcher.fetch('https://tower.example.com/').join()
+        then:
+        1 * connector.sendAsync('https://tower.example.com/', _ as ProxyHttpRequest) >> { String ep, ProxyHttpRequest req ->
+            assert req.uri == 'https://tower.example.com/.well-known/jwks.json'
+            assert req.method == 'GET'
+            assert req.auth == null
+            assert req.msgId
+            CompletableFuture.completedFuture(new ProxyHttpResponse(msgId: req.msgId, status: 200, body: '{"keys":[]}'))
+        }
+        result == '{"keys":[]}'
+    }
+
+    def 'should fail on non-200 response' () {
+        given:
+        def connector = Mock(TowerConnector) {
+            sendAsync(_, _) >> CompletableFuture.completedFuture(new ProxyHttpResponse(msgId: 'x', status: 404, body: null))
+        }
+        def fetcher = new PairingJwksFetcher(connector, new JwksAuthConfig(path: '/.well-known/jwks.json'))
+
+        when:
+        fetcher.fetch('https://tower.example.com').join()
+        then:
+        def e = thrown(CompletionException)
+        e.cause instanceof JwksUnavailableException
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `./gradlew test --tests 'PairingJwksFetcherTest'`
+Expected: FAIL (classes not found)
+
+- [ ] **Step 4: Write the implementation**
+
+`src/main/groovy/io/seqera/wave/auth/JwksAuthConfig.groovy`:
+
+```groovy
+package io.seqera.wave.auth
+
+import java.time.Duration
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.Value
+import io.seqera.auth.jwks.JwksConfig
+import jakarta.inject.Singleton
+
+/**
+ * Configuration for JWKS-based validation of Platform JWT tokens.
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Singleton
+@CompileStatic
+class JwksAuthConfig {
+
+    /**
+     * When {@code false} (default) all tokens follow the legacy delegation
+     * path and JWKS validation is never attempted.
+     */
+    @Value('${wave.auth.jwks.enabled:false}')
+    boolean enabled
+
+    @Value('${wave.auth.jwks.path:`/.well-known/jwks.json`}')
+    String path
+
+    @Value('${wave.auth.jwks.cache-duration:6h}')
+    Duration cacheDuration
+
+    @Value('${wave.auth.jwks.refresh-min-interval:60s}')
+    Duration refreshMinInterval
+
+    @Value('${wave.auth.jwks.clock-skew:60s}')
+    Duration clockSkew
+
+    @Value('${wave.auth.jwks.fetch-timeout:30s}')
+    Duration fetchTimeout
+
+    JwksConfig toJwksConfig() {
+        return new JwksConfig(path, cacheDuration, refreshMinInterval, clockSkew, fetchTimeout)
+    }
+}
+```
+
+`src/main/groovy/io/seqera/wave/auth/PairingJwksFetcher.groovy`:
+
+```groovy
+package io.seqera.wave.auth
+
+import java.util.concurrent.CompletableFuture
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.seqera.auth.jwks.JwksFetcher
+import io.seqera.auth.jwks.exception.JwksUnavailableException
+import io.seqera.service.pairing.socket.msg.ProxyHttpRequest
+import io.seqera.service.pairing.socket.msg.ProxyHttpResponse
+import io.seqera.wave.tower.client.connector.TowerConnector
+import jakarta.inject.Singleton
+
+import static io.seqera.random.LongRndKey.rndHex
+
+/**
+ * Retrieves a Platform JWKS document through the Tower connector, i.e.
+ * over the pairing websocket tunnel (or direct HTTP when the legacy
+ * connector is active). This is what makes JWKS work for Platform
+ * instances behind private networks.
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Slf4j
+@Singleton
+@CompileStatic
+class PairingJwksFetcher implements JwksFetcher {
+
+    private final TowerConnector connector
+    private final JwksAuthConfig config
+
+    PairingJwksFetcher(TowerConnector connector, JwksAuthConfig config) {
+        this.connector = connector
+        this.config = config
+    }
+
+    @Override
+    CompletableFuture<String> fetch(String endpoint) {
+        final uri = endpoint.replaceAll('/+$', '') + (config.path.startsWith('/') ? config.path : '/' + config.path)
+        final request = new ProxyHttpRequest(
+                msgId: rndHex(),
+                method: 'GET',
+                uri: uri )
+        log.debug "Fetching JWKS document from '$uri'"
+        return connector
+                .sendAsync(endpoint, request)
+                .thenApply { ProxyHttpResponse resp ->
+                    if( resp.status == 200 )
+                        return resp.body
+                    throw new JwksUnavailableException("Unexpected status ${resp.status} fetching JWKS from '$uri'")
+                }
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./gradlew test --tests 'PairingJwksFetcherTest'`
+Expected: PASS
+
+- [ ] **Step 6: Commit (wave repo)**
+
+```bash
+cd /Users/pditommaso/Projects/wave
+git add build.gradle src/main/groovy/io/seqera/wave/auth src/test/groovy/io/seqera/wave/auth
+git commit -m "feat: JWKS fetcher over the pairing channel and jwks auth config"
+```
+
+---
+
+### Task 6: Wave — Redis-backed JWKS cache store
+
+**Files:**
+- Create: `src/main/groovy/io/seqera/wave/auth/JwksEntry.groovy`
+- Create: `src/main/groovy/io/seqera/wave/auth/RedisJwksCacheStore.groovy`
+- Test: `src/test/groovy/io/seqera/wave/auth/RedisJwksCacheStoreTest.groovy`
+
+**Interfaces:**
+- Consumes: `JwksCacheStore`/`CachedJwks` (lib); `io.seqera.data.store.state.AbstractStateStore` + `io.seqera.data.store.state.impl.StateProvider` and `io.seqera.serde.moshi.MoshiEncodeStrategy` (same pattern as `JwtAuthStore.groovy:34-51`).
+- Produces: `RedisJwksCacheStore` bean implementing `JwksCacheStore` (note: `load`/`save` interface names deliberately avoid clashing with `AbstractStateStore.get/put`). Redis prefix `jwks-cache/v1`, retention 7 days (freshness within the retention window is decided by the verifier's `cacheDuration`).
+
+- [ ] **Step 1: Write the failing test** (`@MicronautTest` resolves the local `StateProvider` when Redis is absent — same approach as other Wave state-store tests)
+
+`src/test/groovy/io/seqera/wave/auth/RedisJwksCacheStoreTest.groovy`:
+
+```groovy
+package io.seqera.wave.auth
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class RedisJwksCacheStoreTest extends Specification {
+
+    @Inject
+    RedisJwksCacheStore store
+
+    def 'should save and load a jwks document' () {
+        expect:
+        store.load('https://tower.example.com') == null
+
+        when:
+        store.save('https://tower.example.com', '{"keys":[]}')
+        def entry = store.load('https://tower.example.com')
+        then:
+        entry.json() == '{"keys":[]}'
+        entry.createdAt() != null
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests 'RedisJwksCacheStoreTest'`
+Expected: FAIL (class not found)
+
+- [ ] **Step 3: Write the implementation**
+
+`src/main/groovy/io/seqera/wave/auth/JwksEntry.groovy`:
+
+```groovy
+package io.seqera.wave.auth
+
+import java.time.Instant
+
+import groovy.transform.Canonical
+import groovy.transform.CompileStatic
+
+/**
+ * Serializable state-store entry holding a cached JWKS document.
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Canonical
+@CompileStatic
+class JwksEntry {
+    String json
+    Instant createdAt
+}
+```
+
+`src/main/groovy/io/seqera/wave/auth/RedisJwksCacheStore.groovy`:
+
+```groovy
+package io.seqera.wave.auth
+
+import java.time.Duration
+import java.time.Instant
+
+import groovy.transform.CompileStatic
+import io.seqera.auth.jwks.CachedJwks
+import io.seqera.auth.jwks.JwksCacheStore
+import io.seqera.data.store.state.AbstractStateStore
+import io.seqera.data.store.state.impl.StateProvider
+import io.seqera.serde.moshi.MoshiEncodeStrategy
+import jakarta.inject.Singleton
+
+/**
+ * JWKS cache backed by the Wave state store (Redis in production, local
+ * in dev), so all replicas share fetched key sets and retain stale
+ * copies for fallback when the issuer is unreachable.
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Singleton
+@CompileStatic
+class RedisJwksCacheStore extends AbstractStateStore<JwksEntry> implements JwksCacheStore {
+
+    RedisJwksCacheStore(StateProvider<String,String> provider) {
+        super(provider, new MoshiEncodeStrategy<JwksEntry>() {})
+    }
+
+    @Override
+    protected String getPrefix() {
+        return 'jwks-cache/v1'
+    }
+
+    /**
+     * Retention, not freshness: the verifier treats entries older than its
+     * configured cache-duration as stale but may still use them as a
+     * fallback when the issuer cannot be reached.
+     */
+    @Override
+    protected Duration getDuration() {
+        return Duration.ofDays(7)
+    }
+
+    @Override
+    CachedJwks load(String endpoint) {
+        final entry = get(endpoint)
+        return entry ? new CachedJwks(entry.json, entry.createdAt) : null
+    }
+
+    @Override
+    void save(String endpoint, String jwksJson) {
+        put(endpoint, new JwksEntry(jwksJson, Instant.now()))
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew test --tests 'RedisJwksCacheStoreTest'`
+Expected: PASS
+
+- [ ] **Step 5: Commit (wave repo)**
+
+```bash
+git add src/main/groovy/io/seqera/wave/auth src/test/groovy/io/seqera/wave/auth
+git commit -m "feat: Redis-backed JWKS cache store"
+```
+
+---
+
+### Task 7: Wave — verifier bean + UserServiceImpl wiring (the flag-gated dual path)
+
+**Files:**
+- Create: `src/main/groovy/io/seqera/wave/auth/JwksAuthFactory.groovy`
+- Modify: `src/main/groovy/io/seqera/wave/service/UserServiceImpl.groovy` (whole class shown below)
+- Test: `src/test/groovy/io/seqera/wave/service/UserServiceImplJwksTest.groovy`
+
+**Interfaces:**
+- Consumes: `JwksJwtVerifier`, `JwtInspector`, lib exceptions; `JwksAuthConfig` (Task 5), `PairingJwksFetcher` (Task 5), `RedisJwksCacheStore` (Task 6); existing `TowerClient.userInfo(String, JwtAuth)` and `UnauthorizedException`.
+- Produces: `JwksJwtVerifier` singleton bean; the dual-path behavior in `UserServiceImpl.getUserByAccessToken` — the ONLY behavioral change in Wave, covering both `ContainerController` and `InspectController` since both resolve identity through this method.
+
+- [ ] **Step 1: Write the failing test**
+
+`src/test/groovy/io/seqera/wave/service/UserServiceImplJwksTest.groovy` — uses Groovy direct field access (`service.@field`) to inject stubs without refactoring the service:
+
+```groovy
+package io.seqera.wave.service
+
+import io.seqera.auth.jwks.JwksJwtVerifier
+import io.seqera.auth.jwks.VerifiedJwt
+import io.seqera.auth.jwks.exception.InvalidTokenException
+import io.seqera.auth.jwks.exception.JwksUnavailableException
+import io.seqera.wave.auth.JwksAuthConfig
+import io.seqera.wave.exception.UnauthorizedException
+import io.seqera.wave.tower.User
+import io.seqera.wave.tower.auth.JwtAuth
+import io.seqera.wave.tower.client.TowerClient
+import io.seqera.wave.tower.client.GetUserInfoResponse
+import spock.lang.Specification
+
+import java.security.KeyPairGenerator
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+
+class UserServiceImplJwksTest extends Specification {
+
+    // a structurally valid RS256 JWT (not verifiable — only parsed by JwtInspector)
+    static final String RS256_TOKEN = rs256Token()
+    static final String ENDPOINT = 'https://tower.example.com'
+
+    static String rs256Token() {
+        final keyPair = KeyPairGenerator.getInstance('RSA').tap { initialize(2048) }.generateKeyPair()
+        final jwt = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID('k1').build(),
+                new JWTClaimsSet.Builder().subject('user-1').build() )
+        jwt.sign(new RSASSASigner(keyPair.private))
+        return jwt.serialize()
+    }
+
+    static JwtAuth auth(String token) {
+        // positional @Canonical constructor: (key, endpoint, bearer, refresh, createdAt, updatedAt)
+        return new JwtAuth('test-key', ENDPOINT, token)
+    }
+
+    private UserServiceImpl service(Map opts) {
+        final result = new UserServiceImpl()
+        result.@towerClient = opts.towerClient as TowerClient
+        result.@jwksConfig = opts.config as JwksAuthConfig
+        result.@jwksVerifier = opts.verifier as JwksJwtVerifier
+        return result
+    }
+
+    def 'should verify asymmetric jwt via jwks when enabled' () {
+        given:
+        def verifier = Mock(JwksJwtVerifier)
+        def towerClient = Mock(TowerClient)
+        def srv = service(config: new JwksAuthConfig(enabled: true), verifier: verifier, towerClient: towerClient)
+
+        when:
+        def user = srv.getUserByAccessToken(ENDPOINT, auth(RS256_TOKEN))
+        then:
+        1 * verifier.verify(RS256_TOKEN, ENDPOINT) >> new VerifiedJwt(ENDPOINT, 'user-123', null, [:])
+        1 * towerClient.userInfo(ENDPOINT, _) >> new GetUserInfoResponse(user: new User(id: 1))
+        user.id == 1
+    }
+
+    def 'should reject invalid jwt when enabled' () {
+        given:
+        def verifier = Mock(JwksJwtVerifier) {
+            verify(_, _) >> { throw new InvalidTokenException('bad signature') }
+        }
+        def towerClient = Mock(TowerClient)
+        def srv = service(config: new JwksAuthConfig(enabled: true), verifier: verifier, towerClient: towerClient)
+
+        when:
+        srv.getUserByAccessToken(ENDPOINT, auth(RS256_TOKEN))
+        then:
+        thrown(UnauthorizedException)
+        0 * towerClient.userInfo(_, _)
+    }
+
+    def 'should reject when jwks is unavailable and token is asymmetric jwt' () {
+        given:
+        def verifier = Mock(JwksJwtVerifier) {
+            verify(_, _) >> { throw new JwksUnavailableException('no route') }
+        }
+        def towerClient = Mock(TowerClient)
+        def srv = service(config: new JwksAuthConfig(enabled: true), verifier: verifier, towerClient: towerClient)
+
+        when:
+        srv.getUserByAccessToken(ENDPOINT, auth(RS256_TOKEN))
+        then:
+        thrown(UnauthorizedException)
+        0 * towerClient.userInfo(_, _)
+    }
+
+    def 'should skip jwks for opaque tokens even when enabled' () {
+        given:
+        def verifier = Mock(JwksJwtVerifier)
+        def towerClient = Mock(TowerClient)
+        def srv = service(config: new JwksAuthConfig(enabled: true), verifier: verifier, towerClient: towerClient)
+
+        when:
+        def user = srv.getUserByAccessToken(ENDPOINT, auth('opaque-personal-access-token'))
+        then:
+        0 * verifier.verify(_, _)
+        1 * towerClient.userInfo(ENDPOINT, _) >> new GetUserInfoResponse(user: new User(id: 2))
+        user.id == 2
+    }
+
+    def 'should skip jwks when disabled' () {
+        given:
+        def verifier = Mock(JwksJwtVerifier)
+        def towerClient = Mock(TowerClient)
+        def srv = service(config: new JwksAuthConfig(enabled: false), verifier: verifier, towerClient: towerClient)
+
+        when:
+        srv.getUserByAccessToken(ENDPOINT, auth(RS256_TOKEN))
+        then:
+        0 * verifier.verify(_, _)
+        1 * towerClient.userInfo(ENDPOINT, _) >> new GetUserInfoResponse(user: new User(id: 3))
+    }
+}
+```
+
+Note: `GetUserInfoResponse` is the actual return type of `TowerClient.userInfo` (see `TowerClient.groovy:70`); the `rs256Token()` helper is inlined because the lib's test classes are not on Wave's test classpath.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests 'UserServiceImplJwksTest'`
+Expected: FAIL (no `jwksConfig`/`jwksVerifier` fields on `UserServiceImpl`, `JwksAuthFactory` missing)
+
+- [ ] **Step 3: Write the implementation**
+
+`src/main/groovy/io/seqera/wave/auth/JwksAuthFactory.groovy`:
+
+```groovy
+package io.seqera.wave.auth
+
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.Factory
+import io.seqera.auth.jwks.JwksJwtVerifier
+import jakarta.inject.Singleton
+
+/**
+ * Assembles the lib-auth-jwks verifier with the Wave-specific transport
+ * (pairing tunnel) and cache (Redis state store) implementations.
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@Factory
+@CompileStatic
+class JwksAuthFactory {
+
+    @Singleton
+    JwksJwtVerifier jwksJwtVerifier(PairingJwksFetcher fetcher, RedisJwksCacheStore cacheStore, JwksAuthConfig config) {
+        return new JwksJwtVerifier(fetcher, cacheStore, config.toJwksConfig())
+    }
+}
+```
+
+`UserServiceImpl.groovy` — replace the class body (keep the existing license header and add the new imports):
+
+```groovy
+package io.seqera.wave.service
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.micronaut.core.annotation.Nullable
+import io.seqera.auth.jwks.JwksJwtVerifier
+import io.seqera.auth.jwks.JwtInspector
+import io.seqera.auth.jwks.exception.InvalidTokenException
+import io.seqera.auth.jwks.exception.JwksUnavailableException
+import io.seqera.auth.jwks.exception.UnknownIssuerException
+import io.seqera.wave.auth.JwksAuthConfig
+import io.seqera.wave.exception.UnauthorizedException
+import io.seqera.wave.tower.User
+import io.seqera.wave.tower.auth.JwtAuth
+import io.seqera.wave.tower.client.TowerClient
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+/**
+ * Define a service to access a Tower user
+ *
+ * @author Paolo Di Tommaso <paolo.ditommaso@gmail.com>
+ */
+@CompileStatic
+@Slf4j
+@Singleton
+class UserServiceImpl implements UserService {
+
+    @Inject
+    @Nullable
+    private TowerClient towerClient
+
+    @Inject
+    private JwksAuthConfig jwksConfig
+
+    @Inject
+    @Nullable
+    private JwksJwtVerifier jwksVerifier
+
+    @Override
+    User getUserByAccessToken(String endpoint, JwtAuth auth) {
+        // when enabled, tokens shaped as asymmetric-signed JWTs are verified
+        // locally against the issuer JWKS; opaque PATs and HS256 tokens keep
+        // following the legacy delegation path below
+        if( jwksConfig.enabled && jwksVerifier && JwtInspector.isAsymmetricJwt(auth.bearer) ) {
+            verifyJwksToken(endpoint, auth.bearer)
+        }
+        final resp = towerClient.userInfo(endpoint, auth)
+        if (!resp || !resp.user)
+            throw new UnauthorizedException("Unauthorized - Make sure you have provided a valid access token")
+        log.debug("Authorized user=$resp.user")
+        return resp.user
+    }
+
+    protected void verifyJwksToken(String endpoint, String token) {
+        try {
+            final verified = jwksVerifier.verify(token, endpoint)
+            log.trace "JWKS token verification OK - issuer '${verified.issuer()}'; subject '${verified.subject()}'"
+        }
+        catch (JwksUnavailableException e) {
+            log.warn "Unable to retrieve JWKS keys for endpoint '$endpoint' - cause: ${e.message}"
+            throw new UnauthorizedException("Unable to validate access token for Tower endpoint '$endpoint'")
+        }
+        catch (InvalidTokenException | UnknownIssuerException e) {
+            log.debug "JWKS token verification failed for endpoint '$endpoint' - cause: ${e.message}"
+            throw new UnauthorizedException("Invalid access token for Tower endpoint '$endpoint'")
+        }
+    }
+}
+```
+
+Note: a JWKS-verified failure MUST reject — never fall through to the delegation path (spec: "no silent fallback"). The `/user-info` call after successful verification is intentional in phase 1: it supplies the `User` entity that `PlatformId` needs; dropping it is phase 2, out of scope here.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew test --tests 'UserServiceImplJwksTest'`
+Expected: PASS
+
+- [ ] **Step 5: Run the impacted existing suites**
+
+Run: `./gradlew test --tests 'UserServiceImplTest' --tests 'ContainerControllerTest' --tests 'InspectControllerTest'`
+Expected: PASS (flag defaults to false → zero behavior change; if any of those test classes don't exist under exactly these names, run the closest existing ones touching `UserService`/the two controllers)
+
+- [ ] **Step 6: Commit (wave repo)**
+
+```bash
+git add src/main/groovy/io/seqera/wave/auth/JwksAuthFactory.groovy src/main/groovy/io/seqera/wave/service/UserServiceImpl.groovy src/test/groovy/io/seqera/wave/service/UserServiceImplJwksTest.groovy
+git commit -m "feat: flag-gated JWKS validation of Platform JWT tokens"
+```
+
+---
+
+### Task 8: Full regression + docs touch-up
+
+**Files:**
+- Modify: `src/main/resources/application.yml` (documentation-only commented block, optional)
+- Modify: `docs/superpowers/specs/2026-07-22-jwks-multi-issuer-auth-design.md` (only if implementation deviated — keep the spec truthful)
+
+- [ ] **Step 1: Full Wave test suite**
+
+Run: `cd /Users/pditommaso/Projects/wave && ./gradlew test`
+Expected: PASS. Fix any regression before proceeding (most likely candidates: Micronaut context tests that now instantiate the new beans — all new beans must be constructible with default config and no Redis).
+
+- [ ] **Step 2: Full lib test suite**
+
+Run: `cd /Users/pditommaso/Projects/libseqera && ./gradlew :lib-auth-jwks:check`
+Expected: PASS
+
+- [ ] **Step 3: Add the config reference block**
+
+In `application.yml`, next to the existing `wave:` documentation patterns, add a commented reference:
+
+```yaml
+# JWKS-based validation of Platform JWT tokens (disabled by default).
+# When enabled, asymmetric-signed JWTs are verified locally against the
+# issuer JWKS fetched over the pairing channel; PATs and HS256 tokens
+# keep using the legacy /user-info delegation path.
+#wave:
+#  auth:
+#    jwks:
+#      enabled: true
+#      path: '/.well-known/jwks.json'
+#      cache-duration: 6h
+#      refresh-min-interval: 60s
+#      clock-skew: 60s
+#      fetch-timeout: 30s
+```
+
+- [ ] **Step 4: Commit (wave repo)**
+
+```bash
+git add src/main/resources/application.yml docs/
+git commit -m "docs: JWKS auth configuration reference"
+```
+
+---
+
+## Out of scope (deliberate)
+
+- **Platform-side work (P1–P3 in the spec):** asymmetric signing, JWKS endpoint, `iss` claim. Nothing in this plan delivers user-visible value until Platform ships those; the Wave code is flag-off inert until then.
+- **Phase 2** (identity from claims, dropping `/user-info` for verified JWTs) and **Phase 3** (`Authorization: Bearer` header migration).
+- **End-to-end integration test** with a mock Platform over a real pairing websocket: verified in staging during rollout instead; the seams are individually covered by the tests above.
+- **lib-auth-jwks release to maven.seqera.io:** follows the standard libseqera release process; the Wave PR depends on it and must not merge first (and the temporary `mavenLocal()` entry must be dropped from `build.gradle` before merge).

--- a/docs/superpowers/specs/2026-07-22-jwks-multi-issuer-auth-design.md
+++ b/docs/superpowers/specs/2026-07-22-jwks-multi-issuer-auth-design.md
@@ -1,0 +1,159 @@
+# JWKS-based multi-issuer authentication for Wave
+
+**Date:** 2026-07-22
+**Status:** Approved design
+**Scope:** Wave + new libseqera module `lib-auth-jwks` (Platform-side changes listed as prerequisites only)
+
+## Problem
+
+Wave performs no cryptographic validation of the Platform (Tower) JWTs it receives.
+Authentication is delegation-based: the token from `SubmitContainerTokenRequest.towerAccessToken`
+is forwarded to `<towerEndpoint>/user-info` (over the pairing websocket tunnel or direct HTTP)
+and Wave trusts the response. Goals:
+
+1. Validate JWTs locally using the canonical JWKS protocol (signature, expiry, issuer).
+2. Support **multiple Platform issuers** dynamically — any Platform instance that pairs with
+   Wave becomes a trusted issuer, with no static per-issuer configuration.
+3. Support issuers **behind private networks** — the JWKS document must be retrievable over
+   the existing pairing websocket channel, since Wave may have no direct route to the Platform.
+4. Keep the implementation Wave-agnostic in a reusable library (`lib-auth-jwks` in libseqera,
+   package `io.seqera.auth.jwks`) so other services can adopt it.
+
+## Constraints discovered during investigation
+
+- **Platform signs JWTs with symmetric HS256** (`micronaut.security.token.jwt.signatures.secret.generator`).
+  A JWKS cannot publish a symmetric key. Platform must add asymmetric signing (prerequisite P1).
+- **Platform personal access tokens (PATs) are opaque** — random secrets checked against the
+  Platform DB (`AccessTokenServiceImpl`), not JWTs. They can never be verified via JWKS.
+  The existing delegation path is retained for them (decision: cheapest option, no token exchange).
+- The pairing tunnel already carries arbitrary HTTP GETs (`ProxyHttpRequest`/`ProxyHttpResponse`
+  correlated by `msgId`, routed by `tower:<host>` Redis queues). Fetching a JWKS document over it
+  requires **no changes to lib-pairing**.
+- Wave's JWT store/refresh machinery (`JwtAuthStore`, `JwtMonitor`, `/oauth/access_token` refresh)
+  exists so Wave can call Platform APIs *on behalf of the user* during long pipelines.
+  That is a delegated-credential concern, orthogonal to authentication. **It is not touched.**
+
+## Platform prerequisites (out of scope here, tracked separately)
+
+- **P1** — Sign access JWTs with RS256 or ES256, including a `kid` header. Keep HS256
+  verification during the transition (Micronaut supports multiple signature configurations).
+- **P2** — Expose a JWKS endpoint serving the public key set. Path served under the Platform
+  API; Wave treats the path as configurable.
+- **P3** — Set the `iss` claim to the Platform/custom API endpoint URL (the same URL the
+  pairing is registered under, post-normalization).
+
+## Trust model
+
+Pairing **is** issuer registration. A JWT is accepted only when:
+
+1. `request.towerEndpoint` has a live `PairingRecord` (unchanged from today — this is the
+   existing trust anchor).
+2. The JWKS for that endpoint verifies the token signature.
+3. The token's `iss` claim equals the normalized `towerEndpoint`
+   (same normalization Wave already applies: scheme/trailing-slash/legacy-host patching).
+4. `exp` is valid (with small configurable clock skew) and the algorithm is on the allow-list
+   (RS256/ES256 — `none` and HS* are never accepted on this path).
+
+### Dual path — routing by token shape
+
+The token's own header decides the path; no capability probing of the Platform version:
+
+| Token | Path |
+|---|---|
+| Signed JWT, asymmetric alg (RS/ES) | JWKS validation (strict — failure rejects the request, no fallback) |
+| Signed JWT, HS256 (older Platform) | Legacy delegation (`/user-info`) |
+| Opaque PAT | Legacy delegation (`/user-info`) |
+
+There is no downgrade attack: forcing the legacy path just means full delegation validation
+by the Platform itself. The asymmetric-JWT path never silently falls back — a JWKS-verifiable
+token that fails verification is rejected.
+
+## Architecture
+
+### New libseqera module: `lib-auth-jwks` (package `io.seqera.auth.jwks`)
+
+Wave-agnostic. Dependencies: `nimbus-jose-jwt` (+ optionally `micronaut-inject` annotations,
+matching lib-pairing's style). No dependency on Wave, lib-pairing, or Redis.
+
+- **`JwksFetcher`** (interface) — `CompletableFuture<String> fetch(String issuerEndpoint)`
+  returns the raw JWKS JSON for an issuer. This is the transport seam: the library ships a
+  default `HttpJwksFetcher` (java.net.http); Wave plugs in a pairing-tunnel implementation.
+  The JWKS path relative to the endpoint is configuration (default `/.well-known/jwks.json`).
+- **`JwksCacheStore`** (interface) — get/put of the cached JWKS document per issuer with TTL.
+  Default in-memory (Caffeine) implementation in the library; consumers may provide a
+  distributed one.
+- **`JwksJwtVerifier`** — the entry point:
+  `VerifiedJwt verify(String token, String expectedIssuer)`.
+  Internally a Nimbus `ConfigurableJWTProcessor` with a custom `JWKSource` backed by
+  `JwksCacheStore` + `JwksFetcher`. Behavior:
+  - cache hit → verify locally, zero network I/O;
+  - unknown `kid` → rate-limited re-fetch (key rotation), then verify;
+  - fetch failure with a stale cached document → use the stale copy (verification is still
+    cryptographic; staleness only delays rotation pickup);
+  - fetch failure with no cache → typed failure (`JwksUnavailableException`).
+  Verifies signature, `exp`/`nbf` (configurable skew), `iss` equality, alg allow-list.
+  Typed exceptions: `InvalidTokenException`, `UnknownIssuerException`, `JwksUnavailableException`.
+- **`JwtInspector`** — static helper: is this string a signed JWT, and is its alg asymmetric?
+  Drives the dual-path branch without cryptographic work.
+- **`VerifiedJwt`** — immutable claims view (subject, issuer, expiry, raw claim map).
+
+### Wave-side integration (thin adapters)
+
+- **`PairingJwksFetcher implements JwksFetcher`** — delegates to the existing
+  `TowerConnector.sendAsync(endpoint, ProxyHttpRequest)` with a GET for the JWKS path and no
+  auth header (JWKS is public). Because `TowerConnector` is the abstraction, this transparently
+  uses the websocket tunnel (default) or direct HTTP (`legacy-http-connector` env) — private
+  network support comes for free.
+- **`RedisJwksCacheStore implements JwksCacheStore`** — backed by
+  `io.seqera.data.store.state.AbstractStateStore` (lib-data-store-state-redis), prefix
+  `jwks-cache/v1`, TTL `wave.auth.jwks.cache-duration` (default 6h). Shared across replicas.
+- **Service wiring** — in `UserServiceImpl.getUserByAccessToken`, the single choke point
+  both `ContainerController` and `InspectController` resolve identity through (and which
+  they only reach after the pairing-record check):
+  - if `wave.auth.jwks.enabled` and `JwtInspector` says asymmetric JWT →
+    `jwksJwtVerifier.verify(token, endpoint)`; on success proceed, on failure → 401.
+  - Phase 1 keeps the `/user-info` call after successful verification, because `PlatformId`
+    needs the `User` entity (id, email) and current Platform claims don't carry it.
+    Phase 2 (after Platform enriches claims) builds `PlatformId` from claims and drops the
+    `/user-info` call for verified JWTs.
+  - otherwise → existing path unchanged.
+- **Config** (`wave.auth.jwks.*`): `enabled` (default `false`), `path`
+  (default `/.well-known/jwks.json`), `cache-duration` (6h), `refresh-min-interval`
+  (rate limit for kid-miss refetch, default 60s), `clock-skew` (60s).
+
+### What is intentionally NOT changed
+
+- `JwtAuthStore` / `JwtTimeStore` / `JwtMonitor` / token refresh — untouched (delegated
+  credential lifecycle, still required for credentials fetch and workflow describe).
+- lib-pairing protocol and message types — untouched.
+- Client-facing API — token stays in the request body. Moving to `Authorization: Bearer`
+  with Micronaut's `SecurityFilter` is a possible later phase, not in scope.
+- No token exchange for PATs (decision: dual path is permanent until Platform ever offers it).
+
+## Error handling summary
+
+| Condition | Behavior |
+|---|---|
+| Asymmetric JWT, bad signature / expired / iss mismatch | 401, request rejected |
+| Asymmetric JWT, unknown `kid` | rate-limited JWKS refetch, then verify or 401 |
+| JWKS unreachable, stale cache present | verify against stale cache |
+| JWKS unreachable, no cache | 401 with distinct log/metric (`JwksUnavailableException`) |
+| No pairing record for endpoint | 400 (unchanged, existing behavior) |
+| HS256 JWT or opaque PAT | legacy `/user-info` delegation (unchanged) |
+
+## Testing
+
+- **lib-auth-jwks** (JUnit/Spock): generated RSA/EC keypairs; verify happy path, tampered
+  signature, expired token, wrong issuer, alg confusion (`none`, HS256 signed with a public
+  key), kid rotation triggering refetch, rate limiting, stale-cache fallback, no-cache failure.
+- **Wave** (Spock): dual-path branching (asymmetric JWT vs HS256 vs opaque), flag off/on,
+  `PairingJwksFetcher` against a stubbed `TowerConnector`, controller-level 401 behavior,
+  Redis cache store round-trip (existing Redis test fixtures).
+- **Integration**: mock Platform serving a JWKS + signed tokens over the pairing test harness.
+
+## Rollout
+
+1. Ship with `wave.auth.jwks.enabled=false` — zero behavior change.
+2. Enable in staging against a Platform build with P1–P3.
+3. Enable in production; HS256/PAT traffic continues on the legacy path throughout, so older
+   Platform instances are unaffected indefinitely.

--- a/docs/superpowers/specs/2026-07-22-jwks-multi-issuer-auth-design.md
+++ b/docs/superpowers/specs/2026-07-22-jwks-multi-issuer-auth-design.md
@@ -1,7 +1,7 @@
 # JWKS-based multi-issuer authentication for Wave
 
 **Date:** 2026-07-22
-**Status:** Approved design
+**Status:** Approved design (rev 2 — builds on Micronaut Security JWKS support and existing Platform OIDC module)
 **Scope:** Wave + new libseqera module `lib-auth-jwks` (Platform-side changes listed as prerequisites only)
 
 ## Problem
@@ -18,29 +18,61 @@ and Wave trusts the response. Goals:
    the existing pairing websocket channel, since Wave may have no direct route to the Platform.
 4. Keep the implementation Wave-agnostic in a reusable library (`lib-auth-jwks` in libseqera,
    package `io.seqera.auth.jwks`) so other services can adopt it.
+5. **Reuse Micronaut Security's JWKS machinery** rather than re-implementing it: the library
+   builds on `micronaut-security-jwt`'s `JwksClient` (pluggable transport), `JwkSetFetcher`
+   (fetch + caching) and `JwkValidator` (signature verification) extension points, adding only
+   the dynamic multi-issuer resolution Micronaut does not provide (its `SignatureConfiguration`
+   beans are fixed at startup via static config).
 
 ## Constraints discovered during investigation
 
-- **Platform signs JWTs with symmetric HS256** (`micronaut.security.token.jwt.signatures.secret.generator`).
-  A JWKS cannot publish a symmetric key. Platform must add asymmetric signing (prerequisite P1).
+- **Platform user-session JWTs are signed with symmetric HS256**
+  (`micronaut.security.token.jwt.signatures.secret.generator`). A JWKS cannot publish a
+  symmetric key, so these tokens are never JWKS-verifiable.
 - **Platform personal access tokens (PATs) are opaque** — random secrets checked against the
   Platform DB (`AccessTokenServiceImpl`), not JWTs. They can never be verified via JWKS.
-  The existing delegation path is retained for them (decision: cheapest option, no token exchange).
+  The existing delegation path is retained for them.
+- **Platform already ships most of the issuer-side machinery** in the `platform-oidc` module,
+  active when `TOWER_OIDC_PEM_PATH` (RSA keypair PEM) is configured:
+  - `GET /.well-known/jwks.json` (`OpenIdConnectController`) serves the RSA public key set
+    with a stable RFC 7638 thumbprint `kid`, `use: sig`, `alg: RS256`;
+  - `TokenIssuer` mints RS256 access tokens with `kid` header and `iss` claim set to the
+    Platform API endpoint URL (`TowerService.getTowerPublicEndpoint()`);
+  - `OidcRSASignatureConfiguration` makes Platform accept RS256 tokens as inbound
+    authentication alongside HS256;
+  - token-exchange plumbing exists (`GET /exchange/token` + `TokenIssuer.issueRefreshableAccessToken`)
+    but is currently Studio-specific (session-initialization tokens).
 - The pairing tunnel already carries arbitrary HTTP GETs (`ProxyHttpRequest`/`ProxyHttpResponse`
   correlated by `msgId`, routed by `tower:<host>` Redis queues). Fetching a JWKS document over it
   requires **no changes to lib-pairing**.
 - Wave's JWT store/refresh machinery (`JwtAuthStore`, `JwtMonitor`, `/oauth/access_token` refresh)
   exists so Wave can call Platform APIs *on behalf of the user* during long pipelines.
   That is a delegated-credential concern, orthogonal to authentication. **It is not touched.**
+- Micronaut Security (v4.11) extension points verified in source:
+  - `JwksClient` — `@FunctionalInterface`, `Publisher<String> load(String providerName, String url)`;
+    default `HttpClientJwksClient` is disabled via
+    `micronaut.security.token.jwt.signatures.jwks-client.http-client.enabled: false`, letting a
+    custom bean take over all JWKS retrieval;
+  - `JwkSetFetcher<JWKSet>` — `fetch(providerName, url)` + `clearCache(url)`; the default
+    (`DefaultJwkSetFetcher` behind a caching `@Primary` wrapper) parses and caches the key set
+    per URL (default expiration 60s; a Micronaut-cache-backed variant `CacheableJwkSetFetcher`
+    activates when a `jwks` cache is configured — that is the hook for distributed caching);
+  - `JwkValidator`/`DefaultJwkValidator` — verifies a `SignedJWT` against a `JWK`
+    (RSA/EC only — symmetric keys can never pass).
 
 ## Platform prerequisites (out of scope here, tracked separately)
 
-- **P1** — Sign access JWTs with RS256 or ES256, including a `kid` header. Keep HS256
-  verification during the transition (Micronaut supports multiple signature configurations).
-- **P2** — Expose a JWKS endpoint serving the public key set. Path served under the Platform
-  API; Wave treats the path as configurable.
-- **P3** — Set the `iss` claim to the Platform/custom API endpoint URL (the same URL the
-  pairing is registered under, post-normalization).
+Mostly satisfied by the existing `platform-oidc` module:
+
+- **P1 (done)** — JWKS endpoint: `/.well-known/jwks.json` with proper `kid`/`use`/`alg`.
+- **P2 (done)** — `iss` claim = Platform API endpoint URL, `kid` in header, for tokens minted
+  by `TokenIssuer`; Platform accepts these RS256 tokens as inbound auth.
+- **P3 (remaining)** — get an RS256 token into the Wave request flow: the tokens clients send
+  today (HS256 session JWTs, opaque PATs) are not JWKS-verifiable. Options: a generic
+  token-exchange grant on the existing `TokenIssuer` machinery (PAT/session JWT in → RS256
+  access token out), or issuing RS256 tokens at workflow-launch time.
+- **P4 (deployment)** — `TOWER_OIDC_PEM_PATH` must be configured (it is optional today;
+  no PEM → no JWKS endpoint → Wave's dual path keeps everything on the legacy route).
 
 ## Trust model
 
@@ -52,7 +84,7 @@ Pairing **is** issuer registration. A JWT is accepted only when:
 3. The token's `iss` claim equals the normalized `towerEndpoint`
    (same normalization Wave already applies: scheme/trailing-slash/legacy-host patching).
 4. `exp` is valid (with small configurable clock skew) and the algorithm is on the allow-list
-   (RS256/ES256 — `none` and HS* are never accepted on this path).
+   (RS256/RS384/RS512/ES256/ES384/ES512 — `none` and HS* are never accepted on this path).
 
 ### Dual path — routing by token shape
 
@@ -61,7 +93,7 @@ The token's own header decides the path; no capability probing of the Platform v
 | Token | Path |
 |---|---|
 | Signed JWT, asymmetric alg (RS/ES) | JWKS validation (strict — failure rejects the request, no fallback) |
-| Signed JWT, HS256 (older Platform) | Legacy delegation (`/user-info`) |
+| Signed JWT, HS256 (session tokens) | Legacy delegation (`/user-info`) |
 | Opaque PAT | Legacy delegation (`/user-info`) |
 
 There is no downgrade attack: forcing the legacy path just means full delegation validation
@@ -72,54 +104,65 @@ token that fails verification is rejected.
 
 ### New libseqera module: `lib-auth-jwks` (package `io.seqera.auth.jwks`)
 
-Wave-agnostic. Dependencies: `nimbus-jose-jwt` (+ optionally `micronaut-inject` annotations,
-matching lib-pairing's style). No dependency on Wave, lib-pairing, or Redis.
+Wave-agnostic Micronaut library (same style as `lib-pairing`). Dependencies:
+`io.micronaut.security:micronaut-security-jwt` (api). No dependency on Wave, lib-pairing, or Redis.
 
-- **`JwksFetcher`** (interface) — `CompletableFuture<String> fetch(String issuerEndpoint)`
-  returns the raw JWKS JSON for an issuer. This is the transport seam: the library ships a
-  default `HttpJwksFetcher` (java.net.http); Wave plugs in a pairing-tunnel implementation.
-  The JWKS path relative to the endpoint is configuration (default `/.well-known/jwks.json`).
-- **`JwksCacheStore`** (interface) — get/put of the cached JWKS document per issuer with TTL.
-  Default in-memory (Caffeine) implementation in the library; consumers may provide a
-  distributed one.
-- **`JwksJwtVerifier`** — the entry point:
-  `VerifiedJwt verify(String token, String expectedIssuer)`.
-  Internally a Nimbus `ConfigurableJWTProcessor` with a custom `JWKSource` backed by
-  `JwksCacheStore` + `JwksFetcher`. Behavior:
-  - cache hit → verify locally, zero network I/O;
-  - unknown `kid` → rate-limited re-fetch (key rotation), then verify;
-  - fetch failure with a stale cached document → use the stale copy (verification is still
-    cryptographic; staleness only delays rotation pickup);
-  - fetch failure with no cache → typed failure (`JwksUnavailableException`).
-  Verifies signature, `exp`/`nbf` (configurable skew), `iss` equality, alg allow-list.
-  Typed exceptions: `InvalidTokenException`, `UnknownIssuerException`, `JwksUnavailableException`.
-- **`JwtInspector`** — static helper: is this string a signed JWT, and is its alg asymmetric?
+- **`JwtInspector`** — static helpers: is this string a signed JWT, and is its alg asymmetric?
   Drives the dual-path branch without cryptographic work.
-- **`VerifiedJwt`** — immutable claims view (subject, issuer, expiry, raw claim map).
+- **`JwksVerifierConfig`** (interface) — `getJwksPath()`, `getRefreshMinInterval()`,
+  `getClockSkew()`, `getFetchTimeout()`. Implemented by the consuming service
+  (same pattern as lib-pairing's `PairingConfig`).
+- **`DynamicJwksVerifier`** (`@Singleton`, requires a `JwksVerifierConfig` bean) — the entry point:
+  `VerifiedJwt verify(String token, String expectedIssuer)`. Composes Micronaut beans
+  (`JwkSetFetcher<JWKSet>`, `JwkValidator`) instead of re-implementing them:
+  - alg allow-list check on the parsed header;
+  - resolve the JWKS URL dynamically: `normalizeIssuer(endpoint) + jwksPath`, fetch via
+    `jwkSetFetcher.fetch(endpoint, url)` (`providerName` = the endpoint, so a custom
+    `JwksClient` can route by issuer) — caching comes from Micronaut's fetcher;
+  - unknown `kid` → rate-limited `clearCache(url)` + re-fetch (key rotation), min interval
+    `refreshMinInterval` per endpoint;
+  - signature check: Nimbus `JWKSelector`/`JWKMatcher.forJWSHeader` key selection +
+    `jwkValidator.validate(jwt, jwk)`;
+  - claims: `exp`/`nbf` via Nimbus claims verifier with configurable skew; `iss` compared
+    against the normalized expected issuer;
+  - typed failures: `InvalidTokenException`, `UnknownIssuerException`, `JwksUnavailableException`.
+- **`VerifiedJwt`** — immutable claims view (issuer, subject, expiration, raw claim map).
+
+What the library deliberately does NOT contain: HTTP fetching (Micronaut's `HttpClientJwksClient`
+is the default transport), JWKS parsing/caching (Micronaut's `JwkSetFetcher`), signature
+primitives (Micronaut's `JwkValidator`). A consumer with a plain network path needs zero
+custom transport code.
 
 ### Wave-side integration (thin adapters)
 
-- **`PairingJwksFetcher implements JwksFetcher`** — delegates to the existing
-  `TowerConnector.sendAsync(endpoint, ProxyHttpRequest)` with a GET for the JWKS path and no
-  auth header (JWKS is public). Because `TowerConnector` is the abstraction, this transparently
-  uses the websocket tunnel (default) or direct HTTP (`legacy-http-connector` env) — private
-  network support comes for free.
-- **`RedisJwksCacheStore implements JwksCacheStore`** — backed by
-  `io.seqera.data.store.state.AbstractStateStore` (lib-data-store-state-redis), prefix
-  `jwks-cache/v1`, TTL `wave.auth.jwks.cache-duration` (default 6h). Shared across replicas.
+- **`PairingJwksClient implements JwksClient`** — routes `load(providerName, url)` through the
+  existing `TowerConnector.sendAsync(endpoint, ProxyHttpRequest)` with a GET for the JWKS URL and
+  no auth header (JWKS is public); `providerName` carries the Tower endpoint for tunnel routing.
+  Because `TowerConnector` is the abstraction, this transparently uses the websocket tunnel
+  (default) or direct HTTP (`legacy-http-connector` env) — private-network support comes for free.
+  Micronaut's own HTTP JWKS client is disabled via
+  `micronaut.security.token.jwt.signatures.jwks-client.http-client.enabled: false`, making the
+  pairing client the sole `JwksClient` bean.
+- **Caching** — Micronaut's default in-memory `JwkSetFetcher` cache (per replica, 60s). Good
+  enough: a JWKS fetch is one small GET per issuer per minute worst case. If distributed caching
+  is ever wanted, configure a Micronaut cache named `jwks` (libseqera's `micronaut-cache-redis`
+  module) and `CacheableJwkSetFetcher` activates without code changes. There is no custom cache
+  layer and no stale-cache fallback: if the JWKS cannot be fetched and the cache has expired,
+  asymmetric-JWT requests are rejected until the tunnel recovers (PAT/HS256 traffic is unaffected).
 - **Service wiring** — in `UserServiceImpl.getUserByAccessToken`, the single choke point
   both `ContainerController` and `InspectController` resolve identity through (and which
   they only reach after the pairing-record check):
   - if `wave.auth.jwks.enabled` and `JwtInspector` says asymmetric JWT →
-    `jwksJwtVerifier.verify(token, endpoint)`; on success proceed, on failure → 401.
+    `dynamicJwksVerifier.verify(token, endpoint)`; on success proceed, on failure → 401.
   - Phase 1 keeps the `/user-info` call after successful verification, because `PlatformId`
     needs the `User` entity (id, email) and current Platform claims don't carry it.
     Phase 2 (after Platform enriches claims) builds `PlatformId` from claims and drops the
     `/user-info` call for verified JWTs.
   - otherwise → existing path unchanged.
 - **Config** (`wave.auth.jwks.*`): `enabled` (default `false`), `path`
-  (default `/.well-known/jwks.json`), `cache-duration` (6h), `refresh-min-interval`
-  (rate limit for kid-miss refetch, default 60s), `clock-skew` (60s).
+  (default `/.well-known/jwks.json` — matches Platform's existing endpoint),
+  `refresh-min-interval` (rate limit for kid-miss refetch, default 60s), `clock-skew` (60s),
+  `fetch-timeout` (30s). JWKS cache expiration is Micronaut's (60s default).
 
 ### What is intentionally NOT changed
 
@@ -128,32 +171,36 @@ matching lib-pairing's style). No dependency on Wave, lib-pairing, or Redis.
 - lib-pairing protocol and message types — untouched.
 - Client-facing API — token stays in the request body. Moving to `Authorization: Bearer`
   with Micronaut's `SecurityFilter` is a possible later phase, not in scope.
-- No token exchange for PATs (decision: dual path is permanent until Platform ever offers it).
+- No generic token exchange yet — the plumbing exists on Platform (`TokenIssuer`), but wiring
+  a PAT→RS256 grant is Platform work (prerequisite P3), not part of this change.
 
 ## Error handling summary
 
 | Condition | Behavior |
 |---|---|
 | Asymmetric JWT, bad signature / expired / iss mismatch | 401, request rejected |
-| Asymmetric JWT, unknown `kid` | rate-limited JWKS refetch, then verify or 401 |
-| JWKS unreachable, stale cache present | verify against stale cache |
-| JWKS unreachable, no cache | 401 with distinct log/metric (`JwksUnavailableException`) |
+| Asymmetric JWT, unknown `kid` | rate-limited JWKS refetch (cache cleared), then verify or 401 |
+| JWKS unreachable, Micronaut cache still valid | verify from cache |
+| JWKS unreachable, cache expired or empty | 401 with distinct log/metric (`JwksUnavailableException`) |
 | No pairing record for endpoint | 400 (unchanged, existing behavior) |
 | HS256 JWT or opaque PAT | legacy `/user-info` delegation (unchanged) |
 
 ## Testing
 
-- **lib-auth-jwks** (JUnit/Spock): generated RSA/EC keypairs; verify happy path, tampered
-  signature, expired token, wrong issuer, alg confusion (`none`, HS256 signed with a public
-  key), kid rotation triggering refetch, rate limiting, stale-cache fallback, no-cache failure.
+- **lib-auth-jwks** (Spock): generated RSA/EC keypairs; stubbed `JwkSetFetcher`; verify happy
+  path, tampered signature, expired token, wrong issuer, alg confusion (`none`, HS256),
+  kid rotation triggering `clearCache` + refetch, refetch rate limiting, fetch-failure → 
+  `JwksUnavailableException`, issuer normalization.
 - **Wave** (Spock): dual-path branching (asymmetric JWT vs HS256 vs opaque), flag off/on,
-  `PairingJwksFetcher` against a stubbed `TowerConnector`, controller-level 401 behavior,
-  Redis cache store round-trip (existing Redis test fixtures).
-- **Integration**: mock Platform serving a JWKS + signed tokens over the pairing test harness.
+  `PairingJwksClient` against a stubbed `TowerConnector`, `UserServiceImpl` 401 behavior.
+- **Regression**: adding `micronaut-security-jwt` to Wave's classpath activates Micronaut's JWT
+  token readers in the security filter — verify the basic-auth admin endpoints and anonymous
+  routes behave exactly as before.
+- **Integration**: verified in staging against a Platform instance with `TOWER_OIDC_PEM_PATH` set.
 
 ## Rollout
 
 1. Ship with `wave.auth.jwks.enabled=false` — zero behavior change.
-2. Enable in staging against a Platform build with P1–P3.
+2. Enable in staging against a Platform with `TOWER_OIDC_PEM_PATH` configured and P3 in place.
 3. Enable in production; HS256/PAT traffic continues on the legacy path throughout, so older
    Platform instances are unaffected indefinitely.


### PR DESCRIPTION
## Summary

Design documents only — no code changes. Spec + implementation plan for replacing Wave's delegation-only validation of Platform JWT tokens with canonical JWKS verification:

- **Multi-issuer, zero static config**: pairing acts as issuer registration — any Platform instance with a live `PairingRecord` is a candidate issuer; the token's `iss` claim must match the paired endpoint.
- **Private-network issuers**: the JWKS document is fetched through the existing `TowerConnector`/pairing websocket tunnel (`ProxyHttpRequest`), so no changes to lib-pairing are needed.
- **Dual path by token shape**: asymmetric-signed JWTs (RS/ES) are verified locally against the issuer JWKS (strict, no fallback); HS256 JWTs and opaque PATs keep using today's `/user-info` delegation path indefinitely.
- **Built on Micronaut Security, not from scratch**: the reusable core (new libseqera module `lib-auth-jwks`) only adds dynamic per-issuer JWKS resolution; retrieval, caching and signature verification reuse `micronaut-security-jwt`'s `JwksClient` / `JwkSetFetcher` / `JwkValidator` extension points. Wave contributes a `JwksClient` bean routing over the pairing tunnel and a flag-gated wiring in `UserServiceImpl` (`wave.auth.jwks.enabled`, default off).

## Platform prerequisites (mostly already shipped)

The `platform-oidc` module already provides, when `TOWER_OIDC_PEM_PATH` is configured: the `/.well-known/jwks.json` endpoint (RS256, RFC 7638 `kid`), `iss` = Platform API endpoint URL, and inbound acceptance of RS256 tokens. Remaining Platform work (tracked separately):

- a generic token-exchange grant (PAT/session JWT in → RS256 access token out) or RS256 tokens at workflow launch — the tokens Wave receives today are HS256/opaque
- making `TOWER_OIDC_PEM_PATH` configured in deployments that enable this

## Files

- `docs/superpowers/specs/2026-07-22-jwks-multi-issuer-auth-design.md`
- `docs/superpowers/plans/2026-07-22-jwks-multi-issuer-auth.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
