### PR TITLE
fix(deps): upgrade micronaut-micrometer to 5.13.3 (COMP-2258)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,9 +127,9 @@ dependencies {
     // logging
     implementation 'ch.qos.logback:logback-classic:1.5.20'
     implementation 'ch.qos.logback:logback-core:1.5.20'
-    // monitoring
-    implementation 'io.micronaut.micrometer:micronaut-micrometer-core'
-    implementation 'io.micronaut.micrometer:micronaut-micrometer-registry-prometheus'
+    // monitoring - version pinned ahead of the Micronaut platform BOM to pull micrometer 1.15.12 (CVE-2026-40984)
+    implementation "io.micronaut.micrometer:micronaut-micrometer-core:$micronautMicrometerVersion"
+    implementation "io.micronaut.micrometer:micronaut-micrometer-registry-prometheus:$micronautMicrometerVersion"
     // Also required to enable endpoint
     implementation 'io.micronaut:micronaut-management'
     //views

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@
 micronautVersion=4.10.17
 micronautEnvs=local,mail,aws-ses
 nettyVersion=4.2.15.Final
+micronautMicrometerVersion=5.13.3


### PR DESCRIPTION
## Summary

`io.micrometer:micrometer-core` resolved to **1.15.4** on `runtimeClasspath`, which is affected by the Micrometer HTTP server instrumentation DoS (High, 7.5).

It is a transitive dependency: `io.micronaut.platform:micronaut-platform:4.10.17` → `micronaut-micrometer-bom:5.13.2` → `micrometer-bom:1.15.4`. There is no Micronaut platform 4.x release shipping a patched micrometer (4.10.17 is the latest 4.x; 5.x is a major upgrade out of scope here).

Fix: pin the two **directly declared** `io.micronaut.micrometer` artifacts to `5.13.3` — same 5.13.x line already used by platform 4.10.17, a patch bump — whose BOM manages `micrometer 1.15.12`. No `constraints`/`resolutionStrategy.force` used.

## Verification

```
$ ./gradlew dependencyInsight --dependency io.micrometer:micrometer-core --configuration runtimeClasspath
io.micrometer:micrometer-core:1.15.12
   Selection reasons:
      - By conflict resolution: between versions 1.15.12 and 1.15.4
```

All micrometer artifacts (`-core`, `-commons`, `-observation`, `-registry-prometheus`) now resolve to `1.15.12`. `./gradlew compileGroovy compileJava` succeeds.

## JIRA

[COMP-2258](https://seqera.atlassian.net/browse/COMP-2258): Fix Micrometer HTTP server instrumentations DoS

## Security Advisory

- https://github.com/seqeralabs/wave/security/dependabot/74
- CVE-2026-40984 / GHSA-g3pr-3p32-fp23

🤖 Generated with [Claude Code](https://claude.ai/code)

[COMP-2258]: https://seqera.atlassian.net/browse/COMP-2258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ