### PR TITLE
fix(deps): upgrade micronaut-micrometer to 5.13.3 (COMP-2257)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,9 +127,9 @@ dependencies {
     // logging
     implementation 'ch.qos.logback:logback-classic:1.5.20'
     implementation 'ch.qos.logback:logback-core:1.5.20'
-    // monitoring
-    implementation 'io.micronaut.micrometer:micronaut-micrometer-core'
-    implementation 'io.micronaut.micrometer:micronaut-micrometer-registry-prometheus'
+    // monitoring - version pinned ahead of the Micronaut platform BOM to pull in Micrometer 1.15.12 (CVE-2026-40983)
+    implementation 'io.micronaut.micrometer:micronaut-micrometer-core:5.13.3'
+    implementation 'io.micronaut.micrometer:micronaut-micrometer-registry-prometheus:5.13.3'
     // Also required to enable endpoint
     implementation 'io.micronaut:micronaut-management'
     //views


### PR DESCRIPTION
## Summary
- Pins the directly declared `io.micronaut.micrometer:micronaut-micrometer-core` and `micronaut-micrometer-registry-prometheus` to `5.13.3` (previously version-managed by the Micronaut platform BOM `4.10.17`).
- Micronaut platform `4.10.17` — the newest 4.x release — pins Micrometer `1.15.4`, which is vulnerable. `micronaut-micrometer 5.13.3` ships Micrometer `1.15.12`, the patched release.
- Verified with `./gradlew dependencyInsight --dependency micrometer-core --configuration runtimeClasspath` → `io.micrometer:micrometer-core:1.15.12`, and `./gradlew compileGroovy compileJava` passes.
- Resolves CVE-2026-40983 / GHSA-w737-wx49-qj23 (Micrometer gRPC server instrumentation DoS, High 7.5).

## JIRA
COMP-2257: Fix Micrometer gRPC server instrumentation DoS

## Security Advisory
https://github.com/seqeralabs/wave/security/dependabot/73

🤖 Generated with [Claude Code](https://claude.ai/code)