### PR TITLE
fix: carry conda activate.d env hooks into conda/micromamba:v2 images

### DIFF
--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
@@ -19,7 +19,6 @@ RUN micromamba install -y -n base conda-forge::which \
 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \
     && printf '%s\n' \
         '#!/bin/bash' \
-        'unset __wave_nounset' \
         'case $- in *u*) __wave_nounset=1 ;; esac' \
         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
         'set +u' \

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
@@ -19,6 +19,7 @@ RUN micromamba install -y -n base conda-forge::which \
 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \
     && printf '%s\n' \
         '#!/bin/bash' \
+        'unset __wave_nounset' \
         'case $- in *u*) __wave_nounset=1 ;; esac' \
         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
         'set +u' \

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-file.txt
@@ -14,6 +14,21 @@ RUN micromamba install -y -n base conda-forge::which \
     && echo ">> CONDA_LOCK_START" \
     && cat environment.lock \
     && echo "<< CONDA_LOCK_END"
+# combine conda 'activate.d' env hooks into a single script, since the prod stage below never runs
+# `micromamba activate` to trigger them
+RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \
+    && printf '%s\n' \
+        '#!/bin/bash' \
+        'case $- in *u*) __wave_nounset=1 ;; esac' \
+        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
+        'set +u' \
+        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \
+    && (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \
+        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \
+    && printf '%s\n' \
+        '[ -n "${__wave_nounset:-}" ] && set -u' \
+        'unset __wave_nounset' \
+        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 
 FROM {{base_image}} AS prod
 ARG MAMBA_ROOT_PREFIX="/opt/conda"
@@ -21,3 +36,4 @@ ENV MAMBA_ROOT_PREFIX=$MAMBA_ROOT_PREFIX
 COPY --from=build "$MAMBA_ROOT_PREFIX" "$MAMBA_ROOT_PREFIX"
 USER root
 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
@@ -14,6 +14,21 @@ RUN \
     && echo ">> CONDA_LOCK_START" \
     && cat environment.lock \
     && echo "<< CONDA_LOCK_END"
+# combine conda 'activate.d' env hooks into a single script, since the prod stage below never runs
+# `micromamba activate` to trigger them
+RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \
+    && printf '%s\n' \
+        '#!/bin/bash' \
+        'case $- in *u*) __wave_nounset=1 ;; esac' \
+        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
+        'set +u' \
+        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \
+    && (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \
+        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \
+    && printf '%s\n' \
+        '[ -n "${__wave_nounset:-}" ] && set -u' \
+        'unset __wave_nounset' \
+        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 
 FROM {{base_image}} AS prod
 ARG MAMBA_ROOT_PREFIX="/opt/conda"
@@ -21,3 +36,4 @@ ENV MAMBA_ROOT_PREFIX=$MAMBA_ROOT_PREFIX
 COPY --from=build "$MAMBA_ROOT_PREFIX" "$MAMBA_ROOT_PREFIX"
 USER root
 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
@@ -19,6 +19,7 @@ RUN \
 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \
     && printf '%s\n' \
         '#!/bin/bash' \
+        'unset __wave_nounset' \
         'case $- in *u*) __wave_nounset=1 ;; esac' \
         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
         'set +u' \

--- a/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/dockerfile-conda-packages.txt
@@ -19,7 +19,6 @@ RUN \
 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \
     && printf '%s\n' \
         '#!/bin/bash' \
-        'unset __wave_nounset' \
         'case $- in *u*) __wave_nounset=1 ;; esac' \
         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
         'set +u' \

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
@@ -21,6 +21,7 @@ From: {{mamba_image}}
     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
     printf '%s\n' \
         '#!/bin/bash' \
+        'unset __wave_nounset' \
         'case $- in *u*) __wave_nounset=1 ;; esac' \
         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
         'set +u' \

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
@@ -21,7 +21,6 @@ From: {{mamba_image}}
     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
     printf '%s\n' \
         '#!/bin/bash' \
-        'unset __wave_nounset' \
         'case $- in *u*) __wave_nounset=1 ;; esac' \
         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
         'set +u' \

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-file.txt
@@ -16,6 +16,22 @@ From: {{mamba_image}}
     echo ">> CONDA_LOCK_START"
     cat environment.lock
     echo "<< CONDA_LOCK_END"
+    # combine conda 'activate.d' env hooks into a single script, sourced via BASH_ENV below since
+    # `micromamba activate` never runs otherwise
+    mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
+    printf '%s\n' \
+        '#!/bin/bash' \
+        'case $- in *u*) __wave_nounset=1 ;; esac' \
+        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
+        'set +u' \
+        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+    (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \
+        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+    printf '%s\n' \
+        '[ -n "${__wave_nounset:-}" ] && set -u' \
+        'unset __wave_nounset' \
+        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 %environment
     export MAMBA_ROOT_PREFIX=/opt/conda
     export PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+    export BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
@@ -14,6 +14,22 @@ From: {{mamba_image}}
     echo ">> CONDA_LOCK_START"
     cat environment.lock
     echo "<< CONDA_LOCK_END"
+    # combine conda 'activate.d' env hooks into a single script, sourced via BASH_ENV below since
+    # `micromamba activate` never runs otherwise
+    mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
+    printf '%s\n' \
+        '#!/bin/bash' \
+        'case $- in *u*) __wave_nounset=1 ;; esac' \
+        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
+        'set +u' \
+        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+    (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \
+        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+    printf '%s\n' \
+        '[ -n "${__wave_nounset:-}" ] && set -u' \
+        'unset __wave_nounset' \
+        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 %environment
     export MAMBA_ROOT_PREFIX=/opt/conda
     export PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+    export BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
@@ -19,6 +19,7 @@ From: {{mamba_image}}
     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
     printf '%s\n' \
         '#!/bin/bash' \
+        'unset __wave_nounset' \
         'case $- in *u*) __wave_nounset=1 ;; esac' \
         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
         'set +u' \

--- a/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
+++ b/src/main/resources/templates/conda-micromamba-v2/singularityfile-conda-packages.txt
@@ -19,7 +19,6 @@ From: {{mamba_image}}
     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
     printf '%s\n' \
         '#!/bin/bash' \
-        'unset __wave_nounset' \
         'case $- in *u*) __wave_nounset=1 ;; esac' \
         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \
         'set +u' \

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -771,6 +771,21 @@ class ContainerHelperTest extends Specification {
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
+                # combine conda 'activate.d' env hooks into a single script, since the prod stage below never runs
+                # `micromamba activate` to trigger them
+                RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
+                    && printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 
                 FROM ubuntu:24.04 AS prod
                 ARG MAMBA_ROOT_PREFIX="/opt/conda"
@@ -778,6 +793,7 @@ class ContainerHelperTest extends Specification {
                 COPY --from=build "$MAMBA_ROOT_PREFIX" "$MAMBA_ROOT_PREFIX"
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 '''.stripIndent()
     }
 
@@ -813,6 +829,21 @@ class ContainerHelperTest extends Specification {
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
+                # combine conda 'activate.d' env hooks into a single script, since the prod stage below never runs
+                # `micromamba activate` to trigger them
+                RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
+                    && printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 
                 FROM ubuntu:24.04 AS prod
                 ARG MAMBA_ROOT_PREFIX="/opt/conda"
@@ -820,6 +851,7 @@ class ContainerHelperTest extends Specification {
                 COPY --from=build "$MAMBA_ROOT_PREFIX" "$MAMBA_ROOT_PREFIX"
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 '''.stripIndent()
     }
 
@@ -860,6 +892,21 @@ class ContainerHelperTest extends Specification {
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
+                # combine conda 'activate.d' env hooks into a single script, since the prod stage below never runs
+                # `micromamba activate` to trigger them
+                RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
+                    && printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 
                 FROM debian:12 AS prod
                 ARG MAMBA_ROOT_PREFIX="/opt/conda"
@@ -867,6 +914,7 @@ class ContainerHelperTest extends Specification {
                 COPY --from=build "$MAMBA_ROOT_PREFIX" "$MAMBA_ROOT_PREFIX"
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 '''.stripIndent()
     }
 
@@ -901,6 +949,21 @@ class ContainerHelperTest extends Specification {
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
+                # combine conda 'activate.d' env hooks into a single script, since the prod stage below never runs
+                # `micromamba activate` to trigger them
+                RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
+                    && printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 
                 FROM ubuntu:24.04 AS prod
                 ARG MAMBA_ROOT_PREFIX="/opt/conda"
@@ -908,6 +971,7 @@ class ContainerHelperTest extends Specification {
                 COPY --from=build "$MAMBA_ROOT_PREFIX" "$MAMBA_ROOT_PREFIX"
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 '''.stripIndent()
     }
 

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -776,7 +776,6 @@ class ContainerHelperTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -835,7 +834,6 @@ class ContainerHelperTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -899,7 +897,6 @@ class ContainerHelperTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -957,7 +954,6 @@ class ContainerHelperTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -776,6 +776,7 @@ class ContainerHelperTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -834,6 +835,7 @@ class ContainerHelperTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -897,6 +899,7 @@ class ContainerHelperTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -954,6 +957,7 @@ class ContainerHelperTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -505,7 +505,6 @@ class TemplateUtilsTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -551,7 +550,6 @@ class TemplateUtilsTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -606,7 +604,6 @@ class TemplateUtilsTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -660,7 +657,6 @@ class TemplateUtilsTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -755,8 +751,10 @@ class TemplateUtilsTest extends Specification {
     }
 
     def 'should generate an activate.d combiner script that survives real bash execution'() {
-        // exercises the exact shell fragment the v2 templates embed (mkdir/printf/cat), rather than
-        // just asserting on the rendered template text, to catch quoting or shell-state regressions
+        // exercises the exact shell fragment embedded in the Dockerfile v2 template (mkdir/printf/cat),
+        // rather than just asserting on the rendered template text, to catch quoting or shell-state
+        // regressions; the printf-generated script content is identical across all four v2 templates,
+        // only the surrounding RUN-chaining vs plain-statement wrapping differs
         given:
         def tmp = File.createTempDir()
         def activateDir = new File(tmp, 'etc/conda/activate.d')
@@ -773,7 +771,7 @@ class TemplateUtilsTest extends Specification {
                 'RUN (mkdir -p "\\$MAMBA_ROOT_PREFIX/etc/conda/activate\\.d".*?\\.wave-combined-activate\\.sh")\n',
                 java.util.regex.Pattern.DOTALL)
         def matcher = pattern.matcher(dockerfile)
-        matcher.find()
+        assert matcher.find() : "combiner script fragment not found in rendered Dockerfile"
         def genScript = matcher.group(1)
 
         when: 'the generation step runs for real against the fixture activate.d directory'
@@ -983,7 +981,6 @@ class TemplateUtilsTest extends Specification {
                     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
                     printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -1028,7 +1025,6 @@ class TemplateUtilsTest extends Specification {
                     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
                     printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -1079,7 +1075,6 @@ class TemplateUtilsTest extends Specification {
                     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
                     printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -1129,7 +1124,6 @@ class TemplateUtilsTest extends Specification {
                     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
                     printf '%s\\n' \\
                         '#!/bin/bash' \\
-                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -505,6 +505,7 @@ class TemplateUtilsTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -550,6 +551,7 @@ class TemplateUtilsTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -604,6 +606,7 @@ class TemplateUtilsTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -657,6 +660,7 @@ class TemplateUtilsTest extends Specification {
                 RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
                     && printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -729,6 +733,8 @@ class TemplateUtilsTest extends Specification {
         when:
         def dockerResult = TemplateUtils.condaFileToDockerFileUsingV2(CONDA_OPTS)
         def pkgResult = TemplateUtils.condaPackagesToDockerFileUsingV2('bwa=0.7.15', ['conda-forge'], CONDA_OPTS)
+        def singularityResult = TemplateUtils.condaFileToSingularityFileV2(CONDA_OPTS)
+        def singularityPkgResult = TemplateUtils.condaPackagesToSingularityFileV2('bwa=0.7.15', ['conda-forge'], CONDA_OPTS)
 
         then:
         // the combined activate.d script is generated in the build stage, inside $MAMBA_ROOT_PREFIX
@@ -736,11 +742,89 @@ class TemplateUtilsTest extends Specification {
         dockerResult.contains('> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"')
         dockerResult.contains('ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"')
         pkgResult.contains('ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"')
+        // Singularity has no separate copy-from-build stage, so BASH_ENV is set directly in %environment,
+        // which Apptainer sources on every `exec`/`run` regardless of the container's own shell state
+        singularityResult.contains('%environment')
+        singularityResult.contains('export BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"')
+        singularityPkgResult.contains('export BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"')
         // nounset must be disabled while sourcing activate.d scripts (they reference unset vars like
         // $CONDA_PREFIX by design) and restored afterwards, otherwise `bash -ue` tasks abort on startup
         dockerResult.contains("case \$- in *u*) __wave_nounset=1 ;; esac")
         dockerResult.contains('set +u')
         dockerResult.contains('[ -n "${__wave_nounset:-}" ] && set -u')
+    }
+
+    def 'should generate an activate.d combiner script that survives real bash execution'() {
+        // exercises the exact shell fragment the v2 templates embed (mkdir/printf/cat), rather than
+        // just asserting on the rendered template text, to catch quoting or shell-state regressions
+        given:
+        def tmp = File.createTempDir()
+        def activateDir = new File(tmp, 'etc/conda/activate.d')
+        activateDir.mkdirs()
+        // mirrors cmdstan's own activate.d script: a plain export, safe under nounset
+        new File(activateDir, 'cmdstan_activate.sh').text = 'export CMDSTAN_OLD=$CMDSTAN\nexport CMDSTAN=/opt/conda/bin/cmdstan\n'
+        // mirrors a compiler package's activate.d script: references a var only `conda activate` would set
+        new File(activateDir, 'compilers_activate.sh').text = 'export CXX="${CONDA_PREFIX}/bin/g++"\n'
+
+        def CONDA_OPTS = new CondaOpts([mambaImage: 'mambaorg/micromamba:2.1.1', baseImage: 'ubuntu:24.04'])
+        def dockerfile = TemplateUtils.condaFileToDockerFileUsingV2(CONDA_OPTS)
+        // a plain (non-GString) pattern, since slashy-string regex literals still interpolate '$...'
+        def pattern = java.util.regex.Pattern.compile(
+                'RUN (mkdir -p "\\$MAMBA_ROOT_PREFIX/etc/conda/activate\\.d".*?\\.wave-combined-activate\\.sh")\n',
+                java.util.regex.Pattern.DOTALL)
+        def matcher = pattern.matcher(dockerfile)
+        matcher.find()
+        def genScript = matcher.group(1)
+
+        when: 'the generation step runs for real against the fixture activate.d directory'
+        def genProcess = new ProcessBuilder(['bash', '-ec', genScript])
+                .directory(tmp)
+                .redirectErrorStream(true)
+        genProcess.environment().put('MAMBA_ROOT_PREFIX', tmp.absolutePath)
+        def genProc = genProcess.start()
+        def genOutput = genProc.inputStream.text
+        genProc.waitFor()
+
+        then:
+        genProc.exitValue() == 0
+        def combined = new File(activateDir, '.wave-combined-activate.sh')
+        combined.exists()
+
+        when: 'a bash -ue task (nounset active, matching Nextflow task invocation) sources it via BASH_ENV'
+        def task = new File(tmp, 'task.sh')
+        task.text = 'echo "CMDSTAN=${CMDSTAN:-}"\necho "CXX=${CXX:-}"\n'
+        def taskProcess = new ProcessBuilder(['bash', '-ue', task.absolutePath])
+                .directory(tmp)
+                .redirectErrorStream(true)
+        taskProcess.environment().put('MAMBA_ROOT_PREFIX', tmp.absolutePath)
+        taskProcess.environment().put('BASH_ENV', combined.absolutePath)
+        def taskProc = taskProcess.start()
+        def taskOutput = taskProc.inputStream.text
+        taskProc.waitFor()
+
+        then:
+        taskProc.exitValue() == 0
+        taskOutput.contains('CMDSTAN=/opt/conda/bin/cmdstan')
+        taskOutput.contains("CXX=${tmp.absolutePath}/bin/g++")
+
+        when: 'a plain, non-nounset bash task also sources it, to confirm set -u is not force-enabled'
+        def plainTask = new File(tmp, 'plain.sh')
+        plainTask.text = 'echo "still running: $0"\n'
+        def plainProcess = new ProcessBuilder(['bash', plainTask.absolutePath])
+                .directory(tmp)
+                .redirectErrorStream(true)
+        plainProcess.environment().put('MAMBA_ROOT_PREFIX', tmp.absolutePath)
+        plainProcess.environment().put('BASH_ENV', combined.absolutePath)
+        def plainProc = plainProcess.start()
+        def plainOutput = plainProc.inputStream.text
+        plainProc.waitFor()
+
+        then:
+        plainProc.exitValue() == 0
+        plainOutput.contains('still running')
+
+        cleanup:
+        tmp.deleteDir()
     }
 
     /* *********************************************************************************
@@ -899,6 +983,7 @@ class TemplateUtilsTest extends Specification {
                     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
                     printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -943,6 +1028,7 @@ class TemplateUtilsTest extends Specification {
                     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
                     printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -993,6 +1079,7 @@ class TemplateUtilsTest extends Specification {
                     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
                     printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\
@@ -1042,6 +1129,7 @@ class TemplateUtilsTest extends Specification {
                     mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
                     printf '%s\\n' \\
                         '#!/bin/bash' \\
+                        'unset __wave_nounset' \\
                         'case $- in *u*) __wave_nounset=1 ;; esac' \\
                         'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
                         'set +u' \\

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -500,6 +500,21 @@ class TemplateUtilsTest extends Specification {
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
+                # combine conda 'activate.d' env hooks into a single script, since the prod stage below never runs
+                # `micromamba activate` to trigger them
+                RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
+                    && printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 
                 FROM ubuntu:24.04 AS prod
                 ARG MAMBA_ROOT_PREFIX="/opt/conda"
@@ -507,6 +522,7 @@ class TemplateUtilsTest extends Specification {
                 COPY --from=build "$MAMBA_ROOT_PREFIX" "$MAMBA_ROOT_PREFIX"
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 '''.stripIndent()
     }
 
@@ -529,6 +545,21 @@ class TemplateUtilsTest extends Specification {
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
+                # combine conda 'activate.d' env hooks into a single script, since the prod stage below never runs
+                # `micromamba activate` to trigger them
+                RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
+                    && printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 
                 FROM ubuntu:24.04 AS prod
                 ARG MAMBA_ROOT_PREFIX="/opt/conda"
@@ -536,6 +567,7 @@ class TemplateUtilsTest extends Specification {
                 COPY --from=build "$MAMBA_ROOT_PREFIX" "$MAMBA_ROOT_PREFIX"
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 '''.stripIndent()
     }
 
@@ -567,6 +599,21 @@ class TemplateUtilsTest extends Specification {
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
+                # combine conda 'activate.d' env hooks into a single script, since the prod stage below never runs
+                # `micromamba activate` to trigger them
+                RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
+                    && printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 
                 FROM ubuntu:24.04 AS prod
                 ARG MAMBA_ROOT_PREFIX="/opt/conda"
@@ -574,6 +621,7 @@ class TemplateUtilsTest extends Specification {
                 COPY --from=build "$MAMBA_ROOT_PREFIX" "$MAMBA_ROOT_PREFIX"
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 '''.stripIndent()
     }
 
@@ -604,6 +652,21 @@ class TemplateUtilsTest extends Specification {
                     && echo ">> CONDA_LOCK_START" \\
                     && cat environment.lock \\
                     && echo "<< CONDA_LOCK_END"
+                # combine conda 'activate.d' env hooks into a single script, since the prod stage below never runs
+                # `micromamba activate` to trigger them
+                RUN mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d" \\
+                    && printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh" \\
+                    && printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
 
                 FROM debian:12 AS prod
                 ARG MAMBA_ROOT_PREFIX="/opt/conda"
@@ -611,6 +674,7 @@ class TemplateUtilsTest extends Specification {
                 COPY --from=build "$MAMBA_ROOT_PREFIX" "$MAMBA_ROOT_PREFIX"
                 USER root
                 ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 '''.stripIndent()
     }
 
@@ -651,6 +715,32 @@ class TemplateUtilsTest extends Specification {
         result.contains('-f https://foo.com/some/conda-lock.yml')
         result.contains('FROM mambaorg/micromamba:2.1.1 AS build')
         result.contains('FROM ubuntu:24.04 AS prod')
+    }
+
+    def 'should carry conda activate.d hooks into the prod stage via BASH_ENV' () {
+        // the prod stage never runs `micromamba activate`, so a package that configures itself via
+        // an 'activate.d' hook needs that hook's effect carried forward some other way
+        given:
+        def CONDA_OPTS = new CondaOpts([
+                mambaImage: 'mambaorg/micromamba:2.1.1',
+                baseImage: 'ubuntu:24.04'
+        ])
+
+        when:
+        def dockerResult = TemplateUtils.condaFileToDockerFileUsingV2(CONDA_OPTS)
+        def pkgResult = TemplateUtils.condaPackagesToDockerFileUsingV2('bwa=0.7.15', ['conda-forge'], CONDA_OPTS)
+
+        then:
+        // the combined activate.d script is generated in the build stage, inside $MAMBA_ROOT_PREFIX
+        // so it survives the `COPY --from=build "$MAMBA_ROOT_PREFIX" "$MAMBA_ROOT_PREFIX"` into prod
+        dockerResult.contains('> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"')
+        dockerResult.contains('ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"')
+        pkgResult.contains('ENV BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"')
+        // nounset must be disabled while sourcing activate.d scripts (they reference unset vars like
+        // $CONDA_PREFIX by design) and restored afterwards, otherwise `bash -ue` tasks abort on startup
+        dockerResult.contains("case \$- in *u*) __wave_nounset=1 ;; esac")
+        dockerResult.contains('set +u')
+        dockerResult.contains('[ -n "${__wave_nounset:-}" ] && set -u')
     }
 
     /* *********************************************************************************
@@ -804,9 +894,25 @@ class TemplateUtilsTest extends Specification {
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"
+                    # combine conda 'activate.d' env hooks into a single script, sourced via BASH_ENV below since
+                    # `micromamba activate` never runs otherwise
+                    mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
+                    printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+                    (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+                    printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 %environment
                     export MAMBA_ROOT_PREFIX=/opt/conda
                     export PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                    export BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 '''.stripIndent()
 
     }
@@ -832,9 +938,25 @@ class TemplateUtilsTest extends Specification {
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"
+                    # combine conda 'activate.d' env hooks into a single script, sourced via BASH_ENV below since
+                    # `micromamba activate` never runs otherwise
+                    mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
+                    printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+                    (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+                    printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 %environment
                     export MAMBA_ROOT_PREFIX=/opt/conda
                     export PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                    export BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                     '''.stripIndent()
     }
 
@@ -866,9 +988,25 @@ class TemplateUtilsTest extends Specification {
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"
+                    # combine conda 'activate.d' env hooks into a single script, sourced via BASH_ENV below since
+                    # `micromamba activate` never runs otherwise
+                    mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
+                    printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+                    (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+                    printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 %environment
                     export MAMBA_ROOT_PREFIX=/opt/conda
                     export PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                    export BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 '''.stripIndent()
     }
 
@@ -899,9 +1037,25 @@ class TemplateUtilsTest extends Specification {
                     echo ">> CONDA_LOCK_START"
                     cat environment.lock
                     echo "<< CONDA_LOCK_END"
+                    # combine conda 'activate.d' env hooks into a single script, sourced via BASH_ENV below since
+                    # `micromamba activate` never runs otherwise
+                    mkdir -p "$MAMBA_ROOT_PREFIX/etc/conda/activate.d"
+                    printf '%s\\n' \\
+                        '#!/bin/bash' \\
+                        'case $- in *u*) __wave_nounset=1 ;; esac' \\
+                        'export CONDA_PREFIX="${CONDA_PREFIX:-$MAMBA_ROOT_PREFIX}"' \\
+                        'set +u' \\
+                        > "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+                    (cat "$MAMBA_ROOT_PREFIX"/etc/conda/activate.d/*.sh 2>/dev/null || true) \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
+                    printf '%s\\n' \\
+                        '[ -n "${__wave_nounset:-}" ] && set -u' \\
+                        'unset __wave_nounset' \\
+                        >> "$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 %environment
                     export MAMBA_ROOT_PREFIX=/opt/conda
                     export PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+                    export BASH_ENV="$MAMBA_ROOT_PREFIX/etc/conda/activate.d/.wave-combined-activate.sh"
                 '''.stripIndent()
     }
 


### PR DESCRIPTION
## Summary

Switching the default Conda build template to `conda/micromamba:v2` exposed a compatibility issue with Conda packages that rely on `activate.d` scripts.

The v2 template builds the Conda environment in one stage and copies it into a clean final image. Unlike the previous template, the final image does not run `micromamba activate`, so the environment variables configured by `activate.d` scripts are not loaded.

This affects packages such as `cmdstan`, which uses an activation script to set `CMDSTAN`, as well as compiler packages that set variables such as `CC` and `CXX`.

## Fix

The v2 Docker and Singularity templates now:

1. Combine the installed `activate.d` scripts into a single script during the build.
2. Configure `BASH_ENV` in the final image so Bash loads those settings automatically.
3. Temporarily disable `nounset` while loading the scripts, since some activation scripts reference variables that may not yet be defined.

This restores the activation-script behavior for both Docker and Singularity images generated from the v2 templates.

## Validation

- Updated the affected template tests, and added a test that runs the generated combiner script under real `bash -ue` to confirm exported variables survive and `nounset` is restored correctly, rather than only asserting on the rendered template text.
- Verified that `cmdstan` and compiler environment variables are available in generated images.
- Confirmed that a real CmdStan model can compile and run.
- Ran the existing template test suite successfully.

Fixes #1119