### PR TITLE
Fix PATH in Pixi Docker template for OCI-to-SIF converted images

### DIFF
--- a/src/main/resources/templates/conda-pixi-v1/dockerfile-conda-file.txt
+++ b/src/main/resources/templates/conda-pixi-v1/dockerfile-conda-file.txt
@@ -22,6 +22,10 @@ COPY --from=build /shell-hook.sh /shell-hook.sh
 USER root
 ENV USER=root
 
+# add the environment binaries to the PATH so they are available also when the
+# entrypoint is bypassed e.g. 'singularity exec' on an OCI-converted image
+ENV PATH="/opt/wave/.pixi/envs/default/bin:${PATH}"
+
 # set the entrypoint to the shell-hook script (activate the environment and run the command)
 # no more pixi needed in the final container
 ENTRYPOINT ["/bin/bash", "/shell-hook.sh"]

--- a/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/ContainerHelperTest.groovy
@@ -676,6 +676,10 @@ class ContainerHelperTest extends Specification {
                 USER root
                 ENV USER=root
 
+                # add the environment binaries to the PATH so they are available also when the
+                # entrypoint is bypassed e.g. 'singularity exec' on an OCI-converted image
+                ENV PATH="/opt/wave/.pixi/envs/default/bin:${PATH}"
+
                 # set the entrypoint to the shell-hook script (activate the environment and run the command)
                 # no more pixi needed in the final container
                 ENTRYPOINT ["/bin/bash", "/shell-hook.sh"]
@@ -728,7 +732,11 @@ class ContainerHelperTest extends Specification {
                 # set user and environment variables for Python compatibility
                 USER root
                 ENV USER=root
-                 
+
+                # add the environment binaries to the PATH so they are available also when the
+                # entrypoint is bypassed e.g. 'singularity exec' on an OCI-converted image
+                ENV PATH="/opt/wave/.pixi/envs/default/bin:${PATH}"
+
                 # set the entrypoint to the shell-hook script (activate the environment and run the command)
                 # no more pixi needed in the final container
                 ENTRYPOINT ["/bin/bash", "/shell-hook.sh"]

--- a/src/test/groovy/io/seqera/wave/util/PixiHelperTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/PixiHelperTest.groovy
@@ -48,6 +48,7 @@ class PixiHelperTest extends Specification {
         result.contains('pixi shell-hook > /shell-hook.sh')
         result.contains('FROM ubuntu:24.04 AS final')
         result.contains('COPY --from=build /opt/wave/.pixi/envs/default /opt/wave/.pixi/envs/default')
+        result.contains('ENV PATH="/opt/wave/.pixi/envs/default/bin:${PATH}"')
         result.contains('ENTRYPOINT ["/bin/bash", "/shell-hook.sh"]')
     }
 

--- a/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
+++ b/src/test/groovy/io/seqera/wave/util/TemplateUtilsTest.groovy
@@ -376,6 +376,10 @@ class TemplateUtilsTest extends Specification {
                 USER root
                 ENV USER=root
 
+                # add the environment binaries to the PATH so they are available also when the
+                # entrypoint is bypassed e.g. 'singularity exec' on an OCI-converted image
+                ENV PATH="/opt/wave/.pixi/envs/default/bin:${PATH}"
+
                 # set the entrypoint to the shell-hook script (activate the environment and run the command)
                 # no more pixi needed in the final container
                 ENTRYPOINT ["/bin/bash", "/shell-hook.sh"]
@@ -411,6 +415,10 @@ class TemplateUtilsTest extends Specification {
                 # set user and environment variables for Python compatibility
                 USER root
                 ENV USER=root
+
+                # add the environment binaries to the PATH so they are available also when the
+                # entrypoint is bypassed e.g. 'singularity exec' on an OCI-converted image
+                ENV PATH="/opt/wave/.pixi/envs/default/bin:${PATH}"
 
                 # set the entrypoint to the shell-hook script (activate the environment and run the command)
                 # no more pixi needed in the final container
@@ -450,6 +458,10 @@ class TemplateUtilsTest extends Specification {
                 # set user and environment variables for Python compatibility
                 USER root
                 ENV USER=root
+
+                # add the environment binaries to the PATH so they are available also when the
+                # entrypoint is bypassed e.g. 'singularity exec' on an OCI-converted image
+                ENV PATH="/opt/wave/.pixi/envs/default/bin:${PATH}"
 
                 # set the entrypoint to the shell-hook script (activate the environment and run the command)
                 # no more pixi needed in the final container


### PR DESCRIPTION
## Summary

Fixes #1130 — Pixi-based Docker-format containers fail with `singularity exec` after OCI-to-SIF conversion because the pixi environment's `PATH` was only set up by the ENTRYPOINT shell-hook script.

When Singularity converts an OCI image (`singularity pull docker://...`), the Docker `ENTRYPOINT`/`CMD` map to `%runscript` and `ENV` instructions map to the SIF environment. Since the PATH activation lived only in the entrypoint, `singularity run` worked but `singularity exec` (which bypasses `%runscript`) could not find any command from the pixi environment:

```
> singularity exec docker://community.wave.seqera.io/library/multiqc:1.35--c17fb751507e9dfc multiqc
FATAL:   "multiqc": executable file not found in $PATH
```

This notably breaks nf-core pipelines run with Singularity and `ext.singularity_pull_docker_container = true`, since Nextflow launches tasks via `singularity exec`.

## Fix

Add a static instruction to the final stage of the `conda-pixi-v1` Docker template:

```dockerfile
ENV PATH="/opt/wave/.pixi/envs/default/bin:${PATH}"
```

Docker `ENV` instructions survive the OCI-to-SIF conversion, so the environment binaries are on `PATH` for `run`, `exec`, and `shell` alike. This mirrors what the micromamba templates already do (`ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"`) and matches the behaviour of the native Singularity pixi template, which sources the shell-hook in `%environment`.

The ENTRYPOINT shell-hook is kept as-is, since it also exports the other activation variables (e.g. `CONDA_PREFIX`) for Docker-based execution.

## Changes

- `src/main/resources/templates/conda-pixi-v1/dockerfile-conda-file.txt`: add `ENV PATH` to the final stage
- Updated expected template output in `TemplateUtilsTest`, `ContainerHelperTest`, and added an assertion in `PixiHelperTest`

## Testing

```
./gradlew :test --tests 'io.seqera.wave.util.TemplateUtilsTest' \
                --tests 'io.seqera.wave.util.ContainerHelperTest' \
                --tests 'io.seqera.wave.util.PixiHelperTest'
```
All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)