### PR TITLE
fix(deps): upgrade org.postgresql:postgresql to 42.7.12 (COMP-2149)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     // add postgresql dependencies
     implementation 'io.micronaut.data:micronaut-data-jdbc'
     implementation 'io.micronaut.sql:micronaut-jdbc-hikari'  // HikariCP for connection pooling
-    implementation 'org.postgresql:postgresql:42.7.11'       // PostgreSQL Driver
+    implementation 'org.postgresql:postgresql:42.7.12'       // PostgreSQL Driver
     //object storage dependency
     implementation 'io.micronaut.objectstorage:micronaut-object-storage-aws'
     implementation 'software.amazon.awssdk:sts'


### PR DESCRIPTION
## Summary
- Upgrades `org.postgresql:postgresql` from `42.7.11` to `42.7.12`
- Resolves CVE-2026-54291 / GHSA-j92g-9f8w-j867

## Details
PostgreSQL JDBC Driver releases 42.7.4 through 42.7.11 silently downgrade `channelBinding=require` connections from SCRAM-SHA-256-PLUS (with channel binding) to plain SCRAM-SHA-256, losing the MITM protection the setting is meant to guarantee. Fixed in 42.7.12, which enforces channel binding in pgJDBC's own code.

## JIRA
COMP-2149: Fix PostgreSQL JDBC Driver: Silent channel-binding authentication downgrade via unsupported certificate algorithms

## Security Advisory
https://github.com/seqeralabs/wave/security/dependabot/69

🤖 Generated with [Claude Code](https://claude.com/claude-code)